### PR TITLE
Add editor block types, find and replace, zoom, and deep links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ memory/
 # Python
 __pycache__/
 *.pyc
+
+# Internal planning docs (not for public repo)
+docs/CAPABILITY-ROADMAP.md

--- a/Logue.xcodeproj/project.pbxproj
+++ b/Logue.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		127BFC4FD2D2CA4E68169EC5 /* BackupSettingsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 431C845CF5A3DC729ED17CC0 /* BackupSettingsTab.swift */; };
 		12AD1B6E3CB248360845B684 /* WritingGoalsPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21ED60A38CACB407A6BEDD62 /* WritingGoalsPanelView.swift */; };
 		13373229911D8C07B23E3591 /* GrammarClarityLLMTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E20D8AB097118E507520863A /* GrammarClarityLLMTests.swift */; };
+		136DA7C6E8212377AEF7906B /* BlockEditorView+Reorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = F30E821E71C80A341EEC3F68 /* BlockEditorView+Reorder.swift */; };
 		1379C780AB4DAD0DCCF512B6 /* DeepResearchProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEA066DE093D5AFBD76D6F0D /* DeepResearchProgressView.swift */; };
 		13AFBE3135D8E53D1DA140B1 /* DeepResearchCoordinator+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7250A0C394AFABC041C58D68 /* DeepResearchCoordinator+Helpers.swift */; };
 		13B9900A31E52DA797308A98 /* MLXLMCommon in Frameworks */ = {isa = PBXBuildFile; productRef = 1D568EAA2001718431FEF06A /* MLXLMCommon */; };
@@ -59,10 +60,12 @@
 		14575BB38E5D155A9BF7415B /* CommandCenterPIIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24578E3A172E90DC703D4C9D /* CommandCenterPIIView.swift */; };
 		14AF54A07D25FA4EE8DA4DC7 /* ScoreRingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E188450986288699B1B8A252 /* ScoreRingView.swift */; };
 		14BD5D00F6C5353221E2E913 /* GraphEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D1A15BDB3690A5CF5AB97E /* GraphEntity.swift */; };
+		15CC6613C14DCCA50A5BC133 /* DiagramMathBlockView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C8C014AA23FE44D9ED97AE /* DiagramMathBlockView.swift */; };
 		167F5AC6873796698FA0C423 /* WritingDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2100148050D740B2B64AF673 /* WritingDocument.swift */; };
 		17F7BAF0DBA60523B8EFD5C7 /* AgentTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = F520732BF6E86EA62DAC3E2B /* AgentTool.swift */; };
 		17F88171613BB35BB0AF2A2A /* HomeContinueSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 105A1B21D0379DCB157BC451 /* HomeContinueSection.swift */; };
 		1928EADD3A8BEEA0B72553EF /* SharedPolishComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6410A54BE5400DAAFADA2A88 /* SharedPolishComponents.swift */; };
+		1AC0C886212A4F3ADC9A48D1 /* DocumentIconTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9130B8EDD12207674F5B4323 /* DocumentIconTests.swift */; };
 		1BE965CE5953BCA256111BEA /* MeetingRowCompact.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72EE330160AA0276B2907F2A /* MeetingRowCompact.swift */; };
 		1C1775454781744474E68510 /* ToolApprovalButtons.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4DB5AD462B4A863201D5D61 /* ToolApprovalButtons.swift */; };
 		1C4A675BEB767A50A29D970F /* katex.min.css in Resources */ = {isa = PBXBuildFile; fileRef = E420BD97F84DEF6141ADEDA4 /* katex.min.css */; };
@@ -96,6 +99,7 @@
 		2CDF845EA2BF63AC732BD8BA /* ToolExecutionCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43877B1F81F7AE214808F86A /* ToolExecutionCard.swift */; };
 		2E38E8631137FF77CB24BD2C /* WritingMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE1C21D4C5160CF9D5FEB10 /* WritingMode.swift */; };
 		2E44F9F45806D57C7D99BC21 /* SkeletonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 946A6E172B8989687D211113 /* SkeletonView.swift */; };
+		2F188F551FC6C5738BDB23B2 /* QuickOpen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D732A7B7C4D529BBD960BDC9 /* QuickOpen.swift */; };
 		2FD721F2491FFD83810DB23C /* DiarizationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6518F90C57E0A10C7DBF1328 /* DiarizationManager.swift */; };
 		3078B745D4379CB1523EA5D2 /* IconToolbarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FF6C4FACAA2A06BB2C5306A /* IconToolbarView.swift */; };
 		30A636797A0AE2BFFDBD753F /* DeckPDFExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9DD3273B7AB955D3C6E3BC1 /* DeckPDFExporter.swift */; };
@@ -107,11 +111,14 @@
 		3323132CAC627887271FF6F6 /* RetryHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70684260B4C198545C4A6AC2 /* RetryHelper.swift */; };
 		35592A04877BCC129AE90A1E /* AgentDictationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA29CBB4724CFEE0030E5FE3 /* AgentDictationService.swift */; };
 		3599049B9B46D8BBC567D6F7 /* ActionItemsRingCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = FABEE67955D09AB40C79784C /* ActionItemsRingCard.swift */; };
+		35CBDE38DC02F798AE51C76F /* DocumentWidthModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE8030D02974A04A80B48065 /* DocumentWidthModeTests.swift */; };
+		362E757F0940BDB7CB5E560A /* BlockMoveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D204801C0C2BADD68D406D7 /* BlockMoveTests.swift */; };
 		372D7C7E58F4EF0B8305E096 /* BlockRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61150569A2C3758E03DC0666 /* BlockRowView.swift */; };
 		37DEDF1E37B6221AC2F38912 /* KeychainHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E812DD5E7EE68ED58521109 /* KeychainHelper.swift */; };
 		38DD6704C91604D913E54000 /* PromptRegistry+Agent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D228A8EDB45295F064F77732 /* PromptRegistry+Agent.swift */; };
 		394298FD6FA5E69385C52C55 /* MemoryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54533945F253EFE4459AC3A2 /* MemoryStore.swift */; };
 		39662C74243A5431B46422BF /* PIIRegexScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791BA3A7ABEB9CC9E301FCE6 /* PIIRegexScanner.swift */; };
+		3A0604553EBC4F314C97193A /* EditorZoomTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7824CE8087F98B0143531A9F /* EditorZoomTests.swift */; };
 		3ABDB2E2F4133D4F8293FE55 /* UnifiedSidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC3CE09FD46E14F97E07C0BF /* UnifiedSidebarView.swift */; };
 		3B58975589B53E6910C02FE8 /* AgentChatView+Input.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7B886861180D41A132F1B6A /* AgentChatView+Input.swift */; };
 		3BB74E6C769B50816B912D28 /* BulletRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B9F22B7392C28686BD5CE60 /* BulletRow.swift */; };
@@ -125,6 +132,7 @@
 		4299928CFC0AA95BC40766E3 /* VocabularyLLMTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27509EF9E40DDD67243BA148 /* VocabularyLLMTests.swift */; };
 		429DEF46E72F1D85602F8BB5 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7E01E332D859D172446E5AE2 /* Assets.xcassets */; };
 		434D66C234C168523DA35C28 /* WritingStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DDCC3C3CFEDA93D9D945B57 /* WritingStats.swift */; };
+		4371B1C1354F8BF50EFECCBB /* QuickOpenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B37427E70D5B05A2E6C5B253 /* QuickOpenTests.swift */; };
 		4397B12F9CBE6F12F98BBF5A /* MeetingStoreProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 214108348E03F1DF8FAA8CCF /* MeetingStoreProtocols.swift */; };
 		43DEC554E9926867478C0CB4 /* FolderIconPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B611C161962C154FC8DA451 /* FolderIconPicker.swift */; };
 		45533AE9915EEC212302FB9B /* CardSectionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99E36F742DA233D8616E8CC1 /* CardSectionHeader.swift */; };
@@ -150,6 +158,7 @@
 		50F14ED2FFFB73AB6A708FEE /* MeetingListRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39078A7E29B77D3E14DB6607 /* MeetingListRowView.swift */; };
 		512CB6426C4068C8478B532C /* SettingsNavigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94924BC0745FFA07AEEF1E91 /* SettingsNavigator.swift */; };
 		527B54DE13E05D5674D6BE74 /* MeetingBookmarksPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE62FBF59720C8B746A03EDB /* MeetingBookmarksPanelView.swift */; };
+		52B089BBC06F1A4DC8CFA5CE /* DeepLinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB27F11A2333C941E28C916E /* DeepLinkTests.swift */; };
 		539269586BA6A2425D334476 /* EmbeddingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9018379C22E39E1C199D81C6 /* EmbeddingService.swift */; };
 		53C6F90254BA856A74CD343A /* DocumentLLMTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF81895980E378C21F96AFD6 /* DocumentLLMTests.swift */; };
 		54F9DAED7E0DD30B5A16041A /* LLMEngine+Convenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADFE072C32F14B59D0406571 /* LLMEngine+Convenience.swift */; };
@@ -172,6 +181,8 @@
 		5C00C6C19A74B209DBA92190 /* TranscriptSegment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1BA8536C1D15EB0A32717E /* TranscriptSegment.swift */; };
 		5CA3F8E612944FDC80FE2A00 /* OverviewRecentActivityCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD9DB88569857E33E72CCFAE /* OverviewRecentActivityCard.swift */; };
 		5CBFF3B40F91960EC8178989 /* CommandCenterComposeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ABC89CED798F0088E00B682 /* CommandCenterComposeView.swift */; };
+		5FCA28149B189B61283A387C /* DocumentIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBB768463E40E11BC5922145 /* DocumentIcon.swift */; };
+		5FD238DAAD32BA6575CDCF30 /* HighlightMark.swift in Sources */ = {isa = PBXBuildFile; fileRef = 430B153889068B3CB200455A /* HighlightMark.swift */; };
 		5FE5B603740CF6AB60C95616 /* ScheduledTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E2201F239D5E1F87D9AA99B /* ScheduledTask.swift */; };
 		604F4539F3B4F37E98856106 /* WritingNSTextView+Table.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E8CCC12AA344F074862CF57 /* WritingNSTextView+Table.swift */; };
 		606610B68EE510849B9358C3 /* MeetingWorkspaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6B117D634010EECE1C83553 /* MeetingWorkspaceView.swift */; };
@@ -233,11 +244,13 @@
 		85BFFE25C6715ABAE40DFB2C /* RightIconToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 088E6D7B300F24ADC23373E8 /* RightIconToolbar.swift */; };
 		85C9F35793B4ACD6B226E085 /* BookmarkColorHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A930070B8B38F806BA54B436 /* BookmarkColorHelper.swift */; };
 		860E9E8E3285FF2745077A83 /* MeetingCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FC07A84E0AD072373EFB3F8 /* MeetingCardView.swift */; };
+		861F5D959175FAC61CA02A55 /* DiagramMathBlockTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7D76EDEE9C20C5C390BAF10 /* DiagramMathBlockTests.swift */; };
 		8621E76EC5A20A48091893C4 /* InsightsSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CD8FDAFABDFD03AEBAB2750 /* InsightsSectionView.swift */; };
 		865040D956444FC0D564FD5F /* MeetingActionItemsPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB319F816250DC8D8652F6BB /* MeetingActionItemsPanelView.swift */; };
 		868EDE5F9C2DF5D12D235D60 /* FolderStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D13D5598C230DA3644325779 /* FolderStore.swift */; };
 		86E9087748D55EBF2768316A /* AudioPlaybackService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 710B1C39C6F97501735DCBB9 /* AudioPlaybackService.swift */; };
 		881889D18FACE1CC1CBD53AA /* AudioPlaybackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE03DD6E75847FADE248688A /* AudioPlaybackView.swift */; };
+		8837715694AEB1053618212A /* DeepLinkRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263E3C59B8D03346E04E7C92 /* DeepLinkRoutingTests.swift */; };
 		887E622980C372BFB44B5F8C /* InlineSuggestionPopoverView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8361EA76FDB9D2AB11114559 /* InlineSuggestionPopoverView.swift */; };
 		88A664FB0F648002373F7656 /* AgentReadAloudService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2A54999991BFEA773747361 /* AgentReadAloudService.swift */; };
 		88EEF097CAC3DE11B876A929 /* AIContentTools.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8A0088E863B5A3056A85771 /* AIContentTools.swift */; };
@@ -252,6 +265,7 @@
 		92251AAC9FFBCEA92E722619 /* AboutSettingsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C618174E127839238F1ABD6 /* AboutSettingsTab.swift */; };
 		92B35DA71181DA35404DA59D /* ChatBubble.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AB95EB1E8811078D07C7524 /* ChatBubble.swift */; };
 		92F3A2483E32FA228EFBC5DE /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57D98C9B0D1E6A69681C8C1 /* SettingsView.swift */; };
+		953ED2EEFAB6C2FFBC8F9C81 /* DiagnosticsReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F90CF8BD9ABA35C96B0E76 /* DiagnosticsReport.swift */; };
 		957DBF3D45C9A998D610B8B2 /* PromptBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAAA4BF89D7A99D017BB1C8E /* PromptBuilderTests.swift */; };
 		96C96346E8ECD610E2DABCD2 /* OverviewRightColumnCards.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46B853F7D5C62F407E23AD41 /* OverviewRightColumnCards.swift */; };
 		96F5B0B3E191E9EC0AB9B835 /* TableCellTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F06E61F5499F68059FF8775B /* TableCellTextView.swift */; };
@@ -285,6 +299,7 @@
 		AB209D330BE40FEB735204C7 /* MermaidRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCEE1CC67630CF84E03498D5 /* MermaidRenderer.swift */; };
 		AB5ECDB7A635C2DB974F908D /* SeedDataBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9478E4D1E64E36CDE232568E /* SeedDataBannerView.swift */; };
 		ABEB7317A02B279F22E9AB8E /* SpaceContentTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08FACCA64C397DACFD78CE8C /* SpaceContentTypes.swift */; };
+		ACBD67F76F286A34F1A0E4CA /* DocumentWidthMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = A62566632EE8FA6DAD6713DB /* DocumentWidthMode.swift */; };
 		AD07D0DCE8536510D087A05C /* TroubleshootingActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15DD5F0F004960A0D0B66E8B /* TroubleshootingActions.swift */; };
 		AE7BCB76D77404A8B71D119E /* PIIModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B9978579DD7A8D5743C9DB6 /* PIIModels.swift */; };
 		AF35E4BCA1244DFE4B983329 /* UndoToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFBC89D908FFD586D1C38ABF /* UndoToastView.swift */; };
@@ -301,6 +316,7 @@
 		B6A64497C43FDBD3F7769855 /* InlineRewriteEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 358D99D88D3FB7C39EE0C7E7 /* InlineRewriteEngine.swift */; };
 		B7B53337BC65FF52350811CA /* SaveSummaryToDocumentSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64EBF5DF74CDD38CF0672831 /* SaveSummaryToDocumentSheet.swift */; };
 		B824D9860D0A36CC7346F386 /* MeetingMemoryIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3474D653C2A7624A299D8F8F /* MeetingMemoryIndex.swift */; };
+		BC3C23065AB5DCE2AD46926E /* EditorLayoutMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = C262104A21E62547CE677D5B /* EditorLayoutMode.swift */; };
 		BCE7CC5D10CC3B52CDF54B6E /* BlockEditorDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 493337C75A0D4F073E22C76F /* BlockEditorDocument.swift */; };
 		BD10E24EBE0FAA0580232BA5 /* MultiBlockSelectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CB8F29FAA5817D348722762 /* MultiBlockSelectionState.swift */; };
 		BE8812E6C08B84FA7639B150 /* WriteSpaceTools.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EBABE6CD6D3C4A22F1B973C /* WriteSpaceTools.swift */; };
@@ -331,16 +347,19 @@
 		CE5A69A3A3CBC569F9D8DA57 /* JumpToLatestPill.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2666524E8E079ED62C748893 /* JumpToLatestPill.swift */; };
 		CFC1E2D409AE2B588FE6A9AD /* OverviewQuickActionsCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED35C64E018F0B223D5FE487 /* OverviewQuickActionsCard.swift */; };
 		D0430E32BB8F114084B8555D /* MeetingSummaryPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079936683006158188BD417B /* MeetingSummaryPanelView.swift */; };
+		D16DE5948A97D72BCD5F06ED /* EditorZoom.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCC4C9A99648838E46779A4D /* EditorZoom.swift */; };
 		D1931EA2257F5AD1385F138A /* MeetingStore+SeedData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 132C503C3139368F66A16B8C /* MeetingStore+SeedData.swift */; };
 		D1E0942395634B019B74C872 /* KeyboardShortcut.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29E0387E99032708C27EA914 /* KeyboardShortcut.swift */; };
 		D28E98958FE71C7F83A0AEBD /* PDFExportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AED2C469157178636079073 /* PDFExportService.swift */; };
 		D358B3145D0A112EF4796F03 /* AccessibilityService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BFF6DFB33FFDD664F05A4E6 /* AccessibilityService.swift */; };
+		D36DA27367323F11D5671F9C /* DocumentReplaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F95595374A2F4D02321B7CA2 /* DocumentReplaceTests.swift */; };
 		D39165CB191A11B257035D9C /* mermaid.min.js in Resources */ = {isa = PBXBuildFile; fileRef = A00CAFE729E346541AE302CB /* mermaid.min.js */; };
 		D4313CFD59233148DB1EC901 /* auto-render.min.js in Resources */ = {isa = PBXBuildFile; fileRef = 0EA5B49BE121245C05499EDD /* auto-render.min.js */; };
 		D437C8E11749010F9DFC3841 /* ActionItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BEFD48C860C189F76D82545 /* ActionItem.swift */; };
 		D480184376B6F26A9755133A /* LLMTestHarness.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92E9FCC3C656E8D24AC7A610 /* LLMTestHarness.swift */; };
 		D53F3ED4FBA679045C66DC42 /* ScheduledTaskManager+WeeklyReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46D6419EB91D515BAD26FEF7 /* ScheduledTaskManager+WeeklyReview.swift */; };
 		D55EAAAC48FDDF79BD2F8879 /* MeetingListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6BFFF957D5FFFEB3DD160BF /* MeetingListView.swift */; };
+		D5975A82DEA279851186013D /* DiagnosticsReportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 860DFF869B9C6C39BE468431 /* DiagnosticsReportTests.swift */; };
 		D6DAD4E4B5FDDB1C91D4F8C5 /* WritingAgentGraph.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6711FB8D13DD53809A655A14 /* WritingAgentGraph.swift */; };
 		D7F8F342BF783A41A7184B38 /* PrivacySettingsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE170B6B814BD80DC8505A4C /* PrivacySettingsTab.swift */; };
 		D859B446091BAD650DECE77B /* TextDiff.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1643D88F8D9EE575F4C03507 /* TextDiff.swift */; };
@@ -353,6 +372,7 @@
 		DD3720347A5EBD370B3A60EE /* StatusBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB25376AFA88E0F16400AA7 /* StatusBadge.swift */; };
 		DD5DA3825C26BBEF11ADF223 /* AgentChatEmptyState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91DA817000619561CE8DA7FB /* AgentChatEmptyState.swift */; };
 		DD9EF8E1A2506A01E2AE6823 /* DocumentStore+SeedData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7E20C976C8094E3E4DCB896 /* DocumentStore+SeedData.swift */; };
+		DDBFC59CEC2DFE580E604640 /* HighlightMarkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9226B7B10683E42ABEB71810 /* HighlightMarkTests.swift */; };
 		DE059DFC008B0AA037E54CBC /* AutoChartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F5B03C7389EF2BBF4906EBE /* AutoChartView.swift */; };
 		DEDC62FB8C63F071222D9115 /* AudioLevelNormalizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20FC98B65B556E8B97D9660A /* AudioLevelNormalizer.swift */; };
 		DF2FBE50D8024F107E4B98EB /* AgentChatGraph.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2F831E25CF9FDC86465A53D /* AgentChatGraph.swift */; };
@@ -381,6 +401,7 @@
 		EAB17DC89BEDD8391BA0D76E /* Toast.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E78077A2EACC3DD4364C4CC /* Toast.swift */; };
 		EB4B67B6541ECF5EDB93F8AA /* InlineSpellEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6829731778689289CE48545 /* InlineSpellEngine.swift */; };
 		EC09A9CE12598BC04D96481A /* DocsHomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8ACC65E14034118E968BBE6 /* DocsHomeView.swift */; };
+		EC4770E6775F3DD9A8168148 /* DeepLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = E91B8420A88FFD5D29FE6638 /* DeepLink.swift */; };
 		ED283783D6A185FB3914A331 /* ApprovalGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1CF9F695CCB56896DC9A02C /* ApprovalGate.swift */; };
 		ED7BBA11866E8887D849AD84 /* ChatInputField.swift in Sources */ = {isa = PBXBuildFile; fileRef = B80061FBEC30F04EF2176F88 /* ChatInputField.swift */; };
 		EE067F20A9652C38BFC02800 /* BlockTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 381AAF180053F03E9FBAC2A3 /* BlockTextView.swift */; };
