### PR TITLE
fix(ci): release workflow fixes (Xcode select, cert guard, appcast stacking)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,9 +77,15 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Building version: $VERSION"
 
-      # ── Verify Xcode ──────────────────────────────────────
-      - name: Verify Xcode
-        run: xcodebuild -version
+      # ── Select latest Xcode ───────────────────────────────
+      # The default Xcode on the hosted image is too old for the macOS 26 SDK
+      # and does not support `xcodebuild -downloadComponent` (fails exit 64).
+      # Pick the newest installed Xcode, matching ci.yml's build job.
+      - name: Select latest Xcode
+        run: |
+          XCODE_PATH=$(ls -d /Applications/Xcode*.app 2>/dev/null | sort -V | tail -1)
+          sudo xcode-select -s "$XCODE_PATH"
+          xcodebuild -version
 
       # ── Install tools ─────────────────────────────────────
       - name: Ensure XcodeGen and create-dmg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -468,17 +468,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # ── Update appcast (AFTER GitHub Release — so the download URL resolves) ──
-      - name: Update appcast.xml
-        run: |
-          python3 scripts/update_appcast.py \
-            --version "${{ steps.version.outputs.version }}" \
-            --build "${{ github.run_number }}" \
-            --signature "$ED_SIGNATURE" \
-            --length "$FILE_LENGTH" \
-            --min-os "26.0"
-
-      - name: Create appcast PR
+      # ── Update appcast + open PR (AFTER GitHub Release — so the download URL resolves) ──
+      # The appcast MUST be regenerated on top of the base branch's current appcast,
+      # not the tag's stale copy. Otherwise the 2nd+ release drops earlier entries and
+      # `git checkout origin/main` aborts on the dirty working-tree appcast.xml.
+      - name: Update appcast and open PR
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -494,8 +488,21 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+          # Start from the freshest base branch so the new entry stacks on any
+          # already-merged releases. Discard any working-tree appcast.xml first so a
+          # stale/dirty copy can't block the checkout — it is regenerated below.
+          git checkout -- appcast.xml 2>/dev/null || true
           git fetch origin "$BASE_BRANCH"
           git checkout -b "$BRANCH" "origin/$BASE_BRANCH"
+
+          # Regenerate the entry on top of the base branch's appcast.
+          python3 scripts/update_appcast.py \
+            --version "$VERSION" \
+            --build "${{ github.run_number }}" \
+            --signature "$ED_SIGNATURE" \
+            --length "$FILE_LENGTH" \
+            --min-os "26.0"
+
           git add appcast.xml
           git commit -m "chore: update appcast for v${VERSION}"
           git push origin "$BRANCH"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,6 +138,14 @@ jobs:
       - name: Determine signing identity
         run: |
           IDENTITY=$(security find-identity -v -p codesigning "$KEYCHAIN_PATH" | grep "Developer ID Application" | head -1 | awk -F'"' '{print $2}')
+          if [[ -z "$IDENTITY" ]]; then
+            echo "::error::No 'Developer ID Application' identity in the signing keychain."
+            echo "APPLE_CERTIFICATE_BASE64 must be a *Developer ID Application* certificate"
+            echo "(exported as .p12 with its private key) — an 'Apple Development' cert cannot"
+            echo "notarize or distribute. Certificates the keychain does contain:"
+            security find-identity -v -p codesigning "$KEYCHAIN_PATH" || true
+            exit 1
+          fi
           echo "SIGNING_IDENTITY=$IDENTITY" >> "$GITHUB_ENV"
           echo "Signing identity: $IDENTITY"
 


### PR DESCRIPTION
Three release.yml fixes discovered while cutting the v0.1.0-beta.1/beta.2 test releases. These are **not yet on main** (they were committed after PR #1 merged), so a release run built from main would still hit the original failures.

## Fixes
1. **Select latest Xcode** before Metal Toolchain — the default Xcode on the hosted image lacks the macOS 26 SDK and `-downloadComponent` (was exit 64). Mirrors ci.yml.
2. **Fail fast on wrong cert** — if the keychain has no `Developer ID Application` identity, the run now stops immediately with an actionable message instead of a cryptic `no identity found` ~200 lines later.
3. **Regenerate appcast on top of the base branch** — the standalone update step edited the tag's stale appcast, then `git checkout origin/main` aborted on the dirty file (and would drop earlier entries). Now the entry is generated after a clean checkout of main, so each release stacks on the prior feed.

All three are validated by the beta.2 release run (build/sign/notarize/publish all green; only the appcast-PR step needed these).

🤖 Generated with [Claude Code](https://claude.com/claude-code)