### PR TITLE
chore: update appcast for v0.1.0-beta.1

### DIFF
--- a/appcast.xml
+++ b/appcast.xml
@@ -5,5 +5,10 @@
     <link>https://raw.githubusercontent.com/bitwize-ai/Logue/main/appcast.xml</link>
     <description>Sparkle update feed for Logue. Entries are appended automatically by the release workflow (scripts/update_appcast.py) when a GitHub Release is published.</description>
     <language>en</language>
+    <item>
+      <title>Version 0.1.0-beta.1</title>
+      <pubDate>Tue, 21 Jul 2026 20:38:51 +0000</pubDate>
+      <enclosure url="https://github.com/bitwize-ai/Logue/releases/download/v0.1.0-beta.1/Logue-0.1.0-beta.1.zip" length="20018482" type="application/octet-stream" sparkle:edSignature="vr5rwGYtj7rhwKICOD7AFVvmrdUQ3ZG7N75/T1Erjhl5Xzr8nLHd3DbYqcOywILn2sBFgnMb3BpiUfepgYnYCg==" sparkle:version="3" sparkle:shortVersionString="0.1.0-beta.1" sparkle:minimumSystemVersion="26.0" />
+    </item>
   </channel>
 </rss>


### PR DESCRIPTION
Publishes the Sparkle update feed entry for v0.1.0-beta.1. Auto-generated by the release run; PR opened manually as bitwize-lux because the built-in Actions token was blocked from creating PRs (now enabled for future runs).