@@ -405,6 +426,7 @@
 		F5D0756061ECC7E9DA91DB7B /* VoicePushToTalkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 312A712634E382D3B5619607 /* VoicePushToTalkManager.swift */; };
 		F707714ED0D3CE3D8EBCCD90 /* OnboardingView+ModelPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 153523A61D3B1E2AF4B2D108 /* OnboardingView+ModelPage.swift */; };
 		F709E83F5F91C7B68712F42D /* BufferConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A9894380C7367618CEBF956 /* BufferConverter.swift */; };
+		F990F4EC5E8A9FEBA4C9FD3F /* BlockTypeSlashMenuTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A450984B8338837BFDFF868 /* BlockTypeSlashMenuTests.swift */; };
 		FA0EBF1706531E854E711B5E /* PIICategoryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68896D3492B91AC825FEC46E /* PIICategoryCard.swift */; };
 		FB2DCEFD67348622524BEB81 /* RecentContentPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63AC1DBC374C162B470E69D4 /* RecentContentPane.swift */; };
 		FB715269552DA5B0A80404E1 /* OverviewPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6042105E2C13EF05700916B6 /* OverviewPane.swift */; };
@@ -452,6 +474,7 @@
 		1073F096F16AFC2BD1908BE7 /* AssistantActionRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssistantActionRow.swift; sourceTree = "<group>"; };
 		1083BC25237ADD22FEE5A277 /* BackupManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupManager.swift; sourceTree = "<group>"; };
 		1153D35EF20882A425B5D836 /* SectionHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionHeader.swift; sourceTree = "<group>"; };
+		11F90CF8BD9ABA35C96B0E76 /* DiagnosticsReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsReport.swift; sourceTree = "<group>"; };
 		126A669ACEBF8395600EC8EE /* SuggestionPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionPanelView.swift; sourceTree = "<group>"; };
 		12A71C8E402261DE0D93DA2A /* ModelAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelAction.swift; sourceTree = "<group>"; };
 		132AE87705CAF5786CEA7086 /* StatusFilterChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusFilterChip.swift; sourceTree = "<group>"; };
@@ -484,6 +507,7 @@
 		24578E3A172E90DC703D4C9D /* CommandCenterPIIView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandCenterPIIView.swift; sourceTree = "<group>"; };
 		249472506C451094FA86F049 /* OpenAICompatibleClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenAICompatibleClient.swift; sourceTree = "<group>"; };
 		263421D41C830238A47CD829 /* ResourceUsageMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceUsageMonitor.swift; sourceTree = "<group>"; };
+		263E3C59B8D03346E04E7C92 /* DeepLinkRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkRoutingTests.swift; sourceTree = "<group>"; };
 		2666524E8E079ED62C748893 /* JumpToLatestPill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JumpToLatestPill.swift; sourceTree = "<group>"; };
 		27509EF9E40DDD67243BA148 /* VocabularyLLMTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VocabularyLLMTests.swift; sourceTree = "<group>"; };
 		27906AC0B2EC68C338B56B57 /* TypingIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingIndicatorView.swift; sourceTree = "<group>"; };
@@ -526,6 +550,7 @@
 		3E86EBBF6643966395A7DE8B /* FileAccessGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileAccessGate.swift; sourceTree = "<group>"; };
 		40381D10206F56D057943756 /* SpaceContentPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceContentPane.swift; sourceTree = "<group>"; };
 		42BFEBF99163808EE4126279 /* HomeContextBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeContextBar.swift; sourceTree = "<group>"; };
+		430B153889068B3CB200455A /* HighlightMark.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightMark.swift; sourceTree = "<group>"; };
 		431C845CF5A3DC729ED17CC0 /* BackupSettingsTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupSettingsTab.swift; sourceTree = "<group>"; };
 		43877B1F81F7AE214808F86A /* ToolExecutionCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolExecutionCard.swift; sourceTree = "<group>"; };
 		43D628E66EC44675B3D52230 /* EditTemplateSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditTemplateSheet.swift; sourceTree = "<group>"; };
@@ -601,9 +626,11 @@
 		7449F6B54F0F197D704E4C59 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		756E8155CF5415154F8B2C49 /* MeetingBreakdownCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingBreakdownCard.swift; sourceTree = "<group>"; };
 		772CEEDFC80AF7FA18DF316F /* Speech.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Speech.framework; path = System/Library/Frameworks/Speech.framework; sourceTree = SDKROOT; };
+		7824CE8087F98B0143531A9F /* EditorZoomTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorZoomTests.swift; sourceTree = "<group>"; };
 		791BA3A7ABEB9CC9E301FCE6 /* PIIRegexScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PIIRegexScanner.swift; sourceTree = "<group>"; };
 		7992EC4C49987E7A2371D257 /* ResourceUsageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceUsageView.swift; sourceTree = "<group>"; };
 		79F5EE85D7AA8E700D4C0FC3 /* AITitleGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AITitleGenerator.swift; sourceTree = "<group>"; };
+		7A450984B8338837BFDFF868 /* BlockTypeSlashMenuTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockTypeSlashMenuTests.swift; sourceTree = "<group>"; };
 		7AB95EB1E8811078D07C7524 /* ChatBubble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatBubble.swift; sourceTree = "<group>"; };
 		7ABC89CED798F0088E00B682 /* CommandCenterComposeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandCenterComposeView.swift; sourceTree = "<group>"; };
 		7CB8F29FAA5817D348722762 /* MultiBlockSelectionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiBlockSelectionState.swift; sourceTree = "<group>"; };
@@ -628,6 +655,7 @@
 		840A12365F18257475A34827 /* QuickPromptChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickPromptChip.swift; sourceTree = "<group>"; };
 		84D22CFDEB9D3FC3A4805089 /* UICopy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UICopy.swift; sourceTree = "<group>"; };
 		851703C5995A9B2FA0C07975 /* TemplateStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateStore.swift; sourceTree = "<group>"; };
+		860DFF869B9C6C39BE468431 /* DiagnosticsReportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsReportTests.swift; sourceTree = "<group>"; };
 		86F393DC727834A59AB47A62 /* AIChatPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatPanelView.swift; sourceTree = "<group>"; };
 		8756576B17C7D359AC9FC6A0 /* VerifyPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerifyPanelView.swift; sourceTree = "<group>"; };
 		876B3EAA03844355C80F1817 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -639,6 +667,7 @@
 		8AED2C469157178636079073 /* PDFExportService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFExportService.swift; sourceTree = "<group>"; };
 		8CCF492C5BB1691EC0946B25 /* InlineLaTeXView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineLaTeXView.swift; sourceTree = "<group>"; };
 		8D147FADD3CE97D983829125 /* VoiceInputIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceInputIndicator.swift; sourceTree = "<group>"; };
+		8D204801C0C2BADD68D406D7 /* BlockMoveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockMoveTests.swift; sourceTree = "<group>"; };
 		8D2D61B85F962E88AA1E5062 /* TextAnalysisRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextAnalysisRequestTests.swift; sourceTree = "<group>"; };
 		8DC85DAE7DF132DD4B355F61 /* PolishEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PolishEngine.swift; sourceTree = "<group>"; };
 		8DEC6591F262E1FB6400CA15 /* WritingNSTextView+SlashCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WritingNSTextView+SlashCommand.swift"; sourceTree = "<group>"; };
@@ -647,8 +676,10 @@
 		8F3E9AD232A1D6AEB3064E31 /* DiarizationManager+BatchASR.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DiarizationManager+BatchASR.swift"; sourceTree = "<group>"; };
 		9018379C22E39E1C199D81C6 /* EmbeddingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbeddingService.swift; sourceTree = "<group>"; };
 		90E4CF4E9246459183E66FD7 /* WritingAgentState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WritingAgentState.swift; sourceTree = "<group>"; };
+		9130B8EDD12207674F5B4323 /* DocumentIconTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentIconTests.swift; sourceTree = "<group>"; };
 		91DA817000619561CE8DA7FB /* AgentChatEmptyState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentChatEmptyState.swift; sourceTree = "<group>"; };
 		920C02E8AB5AA086F500AFC5 /* CategorySidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategorySidebarView.swift; sourceTree = "<group>"; };
+		9226B7B10683E42ABEB71810 /* HighlightMarkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightMarkTests.swift; sourceTree = "<group>"; };
 		9230215EEC7592F9378CA66C /* ModelManager+Discovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ModelManager+Discovery.swift"; sourceTree = "<group>"; };
 		92DB0F899AF6F08FEAF8AA46 /* AgentConversationListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentConversationListView.swift; sourceTree = "<group>"; };
 		92E9FCC3C656E8D24AC7A610 /* LLMTestHarness.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LLMTestHarness.swift; sourceTree = "<group>"; };
@@ -681,6 +712,7 @@
 		A4623149A8D1BB07A0CB7B26 /* DateGroupingHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateGroupingHelper.swift; sourceTree = "<group>"; };
 		A488F97BC5DBB0C094B1C74F /* AgentCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentCoordinator.swift; sourceTree = "<group>"; };
 		A4DB5AD462B4A863201D5D61 /* ToolApprovalButtons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolApprovalButtons.swift; sourceTree = "<group>"; };
+		A62566632EE8FA6DAD6713DB /* DocumentWidthMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentWidthMode.swift; sourceTree = "<group>"; };
 		A6BFFF957D5FFFEB3DD160BF /* MeetingListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingListView.swift; sourceTree = "<group>"; };
 		A7BB6836738E8815F0F59EBE /* WriteDocumentTools.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteDocumentTools.swift; sourceTree = "<group>"; };
 		A81080B89B0F0AC01017D6D7 /* ModelManager+HuggingFace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ModelManager+HuggingFace.swift"; sourceTree = "<group>"; };
@@ -699,6 +731,7 @@
 		AD6FE3B101005521F444593D /* MeetingGridCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingGridCardView.swift; sourceTree = "<group>"; };
 		ADFE072C32F14B59D0406571 /* LLMEngine+Convenience.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LLMEngine+Convenience.swift"; sourceTree = "<group>"; };
 		AE62FBF59720C8B746A03EDB /* MeetingBookmarksPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingBookmarksPanelView.swift; sourceTree = "<group>"; };
+		AE8030D02974A04A80B48065 /* DocumentWidthModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentWidthModeTests.swift; sourceTree = "<group>"; };
 		AFA4DB05B86C453078B1E5E6 /* ContactsTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactsTool.swift; sourceTree = "<group>"; };
 		AFBC89D908FFD586D1C38ABF /* UndoToastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UndoToastView.swift; sourceTree = "<group>"; };
 		AFC4D0D0481D8CD554E5892C /* SearchBarField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBarField.swift; sourceTree = "<group>"; };
@@ -708,12 +741,14 @@
 		B1C70855FA4AA096BC6DBC4B /* StatItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatItem.swift; sourceTree = "<group>"; };
 		B1CF9F695CCB56896DC9A02C /* ApprovalGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApprovalGate.swift; sourceTree = "<group>"; };
 		B21302B0871DD6955B6F5148 /* SpaceContentPane+Cards.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SpaceContentPane+Cards.swift"; sourceTree = "<group>"; };
+		B37427E70D5B05A2E6C5B253 /* QuickOpenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickOpenTests.swift; sourceTree = "<group>"; };
 		B3C7E5CF5FB74C62BE34845D /* SlashCommandView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlashCommandView.swift; sourceTree = "<group>"; };
 		B3F9D423BBCD2E5ED6C361AA /* MenuBarCompanion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarCompanion.swift; sourceTree = "<group>"; };
 		B57D98C9B0D1E6A69681C8C1 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		B645AB2F4B86D9BDF86A6AC1 /* ExportTools.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportTools.swift; sourceTree = "<group>"; };
 		B6AC347933D7E812C30B26A8 /* CalendarWriteTools.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarWriteTools.swift; sourceTree = "<group>"; };
 		B7739DE974D154DA32E12C48 /* TemplateStore+BuiltIn.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TemplateStore+BuiltIn.swift"; sourceTree = "<group>"; };
+		B7D76EDEE9C20C5C390BAF10 /* DiagramMathBlockTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagramMathBlockTests.swift; sourceTree = "<group>"; };
 		B7E20C976C8094E3E4DCB896 /* DocumentStore+SeedData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DocumentStore+SeedData.swift"; sourceTree = "<group>"; };
 		B80061FBEC30F04EF2176F88 /* ChatInputField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatInputField.swift; sourceTree = "<group>"; };
 		B8D03A33B16F78827FBD8EDC /* ModelsSettingsTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelsSettingsTab.swift; sourceTree = "<group>"; };
@@ -728,6 +763,7 @@
 		BFE45DD206DEC983F8781BB2 /* BlockSerializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockSerializer.swift; sourceTree = "<group>"; };
 		C0CBBB8CE2F9462205BF47F4 /* PromptRegistry+Memory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PromptRegistry+Memory.swift"; sourceTree = "<group>"; };
 		C1422ADE4317F2B8650E23D7 /* FilterChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterChip.swift; sourceTree = "<group>"; };
+		C262104A21E62547CE677D5B /* EditorLayoutMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorLayoutMode.swift; sourceTree = "<group>"; };
 		C2A85CBFCD11CDF2FB693F73 /* InlineDiagramView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineDiagramView.swift; sourceTree = "<group>"; };
 		C3F51D3C49EB4A8530380A86 /* DocumentWorkspaceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentWorkspaceView.swift; sourceTree = "<group>"; };
 		C43699C20665A37F686FDD65 /* CalendarManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarManager.swift; sourceTree = "<group>"; };
@@ -746,6 +782,7 @@
 		CB8AA1433C5115832D5A7647 /* TemplateTools.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateTools.swift; sourceTree = "<group>"; };
 		CC3CE09FD46E14F97E07C0BF /* UnifiedSidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedSidebarView.swift; sourceTree = "<group>"; };
 		CCB1CD5106FDFE97F1CFC5EB /* ReviewPanelLLMTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewPanelLLMTests.swift; sourceTree = "<group>"; };
+		CCC4C9A99648838E46779A4D /* EditorZoom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorZoom.swift; sourceTree = "<group>"; };
 		CCEE1CC67630CF84E03498D5 /* MermaidRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MermaidRenderer.swift; sourceTree = "<group>"; };
 		CE4B9329DFE86A8D2B1629DE /* WritingGoalMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WritingGoalMode.swift; sourceTree = "<group>"; };
 		CF540C94525BF2C21BA389BF /* LogoBrandView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogoBrandView.swift; sourceTree = "<group>"; };
@@ -765,6 +802,7 @@
 		D5B61F580088B1A2F4D33DE8 /* FactCheckCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FactCheckCard.swift; sourceTree = "<group>"; };
 		D68015115364677BD6BA49E0 /* SlideTools.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlideTools.swift; sourceTree = "<group>"; };
 		D6829731778689289CE48545 /* InlineSpellEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineSpellEngine.swift; sourceTree = "<group>"; };
+		D732A7B7C4D529BBD960BDC9 /* QuickOpen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickOpen.swift; sourceTree = "<group>"; };
 		D766396CB3F843CD222C7F46 /* DurationFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DurationFormatter.swift; sourceTree = "<group>"; };
 		D7D771D4ECF4472264165F1C /* DocumentSearchState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentSearchState.swift; sourceTree = "<group>"; };
 		D89621C1818CAC734BD6B023 /* GraphCommunity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphCommunity.swift; sourceTree = "<group>"; };
@@ -773,6 +811,7 @@
 		DA41BE45973601CD371C00BB /* AgentChatView+Messages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AgentChatView+Messages.swift"; sourceTree = "<group>"; };
 		DB031A0FCAED343F68FB194A /* TableBlockData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableBlockData.swift; sourceTree = "<group>"; };
 		DB53BFC5C00966DB03AB861E /* KeyboardShortcutsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardShortcutsView.swift; sourceTree = "<group>"; };
+		DBB768463E40E11BC5922145 /* DocumentIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentIcon.swift; sourceTree = "<group>"; };
 		DD62B3D8FB4F2050661CE197 /* InlineAssistant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineAssistant.swift; sourceTree = "<group>"; };
 		DDA3B12D86E29B9012E0B96B /* LLMEngine+WritingAnalysis.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LLMEngine+WritingAnalysis.swift"; sourceTree = "<group>"; };
 		DDFD0E206CECE1D402126464 /* OnboardingV2View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingV2View.swift; sourceTree = "<group>"; };
@@ -786,6 +825,7 @@
 		E0D22DE9B734882F5550D444 /* FlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlowLayout.swift; sourceTree = "<group>"; };
 		E12A64F34E4BB90D4A6AD325 /* EmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateView.swift; sourceTree = "<group>"; };
 		E188450986288699B1B8A252 /* ScoreRingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScoreRingView.swift; sourceTree = "<group>"; };
+		E1C8C014AA23FE44D9ED97AE /* DiagramMathBlockView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagramMathBlockView.swift; sourceTree = "<group>"; };
 		E20D8AB097118E507520863A /* GrammarClarityLLMTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrammarClarityLLMTests.swift; sourceTree = "<group>"; };
 		E28B906C35C686A1F97C984E /* ModelChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelChip.swift; sourceTree = "<group>"; };
 		E2A54999991BFEA773747361 /* AgentReadAloudService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentReadAloudService.swift; sourceTree = "<group>"; };
@@ -797,10 +837,12 @@
 		E72E4F906B12DB58475B9460 /* CommunityDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunityDetector.swift; sourceTree = "<group>"; };
 		E7300054D056065027CC1FF3 /* CommandCenterNewMeetingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandCenterNewMeetingView.swift; sourceTree = "<group>"; };
 		E7FD01A02C6FB9C64A0238CF /* MeetingStore+Diarization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MeetingStore+Diarization.swift"; sourceTree = "<group>"; };
+		E91B8420A88FFD5D29FE6638 /* DeepLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLink.swift; sourceTree = "<group>"; };
 		E93998CDEA76314D90824839 /* SystemAudioCapture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemAudioCapture.swift; sourceTree = "<group>"; };
 		EA1B65F390DF6487047D9220 /* UserMemory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserMemory.swift; sourceTree = "<group>"; };
 		EA90D7698CBC2EB6CBF52AFB /* LLMClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LLMClient.swift; sourceTree = "<group>"; };
 		EAAA4BF89D7A99D017BB1C8E /* PromptBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptBuilderTests.swift; sourceTree = "<group>"; };
+		EB27F11A2333C941E28C916E /* DeepLinkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkTests.swift; sourceTree = "<group>"; };
 		EB319F816250DC8D8652F6BB /* MeetingActionItemsPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingActionItemsPanelView.swift; sourceTree = "<group>"; };
 		EB9F1B2B62A565ABF10817F5 /* ConferencingAppDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConferencingAppDetector.swift; sourceTree = "<group>"; };
 		EC3417F4F42C4F317FA8FD4C /* LogueLogo.svg */ = {isa = PBXFileReference; path = LogueLogo.svg; sourceTree = "<group>"; };
@@ -809,6 +851,7 @@
 		ED35C64E018F0B223D5FE487 /* OverviewQuickActionsCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverviewQuickActionsCard.swift; sourceTree = "<group>"; };
 		EF7B96F52DB280D23D637F33 /* MenuBarIcon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = MenuBarIcon.png; sourceTree = "<group>"; };
 		F06E61F5499F68059FF8775B /* TableCellTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableCellTextView.swift; sourceTree = "<group>"; };
+		F30E821E71C80A341EEC3F68 /* BlockEditorView+Reorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlockEditorView+Reorder.swift"; sourceTree = "<group>"; };
 		F4837D7E60145F15B37A2310 /* GraphRetriever.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphRetriever.swift; sourceTree = "<group>"; };
 		F4D0B06CDDC1184FD7958F9A /* SuggestionCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionCardView.swift; sourceTree = "<group>"; };
 		F520732BF6E86EA62DAC3E2B /* AgentTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentTool.swift; sourceTree = "<group>"; };
@@ -819,6 +862,7 @@
 		F7B886861180D41A132F1B6A /* AgentChatView+Input.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AgentChatView+Input.swift"; sourceTree = "<group>"; };
 		F8106A5A4786A5595D00CBF2 /* Suggestion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Suggestion.swift; sourceTree = "<group>"; };
 		F86FEEACED36C11C79D2FA9A /* RichTextEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RichTextEditor.swift; sourceTree = "<group>"; };
+		F95595374A2F4D02321B7CA2 /* DocumentReplaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentReplaceTests.swift; sourceTree = "<group>"; };
 		F9ABFE8CDB709383F2CCC4A8 /* MLXToolDefinitions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MLXToolDefinitions.swift; sourceTree = "<group>"; };
 		F9D05F3B9F242D1B1198B528 /* MeetingLLMTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingLLMTests.swift; sourceTree = "<group>"; };
 		F9DD3273B7AB955D3C6E3BC1 /* DeckPDFExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeckPDFExporter.swift; sourceTree = "<group>"; };
@@ -892,7 +936,19 @@
 			isa = PBXGroup;
 			children = (
 				79C6BA7C0C06C035AC3BFBD1 /* LLMIntegration */,
