### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# Code owners for Logue
+#
+# Listed owners are automatically requested for review on every pull request
+# that touches files they own. GitHub skips requesting a review from the PR's
+# own author, so with two owners the other one is always added.
+#
+# Docs: https://docs.github.com/articles/about-code-owners
+#
+# Later, more specific rules win over earlier ones, so keep the catch-all first
+# and add path-specific owners below it as the team grows.
+
+# Everything is owned by the core maintainers.
+*       @shanforge @westerosweb


### PR DESCRIPTION
Adds a `.github/CODEOWNERS` so the maintainers are automatically requested for review on every PR.

```
*       @shanforge @westerosweb
```

- `*` makes both owners of the whole repo.
- GitHub never requests a review from the PR's own author, so with two owners the other one is always auto-added.
- Catch-all is kept first; path-specific rules can be added below it later (more specific wins).

Note: for owners to be auto-requested they need write access to the repo, which both accounts have. To also *require* code-owner approval, enable "Require review from Code Owners" in the branch ruleset separately.