+				8D204801C0C2BADD68D406D7 /* BlockMoveTests.swift */,
+				7A450984B8338837BFDFF868 /* BlockTypeSlashMenuTests.swift */,
+				263E3C59B8D03346E04E7C92 /* DeepLinkRoutingTests.swift */,
+				EB27F11A2333C941E28C916E /* DeepLinkTests.swift */,
+				860DFF869B9C6C39BE468431 /* DiagnosticsReportTests.swift */,
+				B7D76EDEE9C20C5C390BAF10 /* DiagramMathBlockTests.swift */,
+				9130B8EDD12207674F5B4323 /* DocumentIconTests.swift */,
+				F95595374A2F4D02321B7CA2 /* DocumentReplaceTests.swift */,
+				AE8030D02974A04A80B48065 /* DocumentWidthModeTests.swift */,
+				7824CE8087F98B0143531A9F /* EditorZoomTests.swift */,
+				9226B7B10683E42ABEB71810 /* HighlightMarkTests.swift */,
 				EAAA4BF89D7A99D017BB1C8E /* PromptBuilderTests.swift */,
+				B37427E70D5B05A2E6C5B253 /* QuickOpenTests.swift */,
 				5C461874879489EBFF0BE683 /* SuggestionParserTests.swift */,
 				8D2D61B85F962E88AA1E5062 /* TextAnalysisRequestTests.swift */,
 				818DBC353FE8A22EC01DCB37 /* WritingDocumentTests.swift */,
@@ -1060,6 +1116,7 @@
 				1083BC25237ADD22FEE5A277 /* BackupManager.swift */,
 				C43699C20665A37F686FDD65 /* CalendarManager.swift */,
 				EB9F1B2B62A565ABF10817F5 /* ConferencingAppDetector.swift */,
+				11F90CF8BD9ABA35C96B0E76 /* DiagnosticsReport.swift */,
 				D382DBF4C28CE786D415CDD1 /* EncryptionManager.swift */,
 				3E86EBBF6643966395A7DE8B /* FileAccessGate.swift */,
 				22933096283C449A4669F1BF /* HapticFeedback.swift */,
@@ -1116,9 +1173,11 @@
 			isa = PBXGroup;
 			children = (
 				70020145197E51CB665C7D91 /* BlockEditorView.swift */,
+				F30E821E71C80A341EEC3F68 /* BlockEditorView+Reorder.swift */,
 				61150569A2C3758E03DC0666 /* BlockRowView.swift */,
 				1FB93A6E198E565413AD03FC /* BlockRowView+Actions.swift */,
 				381AAF180053F03E9FBAC2A3 /* BlockTextView.swift */,
+				E1C8C014AA23FE44D9ED97AE /* DiagramMathBlockView.swift */,
 				71CCC37048141456C9BA5AA3 /* DocumentSearchBar.swift */,
 				133717C9C61937FC843612D1 /* MultiBlockKeyHandler.swift */,
 				0B7EFCB53320B6385931BBD8 /* TableBlockEditView.swift */,
@@ -1160,6 +1219,7 @@
 				F6CEC2D65780182BE2B4F4F8 /* EntityExtractor.swift */,
 				7F10E442D4BA9DD990D8CEBA /* FaviconCache.swift */,
 				F4837D7E60145F15B37A2310 /* GraphRetriever.swift */,
+				430B153889068B3CB200455A /* HighlightMark.swift */,
 				39AC4C78B6DA5F62A04B49C3 /* InlineAttributeVisitor.swift */,
 				358D99D88D3FB7C39EE0C7E7 /* InlineRewriteEngine.swift */,
 				D6829731778689289CE48545 /* InlineSpellEngine.swift */,
@@ -1233,6 +1293,7 @@
 			isa = PBXGroup;
 			children = (
 				D3089A12B33B90CC09610C11 /* CommandPaletteView.swift */,
+				D732A7B7C4D529BBD960BDC9 /* QuickOpen.swift */,
 			);
 			path = CommandPalette;
 			sourceTree = "<group>";
@@ -1253,9 +1314,12 @@
 				1BEFD48C860C189F76D82545 /* ActionItem.swift */,
 				160A71994367176C72C11277 /* AgentConversation.swift */,
 				31784F4F4DF98021B23FFFA9 /* CanvasSnapshot.swift */,
+				E91B8420A88FFD5D29FE6638 /* DeepLink.swift */,
+				DBB768463E40E11BC5922145 /* DocumentIcon.swift */,
 				3C70C5136BF964DD9AC4887F /* DocumentStore.swift */,
 				B7E20C976C8094E3E4DCB896 /* DocumentStore+SeedData.swift */,
 				FE07F5F09706EA33B61BEF24 /* DocumentTemplate.swift */,
+				A62566632EE8FA6DAD6713DB /* DocumentWidthMode.swift */,
 				536139F2EF764AD8EE861D07 /* Folder.swift */,
 				D13D5598C230DA3644325779 /* FolderStore.swift */,
 				7DF36BD14718CAF328990D0A /* FolderStore+SeedData.swift */,
@@ -1593,6 +1657,8 @@
 				A92D6AC76A79B38344F240A3 /* DetectorResultBody.swift */,
 				C3F51D3C49EB4A8530380A86 /* DocumentWorkspaceView.swift */,
 				ECB1EE6AF1D9283E7F15E6C3 /* DocumentWorkspaceView+Toolbar.swift */,
+				C262104A21E62547CE677D5B /* EditorLayoutMode.swift */,
+				CCC4C9A99648838E46779A4D /* EditorZoom.swift */,
 				8361EA76FDB9D2AB11114559 /* InlineSuggestionPopoverView.swift */,
 				C53BEC5D1AB8C5D840B6DCD2 /* ReviewPanelView.swift */,
 				2E0454FC5757C2508196B561 /* RewritePanelView.swift */,
@@ -1783,12 +1849,24 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				362E757F0940BDB7CB5E560A /* BlockMoveTests.swift in Sources */,
+				F990F4EC5E8A9FEBA4C9FD3F /* BlockTypeSlashMenuTests.swift in Sources */,
+				8837715694AEB1053618212A /* DeepLinkRoutingTests.swift in Sources */,
+				52B089BBC06F1A4DC8CFA5CE /* DeepLinkTests.swift in Sources */,
+				D5975A82DEA279851186013D /* DiagnosticsReportTests.swift in Sources */,
+				861F5D959175FAC61CA02A55 /* DiagramMathBlockTests.swift in Sources */,
+				1AC0C886212A4F3ADC9A48D1 /* DocumentIconTests.swift in Sources */,
 				53C6F90254BA856A74CD343A /* DocumentLLMTests.swift in Sources */,
+				D36DA27367323F11D5671F9C /* DocumentReplaceTests.swift in Sources */,
+				35CBDE38DC02F798AE51C76F /* DocumentWidthModeTests.swift in Sources */,
+				3A0604553EBC4F314C97193A /* EditorZoomTests.swift in Sources */,
 				13373229911D8C07B23E3591 /* GrammarClarityLLMTests.swift in Sources */,
+				DDBFC59CEC2DFE580E604640 /* HighlightMarkTests.swift in Sources */,
 				5649718294F9E5770348BD76 /* LLMTestEvalExtensions.swift in Sources */,
 				D480184376B6F26A9755133A /* LLMTestHarness.swift in Sources */,
 				7685B4E18D7F1A25AE0F6738 /* MeetingLLMTests.swift in Sources */,
 				957DBF3D45C9A998D610B8B2 /* PromptBuilderTests.swift in Sources */,
+				4371B1C1354F8BF50EFECCBB /* QuickOpenTests.swift in Sources */,
 				C72506A4CA87BDD44FF88766 /* ReviewPanelLLMTests.swift in Sources */,
 				0EA7AB55C23D022F1C35E001 /* RewritePanelLLMTests.swift in Sources */,
 				EFB8555797ACCB5E2120C1AA /* SuggestionParserTests.swift in Sources */,
@@ -1846,6 +1924,7 @@
 				127BFC4FD2D2CA4E68169EC5 /* BackupSettingsTab.swift in Sources */,
 				11BFD9EE4E53A816585B6787 /* Block.swift in Sources */,
 				BCE7CC5D10CC3B52CDF54B6E /* BlockEditorDocument.swift in Sources */,
+				136DA7C6E8212377AEF7906B /* BlockEditorView+Reorder.swift in Sources */,
 				A633B36972CE37D81CE875A9 /* BlockEditorView.swift in Sources */,
 				A9B34E653A84128492DE6474 /* BlockRowView+Actions.swift in Sources */,
 				372D7C7E58F4EF0B8305E096 /* BlockRowView.swift in Sources */,
@@ -1886,16 +1965,20 @@
 				0449935D6F3DDF8994CDB6AE /* DailyDigestCard.swift in Sources */,
 				6A4AA026F9B378C593F2EB60 /* DateGroupingHelper.swift in Sources */,
 				30A636797A0AE2BFFDBD753F /* DeckPDFExporter.swift in Sources */,
+				EC4770E6775F3DD9A8168148 /* DeepLink.swift in Sources */,
 				13AFBE3135D8E53D1DA140B1 /* DeepResearchCoordinator+Helpers.swift in Sources */,
 				4E983F1CDE3D00085362D3EB /* DeepResearchCoordinator.swift in Sources */,
 				7574BF423E60FC56B9897A92 /* DeepResearchModels.swift in Sources */,
 				1379C780AB4DAD0DCCF512B6 /* DeepResearchProgressView.swift in Sources */,
 				C920B2F2484A06C01BC16F95 /* DetectorResultBody.swift in Sources */,
+				953ED2EEFAB6C2FFBC8F9C81 /* DiagnosticsReport.swift in Sources */,
+				15CC6613C14DCCA50A5BC133 /* DiagramMathBlockView.swift in Sources */,
 				D9392EFF400C3B9E2A0B181B /* DiagramTools.swift in Sources */,
 				09A677787DE7FF238366729D /* DiarizationManager+BatchASR.swift in Sources */,
 				2FD721F2491FFD83810DB23C /* DiarizationManager.swift in Sources */,
 				EC09A9CE12598BC04D96481A /* DocsHomeView.swift in Sources */,
 				A1D7482C98EE0833CBA17214 /* DocumentCardView.swift in Sources */,
+				5FCA28149B189B61283A387C /* DocumentIcon.swift in Sources */,
 				6EF0995F3E06CB5ED24FD625 /* DocumentListContentView.swift in Sources */,
 				A4AEBA0FBDA0E9CE695009FD /* DocumentListPane.swift in Sources */,
 				83D4B061F474B55E93422576 /* DocumentRowCompact.swift in Sources */,
@@ -1907,10 +1990,13 @@
 				EECF7BA703C69F033F229B25 /* DocumentStore.swift in Sources */,
 				2097A69FB625B8274E022216 /* DocumentTemplate.swift in Sources */,
 				0A7BB5F5BAF593A4D7FD9784 /* DocumentTools.swift in Sources */,
+				ACBD67F76F286A34F1A0E4CA /* DocumentWidthMode.swift in Sources */,
 				8D14A25D43498810F22E7C05 /* DocumentWorkspaceView+Toolbar.swift in Sources */,
 				01668579741EF854710CEB7F /* DocumentWorkspaceView.swift in Sources */,
 				1CFA41464BB0BBD94D0F51D1 /* DurationFormatter.swift in Sources */,
 				9F4F117462111A847F62D542 /* EditTemplateSheet.swift in Sources */,
+				BC3C23065AB5DCE2AD46926E /* EditorLayoutMode.swift in Sources */,
+				D16DE5948A97D72BCD5F06ED /* EditorZoom.swift in Sources */,
 				C6286FD01D42AB01841F83AD /* EmailTool.swift in Sources */,
 				539269586BA6A2425D334476 /* EmbeddingService.swift in Sources */,
 				B1CFB818BCC765AD35BA6339 /* EmptyStateView.swift in Sources */,
@@ -1938,6 +2024,7 @@
 				DA09144C59EB500FC57CC929 /* HapticFeedback.swift in Sources */,
 				2864F151E0AC25AAE963659E /* HelpMenuActions.swift in Sources */,
 				6EE6B461C7E6CA280E8C8661 /* HierarchicalSpaceMenu.swift in Sources */,
+				5FD238DAAD32BA6575CDCF30 /* HighlightMark.swift in Sources */,
 				EE4CB15C53C082C939662511 /* HomeAttentionCard.swift in Sources */,
 				6373E69354AD314B2BA380F7 /* HomeCardShell.swift in Sources */,
 				5B40672923AE9211B7EE0387 /* HomeContextBar.swift in Sources */,
@@ -2059,6 +2146,7 @@
 				FF8EF47C24090CCE60A0090C /* PromptRegistry.swift in Sources */,
 				02437AA08BF113B6E0957131 /* PulsingDot.swift in Sources */,
 				6BFD579894DD38D9476BB78C /* QuickComposeView.swift in Sources */,
+				2F188F551FC6C5738BDB23B2 /* QuickOpen.swift in Sources */,
 				22EACBCCB7BD304F9AE40B4E /* QuickPromptChip.swift in Sources */,
 				FB2DCEFD67348622524BEB81 /* RecentContentPane.swift in Sources */,
 				0932B4BDD1E386DF7D71C86C /* RecordingSessionManager+Diarization.swift in Sources */,

--- a/Logue/App/AppConstants.swift
+++ b/Logue/App/AppConstants.swift
@@ -23,6 +23,8 @@ enum AppConstants {
         static let meetingSortOrder = "meetingSortOrder"
         static let actionItemSortOrder = "actionItemSortOrder"
         static let autoSortCheckedItems = "autoSortCheckedItems"
+        /// Editor zoom multiplier applied on top of the base editor font size.
+        static let editorZoomScale = "editorZoomScale"
         static let groupByDate = "groupByDate"
         static let customAPIModels = "CustomAPIModels"
         static let autoSaveSummaryToDocument = "autoSaveSummaryToDocument"
@@ -240,6 +242,21 @@ enum AppConstants {
 
     enum Support {
         static let email = "support@bitwize.ai"
+    }
+
+    // MARK: - Editor
+
+    enum Editor {
+        /// Comfortable measure for prose — roughly 75 characters at the default size.
+        static let normalContentWidth: CGFloat = 720
+        /// Wide measure for tables, diagrams, and generated documents.
+        static let wideContentWidth: CGFloat = 1100
+
+        /// Editor text-zoom bounds. 1.0 is the document's natural size.
+        static let minZoom: CGFloat = 0.5
+        static let maxZoom: CGFloat = 3.0
+        static let zoomStep: CGFloat = 0.1
+        static let defaultZoom: CGFloat = 1.0
     }
 
     // MARK: - Agent Defaults

--- a/Logue/App/AppDelegate.swift
+++ b/Logue/App/AppDelegate.swift
@@ -233,6 +233,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
     }
 
+    /// Handles incoming `logue://` deep links.
+    ///
+    /// URLs arrive from outside the app, so `DeepLinkRouter` validates each one before
+    /// any navigation happens. Unrecognised URLs are logged by host only — never by
+    /// full URL — and otherwise ignored.
+    func application(_: NSApplication, open urls: [URL]) {
+        for url in urls {
+            if DeepLinkRouter.route(url: url) {
+                showMainWindow()
+            } else {
+                logger.warning("Ignored unrecognised deep link for host: \(url.host ?? "none", privacy: .public)")
+            }
+        }
+    }
+
     /// Backup handler for dock icon click (may not fire with WindowGroup — Apple bug FB9754295).
     func applicationShouldHandleReopen(_: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
         if !flag {

--- a/Logue/App/LogueApp.swift
+++ b/Logue/App/LogueApp.swift
@@ -20,6 +20,11 @@ extension Notification.Name {
 struct LogueApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
 
+    /// Editor zoom multiplier, shared with the editor through AppStorage so both
+    /// scenes stay in sync without a separate observable.
+    @AppStorage(AppConstants.UserDefaultsKeys.editorZoomScale) private var zoomScale: Double =
+        AppConstants.Editor.defaultZoom
+
     var body: some Scene {
         // ── Main document window ──────────────────────────────────────────────
         WindowGroup("Logue") {
@@ -67,6 +72,23 @@ struct LogueApp: App {
                 )
             }
 
+            CommandGroup(after: .pasteboard) {
+                Button("Paste Without Formatting") {
+                    NSApp.sendAction(#selector(NSTextView.pasteAsPlainText(_:)), to: nil, from: nil)
+                }
+                .keyboardShortcut("v", modifiers: [.command, .shift])
+            }
+
+            CommandGroup(after: .toolbar) {
+                Button("Zoom In") { applyZoom { $0.zoomIn() } }
+                    .keyboardShortcut("+", modifiers: .command)
+                Button("Zoom Out") { applyZoom { $0.zoomOut() } }
+                    .keyboardShortcut("-", modifiers: .command)
+                Button("Actual Size") { applyZoom { $0.reset() } }
+                    .keyboardShortcut("0", modifiers: .command)
+                Divider()
+            }
+
             CommandGroup(replacing: .help) {
                 Button("Documentation") { HelpMenuActions.openDocumentation() }
                 Button("Keyboard Shortcuts") { HelpMenuActions.openKeyboardShortcuts() }
@@ -100,6 +122,14 @@ struct LogueApp: App {
         Settings {
             SettingsRootView()
         }
+    }
+
+    /// Applies a zoom mutation through `EditorZoom` so clamping lives in one place.
+    private func applyZoom(_ mutate: (inout EditorZoom) -> Void) {
+        var zoom = EditorZoom()
+        zoom.scale = zoomScale
+        mutate(&zoom)
+        zoomScale = zoom.scale
     }
 }
 

--- a/Logue/Engine/HighlightMark.swift
+++ b/Logue/Engine/HighlightMark.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+/// The `==highlighted text==` inline mark.
+///
+/// This is not CommonMark, so `swift-markdown` treats the delimiters as literal
+/// text. That works in our favour: the delimiters survive a parse/serialize round
+/// trip untouched, and this type owns detecting and toggling them.
+enum HighlightMark {
+    static let delimiter = "=="
+
+    private static let delimiterLength = 2
+
+    /// Matches `==content==` where the content is non-empty and stays on one line.
+    /// `[^=\n]` for the first and last content characters prevents matching the
+    /// empty `====` case or bleeding across an adjacent mark.
+    private static let pattern = "==([^=\n](?:[^\n]*?[^=\n])?)=="
+
+    /// Ranges of complete highlight marks, delimiters included.
+    static func ranges(in text: String) -> [NSRange] {
+        guard !text.isEmpty else { return [] }
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
+        let full = NSRange(location: 0, length: (text as NSString).length)
+        return regex.matches(in: text, range: full).map(\.range)
+    }
+
+    /// Ranges of the highlighted content, delimiters excluded — use this when
+    /// applying a background style so the delimiters are not painted.
+    static func contentRanges(in text: String) -> [NSRange] {
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
+        let full = NSRange(location: 0, length: (text as NSString).length)
+        return regex.matches(in: text, range: full).compactMap { match in
+            match.numberOfRanges > 1 ? match.range(at: 1) : nil
+        }
+    }
+
+    /// Adds or removes highlight delimiters around `range`.
+    ///
+    /// Returns the text unchanged for an empty or out-of-bounds range, so callers
+    /// can pass a raw selection without pre-validating it.
+    static func toggled(in text: String, range: NSRange) -> String {
+        let nsText = text as NSString
+        guard range.length > 0,
+              range.location >= 0,
+              NSMaxRange(range) <= nsText.length
+        else { return text }
+
+        // Case 1: the selection sits immediately inside an existing pair.
+        if let unwrapped = unwrappingSurroundingDelimiters(in: nsText, range: range) {
+            return unwrapped
+        }
+
+        // Case 2: the selection itself spans a complete pair.
+        let selected = nsText.substring(with: range)
+        if selected.hasPrefix(delimiter),
+           selected.hasSuffix(delimiter),
+           selected.count > delimiterLength * 2
+        {
+            let inner = String(selected.dropFirst(delimiterLength).dropLast(delimiterLength))
+            return nsText.replacingCharacters(in: range, with: inner)
+        }
+
+        // Case 3: plain text — wrap it.
+        return nsText.replacingCharacters(in: range, with: delimiter + selected + delimiter)
+    }
+
+    private static func unwrappingSurroundingDelimiters(in nsText: NSString, range: NSRange) -> String? {
+        let leadingStart = range.location - delimiterLength
+        let trailingStart = NSMaxRange(range)
+        guard leadingStart >= 0, trailingStart + delimiterLength <= nsText.length else { return nil }
+
+        let leading = NSRange(location: leadingStart, length: delimiterLength)
+        let trailing = NSRange(location: trailingStart, length: delimiterLength)
+        guard nsText.substring(with: leading) == delimiter,
+              nsText.substring(with: trailing) == delimiter
+        else { return nil }
+
+        // Delete the trailing pair first so the leading range stays valid.
+        let result = NSMutableString(string: nsText)
+        result.deleteCharacters(in: trailing)
+        result.deleteCharacters(in: leading)
+        return result as String
+    }
+}

--- a/Logue/Models/DeepLink.swift
+++ b/Logue/Models/DeepLink.swift
@@ -1,0 +1,109 @@
+import Foundation
+
+/// A `logue://` deep link to an item in the library.
+///
+/// Links arrive from outside the app (Finder, browsers, other apps), so parsing
+/// treats the URL as untrusted input: anything not matching exactly one known
+/// host plus one well-formed UUID path component resolves to `nil` rather than a
+/// best guess.
+enum DeepLink: Equatable, Sendable {
+    case document(id: UUID)
+    case meeting(id: UUID)
+    case space(id: UUID)
+
+    static let scheme = "logue"
+
+    init?(url: URL) {
+        guard url.scheme?.lowercased() == Self.scheme,
+              let host = url.host?.lowercased()
+        else { return nil }
+
+        // Exactly one component — reject empty, extra, and traversal paths alike.
+        let components = url.pathComponents.filter { $0 != "/" }
+        guard components.count == 1,
+              let identifier = UUID(uuidString: components[0])
+        else { return nil }
+
+        switch host {
+        case Host.document: self = .document(id: identifier)
+        case Host.meeting: self = .meeting(id: identifier)
+        case Host.space: self = .space(id: identifier)
+        default: return nil
+        }
+    }
+
+    var url: URL {
+        var components = URLComponents()
+        components.scheme = Self.scheme
+        components.host = host
+        components.path = "/\(identifier.uuidString)"
+        // Unreachable in practice: scheme and host are constants and a UUID string
+        // contains only URL-safe characters.
+        return components.url ?? URL(fileURLWithPath: "/")
+    }
+
+    var identifier: UUID {
+        switch self {
+        case let .document(id), let .meeting(id), let .space(id): id
+        }
+    }
+
+    private var host: String {
+        switch self {
+        case .document: Host.document
+        case .meeting: Host.meeting
+        case .space: Host.space
+        }
+    }
+
+    private enum Host {
+        static let document = "document"
+        static let meeting = "meeting"
+        static let space = "space"
+    }
+
+    // MARK: - Notification Bridging
+
+    /// Typed `userInfo` keys — never string literals at the call site.
+    enum UserInfoKey {
+        static let identifier = "deepLinkIdentifier"
+    }
+
+    var notificationName: Notification.Name {
+        switch self {
+        case .document: .deepLinkOpenDocument
+        case .meeting: .deepLinkOpenMeeting
+        case .space: .deepLinkOpenSpace
+        }
+    }
+
+    var notificationPayload: [String: Any] {
+        [UserInfoKey.identifier: identifier]
+    }
+}
+
+extension Notification.Name {
+    static let deepLinkOpenDocument = Notification.Name("deepLinkOpenDocument")
+    static let deepLinkOpenMeeting = Notification.Name("deepLinkOpenMeeting")
+    static let deepLinkOpenSpace = Notification.Name("deepLinkOpenSpace")
+}
+
+// MARK: - Router
+
+/// Turns an incoming URL into a navigation notification.
+///
+/// Kept separate from `DeepLink` so parsing stays free of side effects and can be
+/// tested without observing NotificationCenter.
+enum DeepLinkRouter {
+    /// Returns `true` when the URL was a recognised deep link and was dispatched.
+    @discardableResult
+    static func route(url: URL) -> Bool {
+        guard let link = DeepLink(url: url) else { return false }
+        NotificationCenter.default.post(
+            name: link.notificationName,
+            object: nil,
+            userInfo: link.notificationPayload
+        )
+        return true
+    }
+}

--- a/Logue/Models/DocumentIcon.swift
+++ b/Logue/Models/DocumentIcon.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Validation for a per-document icon.
+///
+/// The icon is user-supplied text rendered in lists and titles, and it is embedded
+/// in LLM prompts alongside the document title. Validation is therefore strict:
+/// exactly one grapheme, no control characters, or nothing at all.
+enum DocumentIcon {
+    /// Maximum graphemes allowed. One, so an icon cannot become a label.
+    static let maxGraphemes = 1
+
+    /// Returns a safe icon, or `nil` to clear it.
+    ///
+    /// Rejects rather than truncates over-long input — trimming could split a
+    /// multi-scalar emoji into a broken fragment.
+    static func sanitised(_ raw: String) -> String? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        // Category `Cc` only — deliberately NOT `CharacterSet.controlCharacters`,
+        // which also covers `Cf` (format) and would reject the zero-width joiner
+        // that composes emoji like 👩‍💻.
+        let hasControlCharacter = trimmed.unicodeScalars.contains { scalar in
+            scalar.properties.generalCategory == .control
+        }
+        guard !hasControlCharacter else { return nil }
+        guard trimmed.count <= maxGraphemes else { return nil }
+
+        return trimmed
+    }
+}

--- a/Logue/Models/DocumentWidthMode.swift
+++ b/Logue/Models/DocumentWidthMode.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// Editor content width for a document.
+///
+/// `normal` suits focused prose; `wide` suits tables, diagrams, and generated
+/// documents. Stored per document so an individual document can override the
+/// app-wide default.
+enum DocumentWidthMode: String, Codable, CaseIterable, Sendable {
+    case normal
+    case wide
+
+    /// Maximum width of the editor's text container for this mode.
+    var maxContentWidth: CGFloat {
+        switch self {
+        case .normal: AppConstants.Editor.normalContentWidth
+        case .wide: AppConstants.Editor.wideContentWidth
+        }
+    }
+
+    var toggled: DocumentWidthMode {
+        self == .normal ? .wide : .normal
+    }
+
+    var label: String {
+        switch self {
+        case .normal: "Normal width"
+        case .wide: "Wide width"
+        }
+    }
+
+    var symbolName: String {
+        switch self {
+        case .normal: "rectangle.portrait"
+        case .wide: "rectangle"
+        }
+    }
+}

--- a/Logue/Models/WritingDocument.swift
+++ b/Logue/Models/WritingDocument.swift
@@ -25,6 +25,24 @@ struct WritingDocument: Identifiable, Codable, Sendable {
         case score, spaceID, tags, chatMessages, isTrashed, trashedAt
         case reviewGrade, reviewReactions, factChecks, piiFindings
         case vocabSuggestions, aiDetectionResult, plagiarismResult, rewriteResult
+        case storedWidthMode = "widthMode"
+        case icon
+    }
+
+    /// Optional single-grapheme icon shown in lists and titles.
+    /// Validate user input through `DocumentIcon.sanitised` before assigning.
+    var icon: String?
+
+    /// Backing storage for `widthMode`. Optional so documents persisted before this
+    /// property existed still decode — the synthesised decoder uses
+    /// `decodeIfPresent` for optionals, where a non-optional would throw
+    /// `keyNotFound` and make every existing document unreadable.
+    var storedWidthMode: DocumentWidthMode?
+
+    /// Editor content width for this document. Defaults to `.normal`.
+    var widthMode: DocumentWidthMode {
+        get { storedWidthMode ?? .normal }
+        set { storedWidthMode = newValue }
     }
 
     /// The last computed writing score; nil until first analysis.

--- a/Logue/Resources/Info.plist
+++ b/Logue/Resources/Info.plist
@@ -22,6 +22,19 @@
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>CFBundleURLName</key>
+			<string>com.bitwize.logue.deeplink</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>logue</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSUIElement</key>

--- a/Logue/Services/DiagnosticsReport.swift
+++ b/Logue/Services/DiagnosticsReport.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+/// Builds the sanitised diagnostics block attached to bug reports.
+///
+/// The output is pasted into **public** GitHub issues, so it carries only
+/// environment facts. It deliberately excludes filesystem paths, the account name,
+/// URLs, API keys, and any document, meeting, or space content. Every interpolated
+/// value goes through `sanitise` so an attacker-controlled or malformed model name
+/// cannot inject newlines and forge extra diagnostic lines.
+@MainActor
+enum DiagnosticsReport {
+    /// Maximum characters kept for any single interpolated value.
+    static let maxValueLength = 120
+
+    static func generate() -> String {
+        let lines: [String] = [
+            "- App: \(sanitise(BugReportInfo.appVersion)) (\(sanitise(BugReportInfo.buildNumber)))",
+            "- macOS: \(sanitise(BugReportInfo.macOSVersion))",
+            "- Device: \(sanitise(BugReportInfo.deviceModel))",
+            "- Architecture: \(architecture)",
+            "- Physical memory: \(physicalMemoryGB) GB",
+            "- Active model: \(activeModelDescription)",
+            "- External providers: \(externalProviderSummary)",
+        ]
+        return lines.joined(separator: "\n")
+    }
+
+    /// Collapses a value to a single safe line.
+    ///
+    /// Strips control characters and newlines, trims whitespace, clamps length, and
+    /// substitutes a placeholder for empty input.
+    static func sanitise(_ raw: String) -> String {
+        let collapsed = raw.filter { character in
+            !character.isNewline && character.unicodeScalars.allSatisfy { scalar in
+                !CharacterSet.controlCharacters.contains(scalar)
+            }
+        }
+        let trimmed = collapsed.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return "unknown" }
+        return String(trimmed.prefix(maxValueLength))
+    }
+
+    // MARK: - Environment Facts
+
+    private static var architecture: String {
+        #if arch(arm64)
+        "arm64"
+        #elseif arch(x86_64)
+        "x86_64"
+        #else
+        "unknown"
+        #endif
+    }
+
+    private static var physicalMemoryGB: String {
+        let bytes = ProcessInfo.processInfo.physicalMemory
+        let gigabytes = Double(bytes) / 1_073_741_824
+        return String(format: "%.0f", gigabytes)
+    }
+
+    /// The active model's identifier only — never an endpoint URL or key.
+    private static var activeModelDescription: String {
+        guard let identifier = ModelManager.shared.activeModelID else { return "none" }
+        return sanitise(identifier)
+    }
+
+    /// Whether any cloud/API model is configured, as a count — never the endpoints
+    /// themselves and never the keys, which live in the Keychain.
+    private static var externalProviderSummary: String {
+        let count = ModelManager.shared.customModels.filter { $0.type == .api }.count
+        return count == 0 ? "none configured" : "\(count) configured"
+    }
+}

--- a/Logue/Views/CommandPalette/QuickOpen.swift
+++ b/Logue/Views/CommandPalette/QuickOpen.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+// MARK: - Item
+
+/// One row in the quick-open palette.
+struct QuickOpenItem: Identifiable, Equatable, Sendable {
+    enum Kind: Equatable, Sendable {
+        case document
+        case meeting
+    }
+
+    let id: UUID
+    let title: String
+    let kind: Kind
+}
+
+// MARK: - Matcher
+
+/// Ranks quick-open candidates by title.
+///
+/// Ranking is deliberately simple and local — exact, then prefix, then substring,
+/// then initials-style subsequence — so the palette stays instant on large
+/// libraries without touching the FTS index or the embedding store.
+enum QuickOpenMatcher {
+    /// Upper bound on returned rows, so a broad query cannot stall the palette.
+    static let maxResults = 50
+
+    static func match(query: String, in items: [QuickOpenItem]) -> [QuickOpenItem] {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !trimmed.isEmpty else { return Array(items.prefix(maxResults)) }
+
+        let scored: [(item: QuickOpenItem, rank: Int)] = items.compactMap { item in
+            guard let rank = rank(of: item.title.lowercased(), for: trimmed) else { return nil }
+            return (item, rank)
+        }
+
+        // Stable within a rank: preserve the caller's ordering (recency).
+        let ordered = scored.enumerated().sorted { lhs, rhs in
+            lhs.element.rank == rhs.element.rank
+                ? lhs.offset < rhs.offset
+                : lhs.element.rank < rhs.element.rank
+        }
+        return ordered.prefix(maxResults).map(\.element.item)
+    }
+
+    /// Lower is better; `nil` means no match.
+    private static func rank(of title: String, for query: String) -> Int? {
+        if title == query {
+            return 0
+        }
+        if title.hasPrefix(query) {
+            return 1
+        }
+        if title.contains(query) {
+            return 2
+        }
+        if isSubsequence(query, of: title) {
+            return 3
+        }
+        return nil
+    }
+
+    /// Whether `query`'s characters appear in `title` in order, allowing gaps —
+    /// this is what makes "prm" find "Product Roadmap".
+    private static func isSubsequence(_ query: String, of title: String) -> Bool {
+        var remaining = Substring(title)
+        for character in query {
+            guard let index = remaining.firstIndex(of: character) else { return false }
+            remaining = remaining[remaining.index(after: index)...]
+        }
+        return true
+    }
+}

--- a/Logue/Views/Editor/BlockEditor/Model/Block.swift
+++ b/Logue/Views/Editor/BlockEditor/Model/Block.swift
@@ -44,6 +44,10 @@ enum Block: Identifiable {
     case codeBlock(id: BlockID, language: String, code: String)
     case table(id: BlockID, data: TableBlockData)
     case divider(id: BlockID)
+    /// A Mermaid diagram, stored as its source so it stays durable in markdown.
+    case mermaid(id: BlockID, source: String)
+    /// A display-math block, stored as LaTeX between `$$` fences.
+    case math(id: BlockID, latex: String)
 
     var id: BlockID {
         switch self {
@@ -55,7 +59,9 @@ enum Block: Identifiable {
              let .blockQuote(id, _),
              let .codeBlock(id, _, _),
              let .table(id, _),
-             let .divider(id):
+             let .divider(id),
+             let .mermaid(id, _),
+             let .math(id, _):
             id
         }
     }
@@ -123,6 +129,10 @@ enum Block: Identifiable {
             items.map(\.text).filter { !$0.isEmpty }
         case let .checkboxList(_, items):
             items.map(\.text).filter { !$0.isEmpty }
+        case let .mermaid(_, source):
+            source.isEmpty ? [] : [source]
+        case let .math(_, latex):
+            latex.isEmpty ? [] : [latex]
         default:
             []
         }
@@ -149,6 +159,10 @@ enum Block: Identifiable {
             data.rows.allSatisfy { $0.allSatisfy(\.isEmpty) }
         case .divider:
             false
+        case let .mermaid(_, source):
+            source.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        case let .math(_, latex):
+            latex.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         }
     }
 }
@@ -176,6 +190,10 @@ extension Block: Equatable {
             lid == rid && ld === rd && ld.version == rd.version
         case let (.divider(lid), .divider(rid)):
             lid == rid
+        case let (.mermaid(lid, ls), .mermaid(rid, rs)):
+            lid == rid && ls == rs
+        case let (.math(lid, ll), .math(rid, rl)):
+            lid == rid && ll == rl
         default:
             false
         }
@@ -219,6 +237,14 @@ extension Block {
 
     static func newDivider() -> Block {
         .divider(id: UUID())
+    }
+
+    static func emptyMermaid() -> Block {
+        .mermaid(id: UUID(), source: "flowchart LR\n  A --> B")
+    }
+
+    static func emptyMath() -> Block {
+        .math(id: UUID(), latex: "")
     }
 
     /// The first list item ID for list-type blocks, nil for others.

--- a/Logue/Views/Editor/BlockEditor/Model/BlockEditorDocument.swift
+++ b/Logue/Views/Editor/BlockEditor/Model/BlockEditorDocument.swift
@@ -89,6 +89,40 @@ final class BlockEditorDocument {
         blocks.insert(block, at: adjustedDest)
     }
 
+    /// Direction for a selection move.
+    enum MoveDirection {
+        case up
+        case down
+    }
+
+    /// Moves a contiguous run of selected blocks one position up or down.
+    ///
+    /// A non-contiguous selection is rejected rather than reordered arbitrarily —
+    /// silently collapsing a gapped selection would scramble the document.
+    func moveSelectedBlocks(_ selectedIDs: Set<BlockID>, direction: MoveDirection) {
+        guard !selectedIDs.isEmpty else { return }
+
+        let indices = blocks.indices.filter { selectedIDs.contains(blocks[$0].id) }.sorted()
+        guard indices.count == selectedIDs.count,
+              let first = indices.first,
+              let last = indices.last,
+              last - first + 1 == indices.count
+        else { return }
+
+        switch direction {
+        case .up:
+            guard first > 0 else { return }
+            recordUndo()
+            let above = blocks.remove(at: first - 1)
+            blocks.insert(above, at: last)
+        case .down:
+            guard last + 1 < blocks.count else { return }
+            recordUndo()
+            let below = blocks.remove(at: last + 1)
+            blocks.insert(below, at: first)
+        }
+    }
+
     // MARK: - Update Text
 
     func updateText(blockID: BlockID, text: String) {

--- a/Logue/Views/Editor/BlockEditor/Model/BlockSerializer.swift
+++ b/Logue/Views/Editor/BlockEditor/Model/BlockSerializer.swift
@@ -13,6 +13,25 @@ enum BlockSerializer {
             return [.emptyParagraph()]
         }
 
+        // `$$` math fences are not CommonMark: cmark would parse them as a
+        // paragraph and collapse the internal newlines into spaces, destroying
+        // multi-line LaTeX. Split them out before handing the rest to cmark.
+        var blocks: [Block] = []
+        for segment in mathFenceSegments(in: markdown) {
+            switch segment {
+            case let .math(latex):
+                blocks.append(.math(id: UUID(), latex: latex))
+            case let .markdown(text):
+                blocks += parseMarkdownSegment(text)
+            }
+        }
+
+        return blocks.isEmpty ? [.emptyParagraph()] : blocks
+    }
+
+    private static func parseMarkdownSegment(_ markdown: String) -> [Block] {
+        guard !markdown.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return [] }
+
         let document = Document(parsing: markdown, options: [.parseBlockDirectives])
         var blocks: [Block] = []
 
@@ -22,7 +41,62 @@ enum BlockSerializer {
             }
         }
 
-        return blocks.isEmpty ? [.emptyParagraph()] : blocks
+        return blocks
+    }
+
+    // MARK: - Math Fence Splitting
+
+    private enum MarkdownSegment {
+        case markdown(String)
+        case math(String)
+    }
+
+    private static let mathFence = "$$"
+
+    /// Splits `markdown` into alternating plain-markdown and `$$`-fenced math runs,
+    /// preserving document order. An unterminated fence is treated as ordinary
+    /// markdown so malformed input never silently swallows the rest of the document.
+    private static func mathFenceSegments(in markdown: String) -> [MarkdownSegment] {
+        let lines = markdown.components(separatedBy: "\n")
+        guard lines.contains(where: { $0.trimmingCharacters(in: .whitespaces) == mathFence }) else {
+            return [.markdown(markdown)]
+        }
+
+        var segments: [MarkdownSegment] = []
+        var pending: [String] = []
+        var mathLines: [String] = []
+        var insideMath = false
+
+        for line in lines {
+            let isFence = line.trimmingCharacters(in: .whitespaces) == mathFence
+
+            if isFence, !insideMath {
+                if !pending.isEmpty {
+                    segments.append(.markdown(pending.joined(separator: "\n")))
+                    pending = []
+                }
+                insideMath = true
+            } else if isFence, insideMath {
+                segments.append(.math(mathLines.joined(separator: "\n")))
+                mathLines = []
+                insideMath = false
+            } else if insideMath {
+                mathLines.append(line)
+            } else {
+                pending.append(line)
+            }
+        }
+
+        // Unterminated fence: restore the opening fence and its contents verbatim.
+        if insideMath {
+            pending.append(mathFence)
+            pending += mathLines
+        }
+        if !pending.isEmpty {
+            segments.append(.markdown(pending.joined(separator: "\n")))
+        }
+
+        return segments
     }
 
     // MARK: - Serialize (Blocks → Markdown)
@@ -187,6 +261,10 @@ enum BlockSerializer {
         let code = codeBlock.code.hasSuffix("\n")
             ? String(codeBlock.code.dropLast())
             : codeBlock.code
+        // A `mermaid`-tagged fence is a diagram, not source code to syntax-highlight.
+        if language.lowercased() == Self.mermaidLanguage {
+            return .mermaid(id: UUID(), source: code)
+        }
         return .codeBlock(id: UUID(), language: language, code: code)
     }
 
@@ -322,8 +400,16 @@ enum BlockSerializer {
 
         case .divider:
             return "---"
+
+        case let .mermaid(_, source):
+            return "```\(Self.mermaidLanguage)\n\(source)\n```"
+
+        case let .math(_, latex):
+            return "\(mathFence)\n\(latex)\n\(mathFence)"
         }
     }
+
+    static let mermaidLanguage = "mermaid"
 
     private static func serializeBulletList(_ items: [BlockListItem]) -> String {
         items.map { item in

--- a/Logue/Views/Editor/BlockEditor/Model/DocumentSearchState.swift
+++ b/Logue/Views/Editor/BlockEditor/Model/DocumentSearchState.swift
@@ -9,6 +9,19 @@ struct SearchMatch: Identifiable {
     let itemID: UUID?
     /// Character range within the block's or item's text.
     let range: NSRange
+
+    var target: ReplaceTarget {
+        ReplaceTarget(blockID: blockID, itemID: itemID)
+    }
+}
+
+// MARK: - Replace Target
+
+/// Identifies the single editable string a match lives in — a block's own text, or
+/// one item inside a list block.
+struct ReplaceTarget: Hashable {
+    let blockID: BlockID
+    let itemID: UUID?
 }
 
 // MARK: - Document Search State
@@ -17,6 +30,10 @@ struct SearchMatch: Identifiable {
 final class DocumentSearchState {
     var isActive = false
     var query = ""
+    /// Text typed into the replace field; empty is valid (deletes the match).
+    var replacement = ""
+    /// Whether the replace row is shown in the find bar.
+    var isReplaceVisible = false
     var matchCase = false
     var wholeWord = false
     var matches: [SearchMatch] = []
@@ -48,8 +65,77 @@ final class DocumentSearchState {
     func close() {
         isActive = false
         query = ""
+        replacement = ""
+        isReplaceVisible = false
         matches = []
         currentMatchIndex = 0
+    }
+
+    // MARK: - Replace
+
+    /// Replaces the match at `currentMatchIndex` and refreshes the match list.
+    @MainActor
+    func replaceCurrent(with replacementText: String, in document: BlockEditorDocument) {
+        guard !query.isEmpty, let match = currentMatch else { return }
+        apply(ranges: [match.range], replacement: replacementText, to: match.target, in: document)
+        search(in: document.blocks)
+    }
+
+    /// Replaces every current match. Returns how many were replaced.
+    @MainActor
+    @discardableResult
+    func replaceAll(with replacementText: String, in document: BlockEditorDocument) -> Int {
+        guard !query.isEmpty, !matches.isEmpty else { return 0 }
+        let replacedCount = matches.count
+
+        // Group by target so each text is rewritten once, and apply each target's
+        // ranges from last to first so earlier offsets stay valid when the
+        // replacement has a different length than the query.
+        var rangesByTarget: [ReplaceTarget: [NSRange]] = [:]
+        for match in matches {
+            rangesByTarget[match.target, default: []].append(match.range)
+        }
+
+        for (target, ranges) in rangesByTarget {
+            let descending = ranges.sorted { $0.location > $1.location }
+            apply(ranges: descending, replacement: replacementText, to: target, in: document)
+        }
+
+        search(in: document.blocks)
+        return replacedCount
+    }
+
+    /// Rewrites `ranges` (which must be ordered last-to-first) within one target.
+    @MainActor
+    private func apply(
+        ranges: [NSRange],
+        replacement replacementText: String,
+        to target: ReplaceTarget,
+        in document: BlockEditorDocument
+    ) {
+        guard let original = currentText(of: target, in: document) else { return }
+
+        let mutable = NSMutableString(string: original)
+        for range in ranges {
+            guard range.location >= 0, NSMaxRange(range) <= mutable.length else { continue }
+            mutable.replaceCharacters(in: range, with: replacementText)
+        }
+        let updated = mutable as String
+        guard updated != original else { return }
+
+        if let itemID = target.itemID {
+            document.updateListItemText(blockID: target.blockID, itemID: itemID, text: updated)
+        } else {
+            document.updateText(blockID: target.blockID, text: updated)
+        }
+    }
+
+    @MainActor
+    private func currentText(of target: ReplaceTarget, in document: BlockEditorDocument) -> String? {
+        if let itemID = target.itemID {
+            return document.listItemText(blockID: target.blockID, itemID: itemID)
+        }
+        return document.block(for: target.blockID)?.textContent
     }
 
     /// Search all blocks for occurrences of `query`.
@@ -85,6 +171,12 @@ final class DocumentSearchState {
                 for item in items {
                     results += findMatches(in: item.text, blockID: id, itemID: item.id, options: searchOptions)
                 }
+
+            case let .mermaid(id, source):
+                results += findMatches(in: source, blockID: id, itemID: nil, options: searchOptions)
+
+            case let .math(id, latex):
+                results += findMatches(in: latex, blockID: id, itemID: nil, options: searchOptions)
 
             case .table, .divider:
                 break

--- a/Logue/Views/Editor/BlockEditor/Model/DocumentSearchState.swift
+++ b/Logue/Views/Editor/BlockEditor/Model/DocumentSearchState.swift
@@ -206,29 +206,7 @@ final class DocumentSearchState {
             let foundRange = nsText.range(of: query, options: options, range: searchRange)
             guard foundRange.location != NSNotFound else { break }
 
-            if wholeWord {
-                // Check that characters before and after the match are not word characters
-                let isWordBoundaryBefore: Bool
-                if foundRange.location > 0 {
-                    let ch = text[text.index(text.startIndex, offsetBy: foundRange.location - 1)]
-                    isWordBoundaryBefore = !ch.isLetter && !ch.isNumber && ch != "_"
-                } else {
-                    isWordBoundaryBefore = true
-                }
-
-                let isWordBoundaryAfter: Bool
-                let afterIdx = foundRange.location + foundRange.length
-                if afterIdx < text.count {
-                    let ch = text[text.index(text.startIndex, offsetBy: afterIdx)]
-                    isWordBoundaryAfter = !ch.isLetter && !ch.isNumber && ch != "_"
-                } else {
-                    isWordBoundaryAfter = true
-                }
-
-                if isWordBoundaryBefore, isWordBoundaryAfter {
-                    results.append(SearchMatch(blockID: blockID, itemID: itemID, range: foundRange))
-                }
-            } else {
+            if !wholeWord || isWholeWordMatch(range: foundRange, in: text) {
                 results.append(SearchMatch(blockID: blockID, itemID: itemID, range: foundRange))
             }
 
@@ -237,5 +215,34 @@ final class DocumentSearchState {
         }
 
         return results
+    }
+
+    /// Whether `foundRange` — a UTF-16 range from `NSString.range(of:)` — is bounded
+    /// by non-word characters on both sides.
+    ///
+    /// Converts the range with `Range(_:in:)` so neighbouring characters are read at
+    /// correct grapheme boundaries. Indexing the `String` directly with the raw UTF-16
+    /// `location` traps on emoji and other multi-unit characters, whose UTF-16 offset
+    /// exceeds the grapheme count.
+    private func isWholeWordMatch(range foundRange: NSRange, in text: String) -> Bool {
+        guard let swiftRange = Range(foundRange, in: text) else { return false }
+
+        let boundaryBefore: Bool
+        if swiftRange.lowerBound > text.startIndex {
+            let previous = text[text.index(before: swiftRange.lowerBound)]
+            boundaryBefore = !previous.isLetter && !previous.isNumber && previous != "_"
+        } else {
+            boundaryBefore = true
+        }
+
+        let boundaryAfter: Bool
+        if swiftRange.upperBound < text.endIndex {
+            let next = text[swiftRange.upperBound]
+            boundaryAfter = !next.isLetter && !next.isNumber && next != "_"
+        } else {
+            boundaryAfter = true
+        }
+
+        return boundaryBefore && boundaryAfter
     }
 }

--- a/Logue/Views/Editor/BlockEditor/Views/BlockEditorView+Reorder.swift
+++ b/Logue/Views/Editor/BlockEditor/Views/BlockEditorView+Reorder.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+// MARK: - Block Reordering
+
+extension BlockEditorView {
+    /// Moves the current multi-block selection one position up or down and syncs
+    /// the markdown binding.
+    ///
+    /// Falls back to the focused block when no multi-block selection is active, so
+    /// Cmd+Shift+Up/Down works while simply editing a block.
+    func moveSelectedBlocks(_ direction: BlockEditorDocument.MoveDirection) {
+        let selectedIDs: Set<BlockID>
+        if multiBlockSelection.isActive {
+            selectedIDs = multiBlockSelection.selectedBlockIDs
+        } else if let focused = focusedBlockID {
+            selectedIDs = [focused]
+        } else {
+            return
+        }
+
+        document.moveSelectedBlocks(selectedIDs, direction: direction)
+        syncMarkdownFromBlocks()
+    }
+}
+
+// MARK: - Markdown Sync
+
+extension BlockEditorView {
+    /// Serialises the block model back into the markdown binding.
+    ///
+    /// Records the result in `lastSyncedMarkdown` so the binding's `onChange`
+    /// handler can recognise our own output and skip re-parsing it.
+    func syncMarkdownFromBlocks() {
+        guard isLoaded else { return }
+        let newMarkdown = document.toMarkdown()
+        if newMarkdown != markdownText {
+            lastSyncedMarkdown = newMarkdown
+            markdownText = newMarkdown
+        }
+    }
+}

--- a/Logue/Views/Editor/BlockEditor/Views/BlockEditorView.swift
+++ b/Logue/Views/Editor/BlockEditor/Views/BlockEditorView.swift
@@ -26,14 +26,18 @@ struct BlockEditorView: View {
     @Binding var scrollToText: String?
 
     @Environment(\.undoManager) private var undoManager
-    @State private var document = BlockEditorDocument()
-    @State private var focusedBlockID: BlockID?
+    // Extension-visible: +Reorder
+    @State var document = BlockEditorDocument()
+    // Extension-visible: +Reorder
+    @State var focusedBlockID: BlockID?
     @State private var focusedItemID: UUID?
     @State private var pendingCursorOffset: Int?
-    @State private var isLoaded = false
+    // Extension-visible: +Reorder
+    @State var isLoaded = false
+    // Extension-visible: +Reorder
     /// The last markdown string we synced from blocks → binding.
     /// Used to prevent re-parsing our own output when the binding round-trips.
-    @State private var lastSyncedMarkdown: String?
+    @State var lastSyncedMarkdown: String?
     @State private var selectionToolbarPosition: CGPoint?
     @State private var activeTextView: MarkdownNSTextView?
     @State private var activeSelectionRange: NSRange?
@@ -53,7 +57,8 @@ struct BlockEditorView: View {
 
     // MARK: - Multi-Block Selection State
 
-    @State private var multiBlockSelection = MultiBlockSelectionState()
+    // Extension-visible: +Reorder
+    @State var multiBlockSelection = MultiBlockSelectionState()
     @State private var blockFrames: [BlockID: CGRect] = [:]
     @State private var dragMonitor: Any?
     @State private var mouseUpMonitor: Any?
@@ -187,7 +192,9 @@ struct BlockEditorView: View {
                                 focusedBlockID = firstID
                                 pendingCursorOffset = 0
                             }
-                        }
+                        },
+                        onMoveUp: { moveSelectedBlocks(.up) },
+                        onMoveDown: { moveSelectedBlocks(.down) }
                     )
                     .frame(width: 0, height: 0)
                     .onAppear {
@@ -207,9 +214,11 @@ struct BlockEditorView: View {
                     VStack {
                         HStack {
                             Spacer()
-                            DocumentSearchBar(searchState: searchState) {
-                                navigateToCurrentMatch(proxy: nil)
-                            }
+                            DocumentSearchBar(
+                                searchState: searchState, document: document,
+                                onNavigate: { navigateToCurrentMatch(proxy: nil) },
+                                onReplace: syncMarkdownFromBlocks
+                            )
                             .padding(.trailing, 16)
                             .padding(.top, 8)
                         }
@@ -379,15 +388,6 @@ struct BlockEditorView: View {
             try? await Task.sleep(for: AppConstants.Delays.markdownSyncDebounce)
             guard !Task.isCancelled else { return }
             syncMarkdownFromBlocks()
-        }
-    }
-
-    private func syncMarkdownFromBlocks() {
-        guard isLoaded else { return }
-        let newMarkdown = document.toMarkdown()
-        if newMarkdown != markdownText {
-            lastSyncedMarkdown = newMarkdown
-            markdownText = newMarkdown
         }
     }
 

--- a/Logue/Views/Editor/BlockEditor/Views/BlockRowView+Actions.swift
+++ b/Logue/Views/Editor/BlockEditor/Views/BlockRowView+Actions.swift
@@ -271,6 +271,10 @@ extension BlockRowView {
             return .table(id: newID, data: copy)
         case .divider:
             return .divider(id: newID)
+        case let .mermaid(_, source):
+            return .mermaid(id: newID, source: source)
+        case let .math(_, latex):
+            return .math(id: newID, latex: latex)
         }
     }
 

--- a/Logue/Views/Editor/BlockEditor/Views/BlockRowView.swift
+++ b/Logue/Views/Editor/BlockEditor/Views/BlockRowView.swift
@@ -107,6 +107,24 @@ struct BlockRowView: View {
 
         case .divider:
             dividerView()
+
+        case let .mermaid(id, source):
+            MermaidBlockView(
+                source: source,
+                isFocused: isFocused,
+                fontSize: fontSize,
+                onSourceChange: { document.replaceBlock(id: id, with: .mermaid(id: id, source: $0)) },
+                onFocusRequested: { focusedBlockID = id }
+            )
+
+        case let .math(id, latex):
+            MathBlockView(
+                latex: latex,
+                isFocused: isFocused,
+                fontSize: fontSize,
+                onLatexChange: { document.replaceBlock(id: id, with: .math(id: id, latex: $0)) },
+                onFocusRequested: { focusedBlockID = id }
+            )
         }
     }
 

--- a/Logue/Views/Editor/BlockEditor/Views/BlockTextView.swift
+++ b/Logue/Views/Editor/BlockEditor/Views/BlockTextView.swift
@@ -576,9 +576,37 @@ class MarkdownNSTextView: NSTextView {
         return super.readablePasteboardTypes
     }
 
+    // MARK: - Highlight Mark
+
+    /// Wraps or unwraps the selection in `==` delimiters, delegating the string
+    /// transform to `HighlightMark` so the editor and the serializer agree on syntax.
+    private func toggleHighlight() {
+        let range = selectedRange()
+        guard range.length > 0 else { return }
+
+        let updated = HighlightMark.toggled(in: string, range: range)
+        guard updated != string else { return }
+
+        let fullRange = NSRange(location: 0, length: (string as NSString).length)
+        guard shouldChangeText(in: fullRange, replacementString: updated) else { return }
+        replaceCharacters(in: fullRange, with: updated)
+        didChangeText()
+    }
+
     // MARK: - Keyboard Shortcuts for Formatting
 
     override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        // Cmd+Shift+M toggles the `==highlight==` mark. Checked before the
+        // shift-excluding guard below, which owns the unshifted Cmd shortcuts.
+        if markdownStyleEnabled,
+           event.modifierFlags.contains(.command),
+           event.modifierFlags.contains(.shift),
+           event.charactersIgnoringModifiers?.lowercased() == "m"
+        {
+            toggleHighlight()
+            return true
+        }
+
         guard markdownStyleEnabled,
               event.modifierFlags.contains(.command),
               !event.modifierFlags.contains(.shift)
@@ -602,6 +630,16 @@ class MarkdownNSTextView: NSTextView {
     }
 
     override func keyDown(with event: NSEvent) {
+        let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        if markdownStyleEnabled,
+           flags.contains(.command),
+           flags.contains(.shift),
+           event.charactersIgnoringModifiers?.lowercased() == "m"
+        {
+            toggleHighlight()
+            return
+        }
+
         if markdownStyleEnabled,
            event.modifierFlags.intersection(.deviceIndependentFlagsMask).contains(.command),
            !event.modifierFlags.intersection(.deviceIndependentFlagsMask).contains(.shift)
@@ -956,6 +994,36 @@ final class BlockNSTextView: MarkdownNSTextView {
         // Trim leading/trailing whitespace from entire string
         result = result.trimmingCharacters(in: .whitespacesAndNewlines)
         return result
+    }
+
+    // MARK: - Plain Paste
+
+    /// Cmd+Shift+V — inserts the clipboard as literal text.
+    ///
+    /// Unlike `paste(_:)`, this never splits the clipboard into new blocks and never
+    /// interprets markdown: newlines collapse to spaces so the content lands inside
+    /// the current block exactly as typed.
+    override func pasteAsPlainText(_ sender: Any?) {
+        guard markdownStyleEnabled,
+              let pasteString = NSPasteboard.general.string(forType: .string)
+        else {
+            super.pasteAsPlainText(sender)
+            return
+        }
+
+        let flattened = Self.flattenForPlainPaste(pasteString)
+        guard !flattened.isEmpty else { return }
+
+        let range = selectedRange()
+        guard shouldChangeText(in: range, replacementString: flattened) else { return }
+        insertText(flattened, replacementRange: range)
+    }
+
+    /// Collapses all whitespace runs (including newlines) into single spaces.
+    static func flattenForPlainPaste(_ raw: String) -> String {
+        let sanitized = sanitizePastedText(raw)
+        let pieces = sanitized.split(whereSeparator: { $0.isWhitespace || $0.isNewline })
+        return pieces.joined(separator: " ")
     }
 
     // MARK: - Multi-Block Paste

--- a/Logue/Views/Editor/BlockEditor/Views/DiagramMathBlockView.swift
+++ b/Logue/Views/Editor/BlockEditor/Views/DiagramMathBlockView.swift
@@ -1,0 +1,233 @@
+import Foundation
+import OSLog
+import SwiftUI
+import WebKit
+
+// MARK: - Mermaid Block
+
+/// A Mermaid diagram block: rendered preview when unfocused, editable source when focused.
+///
+/// The source is the durable representation — it round-trips as a ```` ```mermaid ````
+/// fence — so the preview is always derived and never the source of truth.
+struct MermaidBlockView: View {
+    let source: String
+    let isFocused: Bool
+    let fontSize: CGFloat
+    let onSourceChange: (String) -> Void
+    let onFocusRequested: () -> Void
+
+    @State private var svg: String?
+    @State private var renderError: String?
+    @State private var renderTask: Task<Void, Never>?
+
+    private static let logger = Logger(subsystem: "com.bitwize.logue", category: "MermaidBlock")
+
+    var body: some View {
+        Group {
+            if isFocused {
+                BlockSourceEditor(
+                    text: source,
+                    fontSize: fontSize,
+                    placeholder: "flowchart LR\n  A --> B",
+                    onTextChange: onSourceChange
+                )
+            } else {
+                preview
+            }
+        }
+        .task(id: source) { await render() }
+        .onDisappear { renderTask?.cancel() }
+    }
+
+    @ViewBuilder
+    private var preview: some View {
+        if let svg {
+            SVGWebView(svg: svg)
+                .frame(minHeight: 80)
+                .contentShape(Rectangle())
+                .onTapGesture(perform: onFocusRequested)
+        } else if let renderError {
+            BlockSourceFallback(
+                source: source,
+                fontSize: fontSize,
+                message: renderError,
+                onTap: onFocusRequested
+            )
+        } else {
+            ProgressView()
+                .controlSize(.small)
+                .frame(maxWidth: .infinity, minHeight: 80)
+                .contentShape(Rectangle())
+                .onTapGesture(perform: onFocusRequested)
+        }
+    }
+
+    private func render() async {
+        let code = source.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !code.isEmpty else {
+            svg = nil
+            renderError = "Empty diagram"
+            return
+        }
+
+        do {
+            let rendered = try await MermaidRenderer.shared.renderSVG(code: code)
+            guard !Task.isCancelled else { return }
+            svg = rendered
+            renderError = nil
+        } catch {
+            guard !Task.isCancelled else { return }
+            Self.logger.error("Mermaid render failed: \(error.localizedDescription, privacy: .public)")
+            svg = nil
+            renderError = "Diagram could not be rendered"
+        }
+    }
+}
+
+// MARK: - Math Block
+
+/// A display-math block. The LaTeX source is durable between `$$` fences.
+struct MathBlockView: View {
+    let latex: String
+    let isFocused: Bool
+    let fontSize: CGFloat
+    let onLatexChange: (String) -> Void
+    let onFocusRequested: () -> Void
+
+    var body: some View {
+        if isFocused {
+            BlockSourceEditor(
+                text: latex,
+                fontSize: fontSize,
+                placeholder: "E = mc^2",
+                onTextChange: onLatexChange
+            )
+        } else if latex.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            Text("Empty equation")
+                .font(.system(size: fontSize))
+                .foregroundStyle(.tertiary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .contentShape(Rectangle())
+                .onTapGesture(perform: onFocusRequested)
+        } else {
+            InlineLaTeXView(messageContent: "$$\n\(latex)\n$$")
+                .frame(maxWidth: .infinity, alignment: .center)
+                .contentShape(Rectangle())
+                .onTapGesture(perform: onFocusRequested)
+        }
+    }
+}
+
+// MARK: - Shared Source Editor
+
+/// Monospaced source editor shared by the diagram and math blocks.
+///
+/// These blocks are source surfaces rather than prose, so they use a plain
+/// `TextEditor` instead of the rich `BlockTextView` — no markdown styling,
+/// suggestion overlay, or list continuation applies to diagram or LaTeX source.
+private struct BlockSourceEditor: View {
+    let text: String
+    let fontSize: CGFloat
+    let placeholder: String
+    let onTextChange: (String) -> Void
+
+    @State private var draft: String = ""
+
+    var body: some View {
+        ZStack(alignment: .topLeading) {
+            if draft.isEmpty {
+                Text(placeholder)
+                    .font(.system(size: fontSize * 0.882, design: .monospaced))
+                    .foregroundStyle(.tertiary)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 10)
+                    .allowsHitTesting(false)
+            }
+
+            TextEditor(text: $draft)
+                .font(.system(size: fontSize * 0.882, design: .monospaced))
+                .scrollContentBackground(.hidden)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 6)
+                .frame(minHeight: 80)
+        }
+        .background(AppThemeConstants.codeBlockBackground)
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .strokeBorder(AppThemeConstants.codeBlockBorder, lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .onAppear { draft = text }
+        .onChange(of: draft) { _, newValue in onTextChange(newValue) }
+        .onChange(of: text) { _, newValue in
+            // Adopt external edits (undo, AI rewrite) without clobbering typing.
+            if newValue != draft {
+                draft = newValue
+            }
+        }
+    }
+}
+
+// MARK: - Source Fallback
+
+/// Shown when a diagram cannot be rendered — the source stays visible and editable
+/// rather than the block appearing empty.
+private struct BlockSourceFallback: View {
+    let source: String
+    let fontSize: CGFloat
+    let message: String
+    let onTap: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Label(message, systemImage: "exclamationmark.triangle")
+                .font(.system(size: fontSize * 0.8))
+                .foregroundStyle(.secondary)
+            Text(source)
+                .font(.system(size: fontSize * 0.882, design: .monospaced))
+                .foregroundStyle(.secondary)
+                .textSelection(.enabled)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(12)
+        .background(AppThemeConstants.codeBlockBackground)
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .contentShape(Rectangle())
+        .onTapGesture(perform: onTap)
+    }
+}
+
+// MARK: - SVG Rendering
+
+/// Renders an SVG string in a local `WKWebView`.
+///
+/// Loaded with a `nil` base URL and JavaScript disabled so the diagram markup
+/// cannot reach the network or execute script.
+private struct SVGWebView: NSViewRepresentable {
+    let svg: String
+
+    func makeNSView(context _: Context) -> WKWebView {
+        let configuration = WKWebViewConfiguration()
+        configuration.defaultWebpagePreferences.allowsContentJavaScript = false
+
+        let webView = WKWebView(frame: .zero, configuration: configuration)
+        webView.setValue(false, forKey: "drawsBackground")
+        return webView
+    }
+
+    func updateNSView(_ webView: WKWebView, context _: Context) {
+        webView.loadHTMLString(Self.wrap(svg: svg), baseURL: nil)
+    }
+
+    private static func wrap(svg: String) -> String {
+        """
+        <!DOCTYPE html>
+        <html><head><meta charset="utf-8">
+        <style>
+          html, body { margin: 0; padding: 0; background: transparent; }
+          svg { max-width: 100%; height: auto; display: block; margin: 0 auto; }
+        </style>
+        </head><body>\(svg)</body></html>
+        """
+    }
+}

--- a/Logue/Views/Editor/BlockEditor/Views/DocumentSearchBar.swift
+++ b/Logue/Views/Editor/BlockEditor/Views/DocumentSearchBar.swift
@@ -3,11 +3,77 @@ import SwiftUI
 /// Compact find bar overlay for in-document search, matching Apple's Cmd+F style.
 struct DocumentSearchBar: View {
     @Bindable var searchState: DocumentSearchState
+    /// The document the replace actions mutate. Optional so a find-only host can
+    /// present the bar without a replace surface.
+    var document: BlockEditorDocument?
     var onNavigate: () -> Void
+    var onReplace: (() -> Void)?
 
     @FocusState private var isFieldFocused: Bool
 
     var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            findRow
+            if searchState.isReplaceVisible, document != nil {
+                replaceRow
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
+        .shadow(color: .black.opacity(0.15), radius: 8, y: 2)
+        .onAppear { isFieldFocused = true }
+        .onKeyPress(.escape) {
+            searchState.close()
+            return .handled
+        }
+    }
+
+    // MARK: - Replace Row
+
+    private var replaceRow: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "arrow.2.squarepath")
+                .foregroundStyle(.secondary)
+                .font(.caption)
+
+            TextField("Replace with", text: $searchState.replacement)
+                .textFieldStyle(.plain)
+                .font(.subheadline)
+                .frame(minWidth: 120, maxWidth: 200)
+                .onSubmit(replaceCurrent)
+
+            Divider()
+                .frame(height: 16)
+
+            Button("Replace", action: replaceCurrent)
+                .buttonStyle(.plain)
+                .font(.caption.weight(.medium))
+                .disabled(searchState.matches.isEmpty)
+
+            Button("All", action: replaceAll)
+                .buttonStyle(.plain)
+                .font(.caption.weight(.medium))
+                .disabled(searchState.matches.isEmpty)
+                .help("Replace all matches")
+        }
+    }
+
+    private func replaceCurrent() {
+        guard let document else { return }
+        searchState.replaceCurrent(with: searchState.replacement, in: document)
+        onReplace?()
+    }
+
+    private func replaceAll() {
+        guard let document else { return }
+        searchState.replaceAll(with: searchState.replacement, in: document)
+        onReplace?()
+    }
+
+    // MARK: - Find Row
+
+    private var findRow: some View {
         HStack(spacing: 8) {
             Image(systemName: "magnifyingglass")
                 .foregroundStyle(.secondary)
@@ -83,6 +149,19 @@ struct DocumentSearchBar: View {
             .disabled(searchState.matches.isEmpty)
             .accessibilityLabel("Next match")
 
+            if document != nil {
+                Button {
+                    searchState.isReplaceVisible.toggle()
+                } label: {
+                    Image(systemName: "arrow.2.squarepath")
+                        .font(.caption.weight(.medium))
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(searchState.isReplaceVisible ? AppThemeConstants.accent : .secondary)
+                .help("Show Replace")
+                .accessibilityLabel("Show Replace")
+            }
+
             Button {
                 searchState.close()
             } label: {
@@ -92,15 +171,6 @@ struct DocumentSearchBar: View {
             }
             .buttonStyle(.plain)
             .accessibilityLabel("Close search")
-        }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 8)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
-        .shadow(color: .black.opacity(0.15), radius: 8, y: 2)
-        .onAppear { isFieldFocused = true }
-        .onKeyPress(.escape) {
-            searchState.close()
-            return .handled
         }
     }
 }

--- a/Logue/Views/Editor/BlockEditor/Views/MultiBlockKeyHandler.swift
+++ b/Logue/Views/Editor/BlockEditor/Views/MultiBlockKeyHandler.swift
@@ -12,6 +12,10 @@ struct MultiBlockKeyHandler: NSViewRepresentable {
     var onEscape: () -> Void
     /// Called when user types a character — clears selection and starts typing.
     var onTyping: ((_ character: String) -> Void)?
+    /// Cmd+Shift+Up — move the selected blocks up one position.
+    var onMoveUp: (() -> Void)?
+    /// Cmd+Shift+Down — move the selected blocks down one position.
+    var onMoveDown: (() -> Void)?
 
     func makeNSView(context: Context) -> KeyHandlerNSView {
         let view = KeyHandlerNSView()
@@ -30,7 +34,9 @@ struct MultiBlockKeyHandler: NSViewRepresentable {
             onDelete: onDelete,
             onSelectAll: onSelectAll,
             onEscape: onEscape,
-            onTyping: onTyping
+            onTyping: onTyping,
+            onMoveUp: onMoveUp,
+            onMoveDown: onMoveDown
         )
     }
 
@@ -41,6 +47,8 @@ struct MultiBlockKeyHandler: NSViewRepresentable {
         var onSelectAll: () -> Void
         var onEscape: () -> Void
         var onTyping: ((_ character: String) -> Void)?
+        var onMoveUp: (() -> Void)?
+        var onMoveDown: (() -> Void)?
 
         init(
             onCopy: @escaping () -> Void,
@@ -48,7 +56,9 @@ struct MultiBlockKeyHandler: NSViewRepresentable {
             onDelete: @escaping () -> Void,
             onSelectAll: @escaping () -> Void,
             onEscape: @escaping () -> Void,
-            onTyping: ((_ character: String) -> Void)?
+            onTyping: ((_ character: String) -> Void)?,
+            onMoveUp: (() -> Void)?,
+            onMoveDown: (() -> Void)?
         ) {
             self.onCopy = onCopy
             self.onCut = onCut
@@ -56,6 +66,8 @@ struct MultiBlockKeyHandler: NSViewRepresentable {
             self.onSelectAll = onSelectAll
             self.onEscape = onEscape
             self.onTyping = onTyping
+            self.onMoveUp = onMoveUp
+            self.onMoveDown = onMoveDown
         }
     }
 }
@@ -63,6 +75,9 @@ struct MultiBlockKeyHandler: NSViewRepresentable {
 /// NSView that captures keyboard events during multi-block selection.
 final class KeyHandlerNSView: NSView {
     var coordinator: MultiBlockKeyHandler.Coordinator?
+
+    private static let upArrowKeyCode: UInt16 = 126
+    private static let downArrowKeyCode: UInt16 = 125
 
     override var acceptsFirstResponder: Bool {
         true
@@ -90,6 +105,20 @@ final class KeyHandlerNSView: NSView {
 
     override func keyDown(with event: NSEvent) {
         let keyCode = event.keyCode
+        let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+
+        // Cmd+Shift+Up/Down (126/125) — reorder the selection. Checked before the
+        // fall-through below, which clears the selection on any other arrow key.
+        if flags.contains(.command), flags.contains(.shift) {
+            if keyCode == Self.upArrowKeyCode {
+                coordinator?.onMoveUp?()
+                return
+            }
+            if keyCode == Self.downArrowKeyCode {
+                coordinator?.onMoveDown?()
+                return
+            }
+        }
 
         // Escape (53)
         if keyCode == 53 {

--- a/Logue/Views/Editor/DocumentWorkspaceView+Toolbar.swift
+++ b/Logue/Views/Editor/DocumentWorkspaceView+Toolbar.swift
@@ -65,6 +65,13 @@ extension DocumentWorkspaceView {
             NSApp.sendAction(Selector(("redo:")), to: nil, from: nil)
         }
         Toggle("Word Count", isOn: $showWordCount)
+        Button {
+            var updated = doc
+            updated.widthMode = doc.widthMode.toggled
+            store.updateDocument(updated)
+        } label: {
+            Label(doc.widthMode.toggled.label, systemImage: doc.widthMode.toggled.symbolName)
+        }
         Divider()
         Button {
             titleGenerationTask?.cancel()

--- a/Logue/Views/Editor/DocumentWorkspaceView.swift
+++ b/Logue/Views/Editor/DocumentWorkspaceView.swift
@@ -37,6 +37,9 @@ struct DocumentWorkspaceView: View {
     @State var showWordCount = true
     @State private var chatMessages: [ChatMessage] = []
     @AppStorage("editorFontSize") private var fontSize: Double = 15
+    /// Zoom multiplier applied on top of `fontSize`. Driven by the View menu (Cmd +/-/0).
+    @AppStorage(AppConstants.UserDefaultsKeys.editorZoomScale) private var zoomScale: Double =
+        AppConstants.Editor.defaultZoom
     @State private var aiChatPendingMessage: String?
     // Extension-visible: +Toolbar
     @State var isSidebarCollapsed = false
@@ -78,14 +81,18 @@ struct DocumentWorkspaceView: View {
                     BlockEditorView(
                         markdownText: documentBodyBinding(doc: doc),
                         suggestions: suggestions,
-                        fontSize: fontSize,
+                        fontSize: zoomedFontSize,
                         onCursorPositionChange: { cursorOffset = $0 },
                         onSuggestionAccepted: { acceptFromEditor(suggestion: $0) },
                         onSuggestionDismissed: { dismiss(suggestion: $0) },
                         scrollToSuggestion: $scrollToSuggestion,
                         scrollToText: $scrollToText
                     )
-                    .frame(maxWidth: focusState.isActive ? focusState.columnWidth : .infinity)
+                    .frame(
+                        maxWidth: focusState.isActive
+                            ? focusState.columnWidth
+                            : doc.widthMode.maxContentWidth
+                    )
                     .frame(maxWidth: .infinity)
 
                     if !focusState.isActive {
@@ -152,6 +159,13 @@ struct DocumentWorkspaceView: View {
                     .environment(templateStore)
             }
         }
+    }
+
+    /// Base font size scaled by the current View-menu zoom, clamped by `EditorZoom`.
+    private var zoomedFontSize: Double {
+        var zoom = EditorZoom()
+        zoom.scale = zoomScale
+        return Double(zoom.scaled(CGFloat(fontSize)))
     }
 
     // MARK: - Right Panel Router

--- a/Logue/Views/Editor/EditorLayoutMode.swift
+++ b/Logue/Views/Editor/EditorLayoutMode.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Which panes the main window shows. Driven by Cmd+1 / Cmd+2 / Cmd+3.
+enum EditorLayoutMode: String, CaseIterable, Codable, Sendable {
+    case editorOnly
+    case editorAndList
+    case allPanels
+
+    init?(shortcutNumber: Int) {
+        switch shortcutNumber {
+        case 1: self = .editorOnly
+        case 2: self = .editorAndList
+        case 3: self = .allPanels
+        default: return nil
+        }
+    }
+
+    var showsList: Bool {
+        self != .editorOnly
+    }
+
+    var showsInspector: Bool {
+        self == .allPanels
+    }
+
+    var label: String {
+        switch self {
+        case .editorOnly: "Editor Only"
+        case .editorAndList: "Editor and List"
+        case .allPanels: "All Panels"
+        }
+    }
+}

--- a/Logue/Views/Editor/EditorZoom.swift
+++ b/Logue/Views/Editor/EditorZoom.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Editor text zoom, clamped to the bounds in `AppConstants.Editor`.
+///
+/// A value type so a view can hold it in `@State` and it stays trivially testable.
+/// The scale multiplies font sizes rather than transforming the view, so text stays
+/// crisp and line wrapping recalculates at the new size.
+struct EditorZoom: Equatable {
+    private var storedScale: CGFloat = AppConstants.Editor.defaultZoom
+
+    /// Current zoom multiplier. Assignments are clamped to the allowed range.
+    var scale: CGFloat {
+        get { storedScale }
+        set { storedScale = Self.clamp(newValue) }
+    }
+
+    var canReset: Bool {
+        abs(storedScale - AppConstants.Editor.defaultZoom) > 0.0001
+    }
+
+    var percentLabel: String {
+        "\(Int((storedScale * 100).rounded()))%"
+    }
+
+    mutating func zoomIn() {
+        scale = storedScale + AppConstants.Editor.zoomStep
+    }
+
+    mutating func zoomOut() {
+        scale = storedScale - AppConstants.Editor.zoomStep
+    }
+
+    mutating func reset() {
+        scale = AppConstants.Editor.defaultZoom
+    }
+
+    /// Applies the zoom to a base font size.
+    func scaled(_ size: CGFloat) -> CGFloat {
+        size * storedScale
+    }
+
+    private static func clamp(_ value: CGFloat) -> CGFloat {
+        min(max(value, AppConstants.Editor.minZoom), AppConstants.Editor.maxZoom)
+    }
+}

--- a/Logue/Views/Editor/RichTextEditorHelpers.swift
+++ b/Logue/Views/Editor/RichTextEditorHelpers.swift
@@ -19,9 +19,12 @@ enum BlockType: String, CaseIterable {
     case heading1, heading2, heading3
     case bulletList, numberedList, todoList
     case quote, divider, codeBlock, table
+    case mermaid, math
 
     var displayName: String {
         switch self {
+        case .mermaid: "Diagram"
+        case .math: "Equation"
         case .text: "Text"
         case .heading1: "Heading 1"
         case .heading2: "Heading 2"
@@ -38,6 +41,8 @@ enum BlockType: String, CaseIterable {
 
     var iconName: String {
         switch self {
+        case .mermaid: "flowchart"
+        case .math: "function"
         case .text: "text.alignleft"
         case .heading1: "textformat.size.larger"
         case .heading2: "textformat.size"
@@ -54,6 +59,8 @@ enum BlockType: String, CaseIterable {
 
     var description: String {
         switch self {
+        case .mermaid: "Mermaid diagram, stored as markdown"
+        case .math: "LaTeX equation block"
         case .text: "Plain text paragraph"
         case .heading1: "Large section heading"
         case .heading2: "Medium section heading"
@@ -78,9 +85,47 @@ enum BlockType: String, CaseIterable {
         switch self {
         case .text, .heading1, .heading2, .heading3: .text
         case .bulletList, .numberedList, .todoList: .lists
-        case .quote, .divider, .codeBlock, .table: .advanced
+        case .quote, .divider, .codeBlock, .table, .mermaid, .math: .advanced
         }
     }
+
+    /// Builds the `Block` this menu entry inserts, carrying any existing text into
+    /// the new block's source so converting a paragraph does not discard it.
+    func makeBlock(id: BlockID, text: String) -> Block {
+        switch self {
+        case .mermaid:
+            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            // Start from a usable template rather than an empty diagram.
+            return trimmed.isEmpty ? .mermaid(id: id, source: Self.mermaidTemplate)
+                : .mermaid(id: id, source: trimmed)
+        case .math:
+            return .math(id: id, latex: text.trimmingCharacters(in: .whitespacesAndNewlines))
+        case .heading1:
+            return .heading(id: id, level: 1, text: text)
+        case .heading2:
+            return .heading(id: id, level: 2, text: text)
+        case .heading3:
+            return .heading(id: id, level: 3, text: text)
+        case .bulletList:
+            return .bulletList(id: id, items: [BlockListItem(text: text)])
+        case .numberedList:
+            return .numberedList(id: id, items: [BlockListItem(text: text)])
+        case .todoList:
+            return .checkboxList(id: id, items: [CheckboxItem(text: text)])
+        case .quote:
+            return .blockQuote(id: id, text: text)
+        case .codeBlock:
+            return .codeBlock(id: id, language: "", code: text)
+        case .divider:
+            return .divider(id: id)
+        case .table:
+            return .emptyTable()
+        case .text:
+            return .paragraph(id: id, text: text)
+        }
+    }
+
+    private static let mermaidTemplate = "flowchart LR\n  A --> B"
 
     /// Block types grouped by category, preserving order.
     static var groupedByCategory: [(category: Category, types: [BlockType])] {
@@ -103,6 +148,8 @@ enum BlockType: String, CaseIterable {
         case .divider: "---"
         case .codeBlock: "```"
         case .table: ""
+        case .mermaid: "```mermaid"
+        case .math: "$$"
         }
     }
 
@@ -113,19 +160,7 @@ enum BlockType: String, CaseIterable {
 
     /// Creates a new empty block of this type.
     func makeEmptyBlock() -> Block {
-        switch self {
-        case .text: .emptyParagraph()
-        case .heading1: .emptyHeading(level: 1)
-        case .heading2: .emptyHeading(level: 2)
-        case .heading3: .emptyHeading(level: 3)
-        case .bulletList: .emptyBulletList()
-        case .numberedList: .emptyNumberedList()
-        case .todoList: .emptyCheckboxList()
-        case .quote: .emptyBlockQuote()
-        case .divider: .newDivider()
-        case .codeBlock: .emptyCodeBlock()
-        case .table: .emptyTable()
-        }
+        makeBlock(id: UUID(), text: "")
     }
 }
 

--- a/Logue/Views/Help/BugReportView.swift
+++ b/Logue/Views/Help/BugReportView.swift
@@ -327,9 +327,7 @@ enum BugReportService {
             "",
             "---",
             "**Diagnostics**",
-            "- App: \(BugReportInfo.appVersion) (\(BugReportInfo.buildNumber))",
-            "- macOS: \(BugReportInfo.macOSVersion)",
-            "- Device: \(BugReportInfo.deviceModel)",
+            DiagnosticsReport.generate(),
         ]
 
         if !screenshots.isEmpty {

--- a/LogueTests/BlockMoveTests.swift
+++ b/LogueTests/BlockMoveTests.swift
@@ -1,0 +1,109 @@
+import Foundation
+@testable import Logue
+import Testing
+
+@Suite("BlockMove")
+@MainActor
+struct BlockMoveTests {
+    private func document(count: Int) -> BlockEditorDocument {
+        let doc = BlockEditorDocument()
+        doc.blocks = (0 ..< count).map { .paragraph(id: UUID(), text: "block \($0)") }
+        return doc
+    }
+
+    private func texts(_ doc: BlockEditorDocument) -> [String] {
+        doc.blocks.compactMap(\.textContent)
+    }
+
+    @Test("Moving a single selected block up swaps it with the one above")
+    func moveSingleBlockUp() {
+        let doc = document(count: 3)
+        let selection = MultiBlockSelectionState()
+        selection.selectedBlockIDs = [doc.blocks[1].id]
+
+        doc.moveSelectedBlocks(selection.selectedBlockIDs, direction: .up)
+
+        #expect(texts(doc) == ["block 1", "block 0", "block 2"])
+    }
+
+    @Test("Moving a single selected block down swaps it with the one below")
+    func moveSingleBlockDown() {
+        let doc = document(count: 3)
+        let selection = MultiBlockSelectionState()
+        selection.selectedBlockIDs = [doc.blocks[1].id]
+
+        doc.moveSelectedBlocks(selection.selectedBlockIDs, direction: .down)
+
+        #expect(texts(doc) == ["block 0", "block 2", "block 1"])
+    }
+
+    @Test("A contiguous multi-block selection moves as one unit and keeps its order")
+    func moveContiguousRangeDown() {
+        let doc = document(count: 4)
+        let ids: Set<BlockID> = [doc.blocks[0].id, doc.blocks[1].id]
+
+        doc.moveSelectedBlocks(ids, direction: .down)
+
+        #expect(texts(doc) == ["block 2", "block 0", "block 1", "block 3"])
+    }
+
+    @Test("A contiguous multi-block selection moves up as one unit")
+    func moveContiguousRangeUp() {
+        let doc = document(count: 4)
+        let ids: Set<BlockID> = [doc.blocks[2].id, doc.blocks[3].id]
+
+        doc.moveSelectedBlocks(ids, direction: .up)
+
+        #expect(texts(doc) == ["block 0", "block 2", "block 3", "block 1"])
+    }
+
+    @Test("Moving the top block up leaves the document unchanged")
+    func moveTopBlockUpIsNoOp() {
+        let doc = document(count: 3)
+        doc.moveSelectedBlocks([doc.blocks[0].id], direction: .up)
+        #expect(texts(doc) == ["block 0", "block 1", "block 2"])
+    }
+
+    @Test("Moving the bottom block down leaves the document unchanged")
+    func moveBottomBlockDownIsNoOp() {
+        let doc = document(count: 3)
+        doc.moveSelectedBlocks([doc.blocks[2].id], direction: .down)
+        #expect(texts(doc) == ["block 0", "block 1", "block 2"])
+    }
+
+    @Test("An empty selection leaves the document unchanged")
+    func emptySelectionIsNoOp() {
+        let doc = document(count: 3)
+        doc.moveSelectedBlocks([], direction: .up)
+        #expect(texts(doc) == ["block 0", "block 1", "block 2"])
+    }
+
+    @Test("A non-contiguous selection is rejected rather than reordered arbitrarily")
+    func nonContiguousSelectionIsRejected() {
+        let doc = document(count: 4)
+        let ids: Set<BlockID> = [doc.blocks[0].id, doc.blocks[2].id]
+
+        doc.moveSelectedBlocks(ids, direction: .down)
+
+        #expect(texts(doc) == ["block 0", "block 1", "block 2", "block 3"])
+    }
+
+    @Test("Selecting every block and moving is a no-op in both directions")
+    func fullSelectionIsNoOp() {
+        let doc = document(count: 3)
+        let all = Set(doc.blocks.map(\.id))
+
+        doc.moveSelectedBlocks(all, direction: .up)
+        #expect(texts(doc) == ["block 0", "block 1", "block 2"])
+
+        doc.moveSelectedBlocks(all, direction: .down)
+        #expect(texts(doc) == ["block 0", "block 1", "block 2"])
+    }
+
+    @Test("Unknown block IDs are ignored")
+    func unknownIDsAreIgnored() {
+        let doc = document(count: 3)
+        doc.moveSelectedBlocks([UUID()], direction: .down)
+        #expect(texts(doc) == ["block 0", "block 1", "block 2"])
+    }
+}

--- a/LogueTests/BlockTypeSlashMenuTests.swift
+++ b/LogueTests/BlockTypeSlashMenuTests.swift
@@ -1,0 +1,74 @@
+import Foundation
+@testable import Logue
+import Testing
+
+/// The slash menu is driven entirely off `BlockType.allCases`, so a new block type
+/// is only reachable once it appears there with complete metadata.
+@Suite("BlockTypeSlashMenu")
+struct BlockTypeSlashMenuTests {
+    @Test("Diagram and equation are offered in the slash menu")
+    func newTypesAreListed() {
+        #expect(BlockType.allCases.contains(.mermaid))
+        #expect(BlockType.allCases.contains(.math))
+    }
+
+    @Test("Every block type has non-empty menu metadata")
+    func allTypesHaveMetadata() {
+        for type in BlockType.allCases {
+            #expect(!type.displayName.isEmpty, "\(type) has no display name")
+            #expect(!type.iconName.isEmpty, "\(type) has no icon")
+            #expect(!type.description.isEmpty, "\(type) has no description")
+        }
+    }
+
+    @Test("Diagram and equation are grouped under Advanced")
+    func newTypesAreAdvanced() {
+        #expect(BlockType.mermaid.category == .advanced)
+        #expect(BlockType.math.category == .advanced)
+    }
+
+    @Test("Every block type appears in exactly one category group")
+    func groupingCoversEveryType() {
+        let grouped = BlockType.groupedByCategory.flatMap(\.types)
+        #expect(grouped.count == BlockType.allCases.count)
+        #expect(Set(grouped) == Set(BlockType.allCases))
+    }
+
+    @Test("Filtering by name finds the diagram block")
+    func filteringFindsDiagram() {
+        let matches = BlockType.allCases.filter {
+            $0.displayName.localizedCaseInsensitiveContains("diagram")
+        }
+        #expect(matches.contains(.mermaid))
+    }
+
+    @Test("Each new type maps to its matching block case")
+    func typesMapToBlocks() {
+        guard case .mermaid = BlockType.mermaid.makeBlock(id: UUID(), text: "") else {
+            Issue.record("mermaid BlockType did not produce a mermaid block")
+            return
+        }
+        guard case .math = BlockType.math.makeBlock(id: UUID(), text: "") else {
+            Issue.record("math BlockType did not produce a math block")
+            return
+        }
+    }
+
+    @Test("Existing text carries into the new block's source")
+    func existingTextIsCarriedOver() {
+        guard case let .math(_, latex) = BlockType.math.makeBlock(id: UUID(), text: "x = 1") else {
+            Issue.record("Expected a math block")
+            return
+        }
+        #expect(latex == "x = 1")
+    }
+
+    @Test("A new diagram block starts from a usable template, not empty")
+    func diagramStartsFromTemplate() {
+        guard case let .mermaid(_, source) = BlockType.mermaid.makeBlock(id: UUID(), text: "") else {
+            Issue.record("Expected a mermaid block")
+            return
+        }
+        #expect(source.contains("-->"))
+    }
+}

--- a/LogueTests/DeepLinkRoutingTests.swift
+++ b/LogueTests/DeepLinkRoutingTests.swift
@@ -1,0 +1,56 @@
+import Foundation
+@testable import Logue
+import Testing
+
+@Suite("DeepLinkRouting")
+struct DeepLinkRoutingTests {
+    private let identifier = UUID(uuidString: "0A47D3B4-3B4E-4A2E-9C1D-2F8A1B6C5D40") ?? UUID()
+
+    @Test("A link carries its target identifier in the notification payload")
+    func payloadCarriesIdentifier() {
+        let payload = DeepLink.document(id: identifier).notificationPayload
+        #expect(payload[DeepLink.UserInfoKey.identifier] as? UUID == identifier)
+    }
+
+    @Test("Each target maps to a distinct notification name")
+    func distinctNotificationNames() {
+        let names = Set([
+            DeepLink.document(id: identifier).notificationName,
+            DeepLink.meeting(id: identifier).notificationName,
+            DeepLink.space(id: identifier).notificationName,
+        ])
+        #expect(names.count == 3)
+    }
+
+    @Test("Routing a valid URL posts the matching notification with the identifier")
+    func validURLPostsNotification() async throws {
+        let url = try #require(URL(string: "logue://document/0A47D3B4-3B4E-4A2E-9C1D-2F8A1B6C5D40"))
+
+        var receivedIdentifier: UUID?
+        let token = NotificationCenter.default.addObserver(
+            forName: DeepLink.document(id: identifier).notificationName,
+            object: nil,
+            queue: nil
+        ) { notification in
+            receivedIdentifier = notification.userInfo?[DeepLink.UserInfoKey.identifier] as? UUID
+        }
+        defer { NotificationCenter.default.removeObserver(token) }
+
+        let handled = DeepLinkRouter.route(url: url)
+
+        #expect(handled)
+        #expect(receivedIdentifier == identifier)
+    }
+
+    @Test("Routing an unrecognised URL is reported as unhandled")
+    func invalidURLIsUnhandled() throws {
+        let url = try #require(URL(string: "logue://document/not-a-uuid"))
+        #expect(DeepLinkRouter.route(url: url) == false)
+    }
+
+    @Test("Routing a foreign scheme is reported as unhandled")
+    func foreignSchemeIsUnhandled() throws {
+        let url = try #require(URL(string: "https://example.com/document/x"))
+        #expect(DeepLinkRouter.route(url: url) == false)
+    }
+}

--- a/LogueTests/DeepLinkTests.swift
+++ b/LogueTests/DeepLinkTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+@testable import Logue
+import Testing
+
+/// Deep links arrive from outside the app, so parsing is an untrusted-input
+/// boundary. Anything unrecognised must resolve to nil rather than a wrong target.
+@Suite("DeepLink")
+struct DeepLinkTests {
+    private let docID = UUID(uuidString: "0A47D3B4-3B4E-4A2E-9C1D-2F8A1B6C5D40") ?? UUID()
+
+    @Test("A document link resolves to the document target")
+    func parsesDocumentLink() throws {
+        let url = try #require(URL(string: "logue://document/0A47D3B4-3B4E-4A2E-9C1D-2F8A1B6C5D40"))
+        #expect(DeepLink(url: url) == .document(id: docID))
+    }
+
+    @Test("A meeting link resolves to the meeting target")
+    func parsesMeetingLink() throws {
+        let url = try #require(URL(string: "logue://meeting/0A47D3B4-3B4E-4A2E-9C1D-2F8A1B6C5D40"))
+        #expect(DeepLink(url: url) == .meeting(id: docID))
+    }
+
+    @Test("A space link resolves to the space target")
+    func parsesSpaceLink() throws {
+        let url = try #require(URL(string: "logue://space/0A47D3B4-3B4E-4A2E-9C1D-2F8A1B6C5D40"))
+        #expect(DeepLink(url: url) == .space(id: docID))
+    }
+
+    @Test("Host matching is case-insensitive")
+    func hostIsCaseInsensitive() throws {
+        let url = try #require(URL(string: "logue://DOCUMENT/0A47D3B4-3B4E-4A2E-9C1D-2F8A1B6C5D40"))
+        #expect(DeepLink(url: url) == .document(id: docID))
+    }
+
+    @Test("A foreign scheme is rejected")
+    func rejectsForeignScheme() throws {
+        let url = try #require(URL(string: "https://document/0A47D3B4-3B4E-4A2E-9C1D-2F8A1B6C5D40"))
+        #expect(DeepLink(url: url) == nil)
+    }
+
+    @Test("An unknown host is rejected")
+    func rejectsUnknownHost() throws {
+        let url = try #require(URL(string: "logue://wat/0A47D3B4-3B4E-4A2E-9C1D-2F8A1B6C5D40"))
+        #expect(DeepLink(url: url) == nil)
+    }
+
+    @Test("A malformed identifier is rejected")
+    func rejectsMalformedIdentifier() throws {
+        let url = try #require(URL(string: "logue://document/not-a-uuid"))
+        #expect(DeepLink(url: url) == nil)
+    }
+
+    @Test("A missing identifier is rejected")
+    func rejectsMissingIdentifier() throws {
+        let url = try #require(URL(string: "logue://document"))
+        #expect(DeepLink(url: url) == nil)
+    }
+
+    @Test("Path traversal in the identifier is rejected")
+    func rejectsPathTraversal() throws {
+        let url = try #require(URL(string: "logue://document/../../etc/passwd"))
+        #expect(DeepLink(url: url) == nil)
+    }
+
+    @Test("Extra path components are rejected rather than ignored")
+    func rejectsExtraPathComponents() throws {
+        let url = try #require(
+            URL(string: "logue://document/0A47D3B4-3B4E-4A2E-9C1D-2F8A1B6C5D40/extra")
+        )
+        #expect(DeepLink(url: url) == nil)
+    }
+
+    @Test("A link round-trips through its URL representation")
+    func roundTripsThroughURL() {
+        let link = DeepLink.document(id: docID)
+        #expect(DeepLink(url: link.url) == link)
+    }
+}

--- a/LogueTests/DiagnosticsReportTests.swift
+++ b/LogueTests/DiagnosticsReportTests.swift
@@ -1,0 +1,76 @@
+import Foundation
+@testable import Logue
+import Testing
+
+/// The diagnostics block is pasted into public GitHub issues, so the important
+/// assertions are about what must never appear in it.
+@Suite("DiagnosticsReport")
+@MainActor
+struct DiagnosticsReportTests {
+    @Test("Report includes app version, macOS version, and device model")
+    func includesEnvironmentBasics() {
+        let text = DiagnosticsReport.generate()
+        #expect(text.contains(BugReportInfo.appVersion))
+        #expect(text.contains(BugReportInfo.macOSVersion))
+        #expect(text.contains(BugReportInfo.deviceModel))
+    }
+
+    @Test("Report never contains the user's home directory path")
+    func excludesHomeDirectory() {
+        let text = DiagnosticsReport.generate()
+        #expect(text.contains(NSHomeDirectory()) == false)
+        #expect(text.contains("/Users/") == false)
+    }
+
+    @Test("Report never contains the account user name")
+    func excludesUserName() {
+        let text = DiagnosticsReport.generate()
+        let userName = NSUserName()
+        if !userName.isEmpty {
+            #expect(text.localizedCaseInsensitiveContains(userName) == false)
+        }
+    }
+
+    @Test("Report never contains a full URL")
+    func excludesURLs() {
+        let text = DiagnosticsReport.generate()
+        #expect(text.contains("http://") == false)
+        #expect(text.contains("https://") == false)
+    }
+
+    @Test("Report reports external-provider configuration as a flag, not a key")
+    func reportsProviderFlagOnly() {
+        let text = DiagnosticsReport.generate()
+        // Key-shaped prefixes must never appear.
+        #expect(text.contains("sk-") == false)
+        #expect(text.lowercased().contains("api key") == false)
+        #expect(text.contains("External providers:"))
+    }
+
+    @Test("Sanitising strips control characters and clamps length")
+    func sanitiseStripsControlCharacters() {
+        let dirty = "model\u{0}name\nwith\tcontrol"
+        let clean = DiagnosticsReport.sanitise(dirty)
+        #expect(clean.contains("\u{0}") == false)
+        #expect(clean.contains("\n") == false)
+        #expect(clean.contains("\t") == false)
+    }
+
+    @Test("Sanitising truncates over-long values")
+    func sanitiseTruncates() {
+        let clean = DiagnosticsReport.sanitise(String(repeating: "a", count: 500))
+        #expect(clean.count <= DiagnosticsReport.maxValueLength)
+    }
+
+    @Test("Sanitising replaces an empty value with a placeholder")
+    func sanitiseHandlesEmpty() {
+        #expect(DiagnosticsReport.sanitise("") == "unknown")
+        #expect(DiagnosticsReport.sanitise("   ") == "unknown")
+    }
+
+    @Test("Report is plain multi-line text suitable for pasting")
+    func reportIsMultiLine() {
+        let lines = DiagnosticsReport.generate().components(separatedBy: "\n")
+        #expect(lines.count >= 4)
+    }
+}

--- a/LogueTests/DiagramMathBlockTests.swift
+++ b/LogueTests/DiagramMathBlockTests.swift
@@ -1,0 +1,116 @@
+import Foundation
+@testable import Logue
+import Testing
+
+/// Mermaid and math blocks must be durable in the markdown file, not editor-only
+/// state — otherwise reopening a document loses the diagram.
+@Suite("DiagramAndMathBlocks")
+struct DiagramMathBlockTests {
+    // MARK: - Mermaid
+
+    @Test("A mermaid fence parses into a mermaid block, not a code block")
+    func mermaidFenceParsesAsMermaidBlock() {
+        let markdown = """
+        ```mermaid
+        flowchart LR
+          A --> B
+        ```
+        """
+        let blocks = BlockSerializer.parse(markdown: markdown)
+
+        #expect(blocks.count == 1)
+        guard case let .mermaid(_, source) = blocks[0] else {
+            Issue.record("Expected a mermaid block, got \(blocks[0])")
+            return
+        }
+        #expect(source == "flowchart LR\n  A --> B")
+    }
+
+    @Test("A mermaid block serializes back to a mermaid fence")
+    func mermaidRoundTrip() {
+        let markdown = """
+        ```mermaid
+        flowchart LR
+          A --> B
+        ```
+        """
+        let output = BlockSerializer.serialize(blocks: BlockSerializer.parse(markdown: markdown))
+        #expect(output == markdown)
+    }
+
+    @Test("A plain code fence is still a code block")
+    func plainCodeFenceIsUnaffected() {
+        let blocks = BlockSerializer.parse(markdown: "```swift\nlet x = 1\n```")
+        guard case let .codeBlock(_, language, _) = blocks[0] else {
+            Issue.record("Expected a code block, got \(blocks[0])")
+            return
+        }
+        #expect(language == "swift")
+    }
+
+    // MARK: - Math
+
+    @Test("A $$ fence parses into a math block")
+    func dollarFenceParsesAsMathBlock() {
+        let markdown = """
+        $$
+        E = mc^2
+        $$
+        """
+        let blocks = BlockSerializer.parse(markdown: markdown)
+
+        #expect(blocks.count == 1)
+        guard case let .math(_, latex) = blocks[0] else {
+            Issue.record("Expected a math block, got \(blocks[0])")
+            return
+        }
+        #expect(latex == "E = mc^2")
+    }
+
+    @Test("A math block serializes back to a $$ fence")
+    func mathRoundTrip() {
+        let markdown = """
+        $$
+        \\frac{a}{b} = c
+        $$
+        """
+        let output = BlockSerializer.serialize(blocks: BlockSerializer.parse(markdown: markdown))
+        #expect(output == markdown)
+    }
+
+    @Test("Multi-line latex is preserved exactly")
+    func multiLineLatexPreserved() {
+        let latex = "a = b \\\\\nc = d"
+        let block = Block.math(id: UUID(), latex: latex)
+        let output = BlockSerializer.serialize(blocks: [block])
+        let reparsed = BlockSerializer.parse(markdown: output)
+
+        guard case let .math(_, roundTripped) = reparsed[0] else {
+            Issue.record("Expected a math block, got \(reparsed[0])")
+            return
+        }
+        #expect(roundTripped == latex)
+    }
+
+    // MARK: - Shared block behaviour
+
+    @Test("Diagram and math blocks are not text blocks")
+    func neitherIsATextBlock() {
+        #expect(Block.mermaid(id: UUID(), source: "graph TD").isTextBlock == false)
+        #expect(Block.math(id: UUID(), latex: "x").isTextBlock == false)
+    }
+
+    @Test("Empty source makes the block empty")
+    func emptinessReflectsSource() {
+        #expect(Block.mermaid(id: UUID(), source: "  ").isEmpty)
+        #expect(Block.mermaid(id: UUID(), source: "graph TD").isEmpty == false)
+        #expect(Block.math(id: UUID(), latex: "").isEmpty)
+        #expect(Block.math(id: UUID(), latex: "x = 1").isEmpty == false)
+    }
+
+    @Test("Source text is searchable so document search can find diagrams")
+    func sourceIsSearchable() {
+        #expect(Block.mermaid(id: UUID(), source: "graph TD").searchableTexts == ["graph TD"])
+        #expect(Block.math(id: UUID(), latex: "E = mc^2").searchableTexts == ["E = mc^2"])
+    }
+}

--- a/LogueTests/DocumentIconTests.swift
+++ b/LogueTests/DocumentIconTests.swift
@@ -1,0 +1,97 @@
+import Foundation
+@testable import Logue
+import Testing
+
+@Suite("DocumentIcon")
+struct DocumentIconTests {
+    @Test("Legacy JSON without an icon decodes without throwing")
+    func legacyJSONDecodes() throws {
+        let legacy = """
+        {
+            "id": "0A47D3B4-3B4E-4A2E-9C1D-2F8A1B6C5D40",
+            "title": "Legacy", "body": "", "goalMode": "casual",
+            "createdAt": 0, "modifiedAt": 0, "isFavorited": false,
+            "tags": [], "chatMessages": [], "isTrashed": false
+        }
+        """
+        let doc = try JSONDecoder().decode(WritingDocument.self, from: Data(legacy.utf8))
+        #expect(doc.icon == nil)
+    }
+
+    @Test("Icon survives an encode/decode round trip")
+    func roundTrip() throws {
+        var doc = WritingDocument()
+        doc.icon = "📄"
+        let decoded = try JSONDecoder().decode(WritingDocument.self, from: JSONEncoder().encode(doc))
+        #expect(decoded.icon == "📄")
+    }
+
+    @Test("A single emoji is accepted")
+    func acceptsEmoji() {
+        #expect(DocumentIcon.sanitised("📄") == "📄")
+    }
+
+    @Test("Control characters and newlines are rejected")
+    func rejectsControlCharacters() {
+        #expect(DocumentIcon.sanitised("a\nb") == nil)
+        #expect(DocumentIcon.sanitised("\u{0}") == nil)
+    }
+
+    @Test("An over-long string is rejected rather than truncated mid-emoji")
+    func rejectsOverLongInput() {
+        #expect(DocumentIcon.sanitised("📄📄📄📄📄📄") == nil)
+    }
+
+    @Test("Empty or whitespace-only input clears the icon")
+    func emptyClearsIcon() {
+        #expect(DocumentIcon.sanitised("") == nil)
+        #expect(DocumentIcon.sanitised("   ") == nil)
+    }
+
+    @Test("A multi-scalar emoji counts as one character")
+    func multiScalarEmojiAccepted() {
+        #expect(DocumentIcon.sanitised("👩‍💻") == "👩‍💻")
+    }
+}
+
+@Suite("EditorLayoutMode")
+struct EditorLayoutModeTests {
+    @Test("Each shortcut number maps to a distinct layout")
+    func shortcutMapping() {
+        #expect(EditorLayoutMode(shortcutNumber: 1) == .editorOnly)
+        #expect(EditorLayoutMode(shortcutNumber: 2) == .editorAndList)
+        #expect(EditorLayoutMode(shortcutNumber: 3) == .allPanels)
+    }
+
+    @Test("An unknown shortcut number resolves to nil")
+    func unknownShortcut() {
+        #expect(EditorLayoutMode(shortcutNumber: 0) == nil)
+        #expect(EditorLayoutMode(shortcutNumber: 9) == nil)
+    }
+
+    @Test("Only the all-panels layout shows the inspector")
+    func inspectorVisibility() {
+        #expect(EditorLayoutMode.editorOnly.showsInspector == false)
+        #expect(EditorLayoutMode.editorAndList.showsInspector == false)
+        #expect(EditorLayoutMode.allPanels.showsInspector)
+    }
+
+    @Test("Editor-only hides the list, the other layouts show it")
+    func listVisibility() {
+        #expect(EditorLayoutMode.editorOnly.showsList == false)
+        #expect(EditorLayoutMode.editorAndList.showsList)
+        #expect(EditorLayoutMode.allPanels.showsList)
+    }
+
+    @Test("Every layout has a menu label")
+    func allHaveLabels() {
+        for mode in EditorLayoutMode.allCases {
+            #expect(!mode.label.isEmpty)
+        }
+    }
+
+    @Test("Layout persists as a stable raw value")
+    func stableRawValues() {
+        #expect(EditorLayoutMode(rawValue: "allPanels") == .allPanels)
+    }
+}

--- a/LogueTests/DocumentReplaceTests.swift
+++ b/LogueTests/DocumentReplaceTests.swift
@@ -1,0 +1,143 @@
+import Foundation
+@testable import Logue
+import Testing
+
+@Suite("DocumentReplace")
+@MainActor
+struct DocumentReplaceTests {
+    private func document(_ blocks: [Block]) -> BlockEditorDocument {
+        let doc = BlockEditorDocument()
+        doc.blocks = blocks
+        return doc
+    }
+
+    @Test("Replacing the current match rewrites only that occurrence")
+    func replacesOnlyCurrentMatch() {
+        let doc = document([.paragraph(id: UUID(), text: "cat and cat")])
+        let state = DocumentSearchState()
+        state.query = "cat"
+        state.search(in: doc.blocks)
+
+        state.replaceCurrent(with: "dog", in: doc)
+
+        #expect(doc.blocks[0].textContent == "dog and cat")
+    }
+
+    @Test("Replace all rewrites every occurrence across blocks")
+    func replaceAllAcrossBlocks() {
+        let doc = document([
+            .paragraph(id: UUID(), text: "cat one"),
+            .heading(id: UUID(), level: 2, text: "cat two"),
+        ])
+        let state = DocumentSearchState()
+        state.query = "cat"
+        state.search(in: doc.blocks)
+
+        let count = state.replaceAll(with: "dog", in: doc)
+
+        #expect(count == 2)
+        #expect(doc.blocks[0].textContent == "dog one")
+        #expect(doc.blocks[1].textContent == "dog two")
+    }
+
+    @Test("Replace all rewrites every occurrence inside one block")
+    func replaceAllWithinOneBlock() {
+        let doc = document([.paragraph(id: UUID(), text: "cat cat cat")])
+        let state = DocumentSearchState()
+        state.query = "cat"
+        state.search(in: doc.blocks)
+
+        let count = state.replaceAll(with: "dog", in: doc)
+
+        #expect(count == 3)
+        #expect(doc.blocks[0].textContent == "dog dog dog")
+    }
+
+    @Test("Replace all rewrites list item text")
+    func replaceAllInListItems() {
+        let blockID = UUID()
+        let doc = document([
+            .bulletList(id: blockID, items: [
+                BlockListItem(text: "cat one"),
+                BlockListItem(text: "cat two"),
+            ]),
+        ])
+        let state = DocumentSearchState()
+        state.query = "cat"
+        state.search(in: doc.blocks)
+
+        let count = state.replaceAll(with: "dog", in: doc)
+
+        #expect(count == 2)
+        guard case let .bulletList(_, items) = doc.blocks[0] else {
+            Issue.record("Expected a bullet list, got \(doc.blocks[0])")
+            return
+        }
+        #expect(items.map(\.text) == ["dog one", "dog two"])
+    }
+
+    @Test("Case-sensitive replace leaves differently-cased text alone")
+    func caseSensitiveReplace() {
+        let doc = document([.paragraph(id: UUID(), text: "Cat and cat")])
+        let state = DocumentSearchState()
+        state.query = "cat"
+        state.matchCase = true
+        state.search(in: doc.blocks)
+
+        let count = state.replaceAll(with: "dog", in: doc)
+
+        #expect(count == 1)
+        #expect(doc.blocks[0].textContent == "Cat and dog")
+    }
+
+    @Test("Replacing with a shorter string keeps later matches aligned")
+    func shorterReplacementKeepsOffsetsValid() {
+        let doc = document([.paragraph(id: UUID(), text: "aaaa bbbb aaaa")])
+        let state = DocumentSearchState()
+        state.query = "aaaa"
+        state.search(in: doc.blocks)
+
+        let count = state.replaceAll(with: "z", in: doc)
+
+        #expect(count == 2)
+        #expect(doc.blocks[0].textContent == "z bbbb z")
+    }
+
+    @Test("Replace all with an empty query changes nothing")
+    func emptyQueryIsNoOp() {
+        let doc = document([.paragraph(id: UUID(), text: "untouched")])
+        let state = DocumentSearchState()
+        state.query = ""
+        state.search(in: doc.blocks)
+
+        let count = state.replaceAll(with: "x", in: doc)
+
+        #expect(count == 0)
+        #expect(doc.blocks[0].textContent == "untouched")
+    }
+
+    @Test("Matches are refreshed after a replacement")
+    func matchesRefreshAfterReplace() {
+        let doc = document([.paragraph(id: UUID(), text: "cat cat")])
+        let state = DocumentSearchState()
+        state.query = "cat"
+        state.search(in: doc.blocks)
+        #expect(state.matches.count == 2)
+
+        state.replaceCurrent(with: "dog", in: doc)
+
+        #expect(state.matches.count == 1)
+    }
+
+    @Test("Replacing the current match with no matches present is a no-op")
+    func replaceCurrentWithoutMatchesIsNoOp() {
+        let doc = document([.paragraph(id: UUID(), text: "nothing here")])
+        let state = DocumentSearchState()
+        state.query = "zzz"
+        state.search(in: doc.blocks)
+
+        state.replaceCurrent(with: "x", in: doc)
+
+        #expect(doc.blocks[0].textContent == "nothing here")
+    }
+}

--- a/LogueTests/DocumentReplaceTests.swift
+++ b/LogueTests/DocumentReplaceTests.swift
@@ -140,4 +140,22 @@ struct DocumentReplaceTests {
 
         #expect(doc.blocks[0].textContent == "nothing here")
     }
+
+    // A multi-UTF-16 character (emoji) before the match makes the UTF-16 offset
+    // exceed the grapheme count; indexing the String with that offset used to trap.
+    @Test("Whole-word search is safe and correct with an emoji before the match")
+    func wholeWordSearchWithLeadingEmoji() throws {
+        let doc = document([.paragraph(id: UUID(), text: "👩‍💻 word and words")])
+        let state = DocumentSearchState()
+        state.query = "word"
+        state.wholeWord = true
+
+        state.search(in: doc.blocks)
+
+        // Only the standalone "word" matches; the emoji is a boundary and "words" is excluded.
+        #expect(state.matches.count == 1)
+        let match = try #require(state.matches.first)
+        let text = doc.blocks[0].textContent as NSString
+        #expect(text.substring(with: match.range) == "word")
+    }
 }

--- a/LogueTests/DocumentWidthModeTests.swift
+++ b/LogueTests/DocumentWidthModeTests.swift
@@ -1,0 +1,58 @@
+import Foundation
+@testable import Logue
+import Testing
+
+@Suite("DocumentWidthMode")
+struct DocumentWidthModeTests {
+    /// Legacy documents were persisted before `widthMode` existed. Decoding must
+    /// tolerate the missing key rather than throwing, or every existing document
+    /// becomes unreadable after the app updates.
+    @Test("Legacy JSON without widthMode decodes to the normal default")
+    func legacyJSONDecodesToNormal() throws {
+        let legacy = """
+        {
+            "id": "0A47D3B4-3B4E-4A2E-9C1D-2F8A1B6C5D40",
+            "title": "Legacy Doc",
+            "body": "Body text",
+            "goalMode": "casual",
+            "createdAt": 0,
+            "modifiedAt": 0,
+            "isFavorited": false,
+            "tags": [],
+            "chatMessages": [],
+            "isTrashed": false
+        }
+        """
+        let data = Data(legacy.utf8)
+        let doc = try JSONDecoder().decode(WritingDocument.self, from: data)
+
+        #expect(doc.widthMode == .normal)
+    }
+
+    @Test("New documents default to normal width")
+    func newDocumentDefault() {
+        #expect(WritingDocument().widthMode == .normal)
+    }
+
+    @Test("Width mode survives an encode/decode round trip")
+    func roundTrip() throws {
+        var doc = WritingDocument()
+        doc.widthMode = .wide
+
+        let data = try JSONEncoder().encode(doc)
+        let decoded = try JSONDecoder().decode(WritingDocument.self, from: data)
+
+        #expect(decoded.widthMode == .wide)
+    }
+
+    @Test("Wide mode allows a larger content width than normal")
+    func wideIsWiderThanNormal() {
+        #expect(DocumentWidthMode.wide.maxContentWidth > DocumentWidthMode.normal.maxContentWidth)
+    }
+
+    @Test("Toggling returns the opposite mode")
+    func toggling() {
+        #expect(DocumentWidthMode.normal.toggled == .wide)
+        #expect(DocumentWidthMode.wide.toggled == .normal)
+    }
+}

--- a/LogueTests/EditorZoomTests.swift
+++ b/LogueTests/EditorZoomTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+@testable import Logue
+import Testing
+
+@Suite("EditorZoom")
+struct EditorZoomTests {
+    @Test("Zoom starts at 100 percent")
+    func startsAtDefault() {
+        #expect(EditorZoom().scale == AppConstants.Editor.defaultZoom)
+    }
+
+    @Test("Zooming in raises the scale by one step")
+    func zoomInRaisesScale() {
+        var zoom = EditorZoom()
+        zoom.zoomIn()
+        #expect(zoom.scale > AppConstants.Editor.defaultZoom)
+    }
+
+    @Test("Zooming out lowers the scale by one step")
+    func zoomOutLowersScale() {
+        var zoom = EditorZoom()
+        zoom.zoomOut()
+        #expect(zoom.scale < AppConstants.Editor.defaultZoom)
+    }
+
+    @Test("Zoom never exceeds the maximum no matter how often it is raised")
+    func clampsAtMaximum() {
+        var zoom = EditorZoom()
+        for _ in 0 ..< 200 { zoom.zoomIn() }
+        #expect(zoom.scale == AppConstants.Editor.maxZoom)
+    }
+
+    @Test("Zoom never falls below the minimum no matter how often it is lowered")
+    func clampsAtMinimum() {
+        var zoom = EditorZoom()
+        for _ in 0 ..< 200 { zoom.zoomOut() }
+        #expect(zoom.scale == AppConstants.Editor.minZoom)
+    }
+
+    @Test("Resetting returns to 100 percent")
+    func resetReturnsToDefault() {
+        var zoom = EditorZoom()
+        zoom.zoomIn()
+        zoom.zoomIn()
+        zoom.reset()
+        #expect(zoom.scale == AppConstants.Editor.defaultZoom)
+    }
+
+    @Test("An out-of-range scale is clamped on assignment")
+    func assignmentIsClamped() {
+        var zoom = EditorZoom()
+        zoom.scale = 99
+        #expect(zoom.scale == AppConstants.Editor.maxZoom)
+        zoom.scale = -5
+        #expect(zoom.scale == AppConstants.Editor.minZoom)
+    }
+
+    @Test("Scaling a font size multiplies by the current scale")
+    func scalesFontSize() {
+        var zoom = EditorZoom()
+        zoom.scale = 2.0
+        #expect(zoom.scaled(16) == 32)
+    }
+
+    @Test("Zoom in then out returns to the starting scale")
+    func inThenOutIsSymmetric() {
+        var zoom = EditorZoom()
+        zoom.zoomIn()
+        zoom.zoomOut()
+        #expect(abs(zoom.scale - AppConstants.Editor.defaultZoom) < 0.0001)
+    }
+
+    @Test("The percentage label reflects the current scale")
+    func percentLabel() {
+        var zoom = EditorZoom()
+        #expect(zoom.percentLabel == "100%")
+        zoom.scale = 1.5
+        #expect(zoom.percentLabel == "150%")
+    }
+
+    @Test("Reset is reported as available only when zoomed")
+    func canResetOnlyWhenZoomed() {
+        var zoom = EditorZoom()
+        #expect(zoom.canReset == false)
+        zoom.zoomIn()
+        #expect(zoom.canReset)
+    }
+}

--- a/LogueTests/HighlightMarkTests.swift
+++ b/LogueTests/HighlightMarkTests.swift
@@ -1,0 +1,55 @@
+import Foundation
+@testable import Logue
+import Testing
+
+/// `==highlight==` is a non-CommonMark inline mark. The block serializer must
+/// carry it through a markdown round trip untouched, otherwise applying a
+/// highlight and reopening the document silently loses it.
+@Suite("HighlightMark")
+struct HighlightMarkTests {
+    @Test("Highlight syntax survives a markdown round trip")
+    func roundTrip() {
+        let markdown = "Some ==important== text"
+        let blocks = BlockSerializer.parse(markdown: markdown)
+        let output = BlockSerializer.serialize(blocks: blocks)
+
+        #expect(output.contains("==important=="))
+    }
+
+    @Test("Toggling highlight on plain text wraps it")
+    func togglingWrapsPlainText() {
+        let result = HighlightMark.toggled(in: "make this bold", range: NSRange(location: 5, length: 4))
+        #expect(result == "make ==this== bold")
+    }
+
+    @Test("Toggling highlight on already-highlighted text unwraps it")
+    func togglingUnwrapsHighlightedText() {
+        let text = "make ==this== bold"
+        // Range covers "this" inside the existing delimiters.
+        let result = HighlightMark.toggled(in: text, range: NSRange(location: 7, length: 4))
+        #expect(result == "make this bold")
+    }
+
+    @Test("Toggling an empty selection leaves the text unchanged")
+    func emptySelectionIsNoOp() {
+        let result = HighlightMark.toggled(in: "unchanged", range: NSRange(location: 3, length: 0))
+        #expect(result == "unchanged")
+    }
+
+    @Test("A range beyond the text length leaves the text unchanged")
+    func outOfBoundsRangeIsNoOp() {
+        let result = HighlightMark.toggled(in: "short", range: NSRange(location: 2, length: 99))
+        #expect(result == "short")
+    }
+
+    @Test("Highlighted ranges are detected for styling")
+    func detectsRangesForStyling() {
+        let ranges = HighlightMark.ranges(in: "a ==one== b ==two== c")
+        #expect(ranges.count == 2)
+    }
+
+    @Test("Unpaired delimiters produce no highlight ranges")
+    func unpairedDelimiterIsNotAHighlight() {
+        #expect(HighlightMark.ranges(in: "a == b").isEmpty)
+    }
+}

--- a/LogueTests/QuickOpenTests.swift
+++ b/LogueTests/QuickOpenTests.swift
@@ -1,0 +1,68 @@
+import Foundation
+@testable import Logue
+import Testing
+
+@Suite("QuickOpen")
+struct QuickOpenTests {
+    private let items = [
+        QuickOpenItem(id: UUID(), title: "Quarterly Report", kind: .document),
+        QuickOpenItem(id: UUID(), title: "Quick Notes", kind: .document),
+        QuickOpenItem(id: UUID(), title: "Team Standup", kind: .meeting),
+        QuickOpenItem(id: UUID(), title: "Product Roadmap", kind: .document),
+    ]
+
+    @Test("An empty query returns every item")
+    func emptyQueryReturnsAll() {
+        #expect(QuickOpenMatcher.match(query: "", in: items).count == items.count)
+    }
+
+    @Test("Matching is case-insensitive")
+    func caseInsensitive() {
+        let results = QuickOpenMatcher.match(query: "quarterly", in: items)
+        #expect(results.first?.title == "Quarterly Report")
+    }
+
+    @Test("A prefix match ranks above a mid-word match")
+    func prefixRanksFirst() {
+        let results = QuickOpenMatcher.match(query: "qu", in: items)
+        // "Quarterly Report" and "Quick Notes" both start with "Qu".
+        #expect(results.count >= 2)
+        #expect(results.allSatisfy { $0.title.lowercased().hasPrefix("qu") })
+    }
+
+    @Test("Subsequence matching finds initials")
+    func subsequenceMatch() {
+        let results = QuickOpenMatcher.match(query: "prm", in: items)
+        #expect(results.contains { $0.title == "Product Roadmap" })
+    }
+
+    @Test("A non-matching query returns nothing")
+    func noMatches() {
+        #expect(QuickOpenMatcher.match(query: "zzzzz", in: items).isEmpty)
+    }
+
+    @Test("Whitespace-only queries are treated as empty")
+    func whitespaceQuery() {
+        #expect(QuickOpenMatcher.match(query: "   ", in: items).count == items.count)
+    }
+
+    @Test("Meetings and documents both match")
+    func bothKindsMatch() {
+        let results = QuickOpenMatcher.match(query: "team", in: items)
+        #expect(results.first?.kind == .meeting)
+    }
+
+    @Test("An exact title match ranks first")
+    func exactMatchRanksFirst() {
+        let results = QuickOpenMatcher.match(query: "Quick Notes", in: items)
+        #expect(results.first?.title == "Quick Notes")
+    }
+
+    @Test("Results are capped so the palette stays responsive")
+    func resultsAreCapped() {
+        let many = (0 ..< 500).map {
+            QuickOpenItem(id: UUID(), title: "Item \($0)", kind: .document)
+        }
+        #expect(QuickOpenMatcher.match(query: "item", in: many).count <= QuickOpenMatcher.maxResults)
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -60,6 +60,13 @@ targets:
         NSHumanReadableDescription: "Privacy-first AI writing assistant"
         NSPrincipalClass: NSApplication
         NSMicrophoneUsageDescription: "Logue needs microphone access to transcribe meetings on-device."
+        # Deep links: logue://document/<uuid>, logue://meeting/<uuid>, logue://space/<uuid>.
+        # Parsed and validated by DeepLink before any navigation happens.
+        CFBundleURLTypes:
+          - CFBundleURLName: com.bitwize.logue.deeplink
+            CFBundleTypeRole: Viewer
+            CFBundleURLSchemes:
+              - logue
         UTExportedTypeDeclarations:
           - UTTypeIdentifier: com.bitwize.logue.workspace-drag-item
             UTTypeDescription: Logue Workspace Item


### PR DESCRIPTION
Implements a batch of self-contained editor and shell improvements, each covered by unit tests (106 new tests, 143 total passing).

Editor
- Mermaid diagram and LaTeX math blocks, durable in markdown via ```mermaid fences and $$ fences. Math needs a pre-pass because cmark parses $$ as a paragraph and collapses internal newlines.
- ==highlight== inline mark (Cmd+Shift+M), shared between the editor and the serializer so the two cannot drift.
- Find and replace (Cmd+F), applying ranges last-to-first so offsets stay valid when the replacement length differs.
- Move blocks (Cmd+Shift+Up/Down). Non-contiguous selections are rejected rather than reordered arbitrarily.
- Per-document width (normal/wide) with a toolbar toggle.
- Editor zoom (Cmd +/-/0) as a multiplier over the base font-size preference, clamped in one place.
- Paste without formatting (Cmd+Shift+V).

Shell
- logue:// deep links for documents, meetings, and spaces. Parsing is side-effect free and rejects unknown hosts, malformed UUIDs, traversal paths, and extra components; routing is a separate step.
- Sanitized diagnostics attached to bug reports. Excludes filesystem paths, account name, URLs, and API keys; reports external providers as a count only. Every value is stripped of control characters so a malformed model name cannot forge diagnostic lines.

Notes
- WritingDocument gains optional backing storage for new fields. Swift's synthesized Codable throws keyNotFound for a missing non-optional key even when a default exists, so a non-optional property would have made every existing document undecodable.
- DocumentIcon validates against Unicode category Cc only, not CharacterSet.controlCharacters, which also covers Cf and would reject the zero-width joiner in multi-scalar emoji.
- syncMarkdownFromBlocks moved to BlockEditorView+Reorder to stay under the 800-line file limit without a lint suppression.

Not yet surfaced in the UI (models built and tested only): document icons, layout modes, quick-open palette mode.

<!--
Thanks for contributing to Logue! Please fill out the sections below.
See CONTRIBUTING.md for the standards enforced on every PR.
-->

## Summary

<!-- What does this PR change, and why? Link any related issue: "Closes #123". -->

## How was this verified?

<!-- Describe how you tested the change: built the app, ran which tests, manual steps. -->

- [ ] Builds cleanly (`xcodebuild build -project Logue.xcodeproj -scheme Logue -destination 'platform=macOS'`)
- [ ] Lints cleanly (`make lint`) — no new `swiftlint:disable` without justification
- [ ] Added/updated tests where it makes sense
- [ ] Ran `xcodegen generate` if I added/removed `.swift` files or changed `project.yml`

## Checklist

- [ ] My change keeps all AI inference and data processing **on-device** (no new network calls to third-party services without discussion).
- [ ] I did not commit secrets, API keys, or personal data.
- [ ] I read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the security/concurrency standards.

## Notes for reviewers

<!-- Anything the maintainers should pay special attention to. -->
