### PR TITLE
Make `make lint` match CI and add a contribution-task issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/contribution_task.yml
+++ b/.github/ISSUE_TEMPLATE/contribution_task.yml
@@ -1,0 +1,101 @@
+name: Contribution task
+description: A scoped, ready-to-pick-up task for contributors (usually filed by maintainers)
+labels: ["enhancement", "help wanted"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for work that is already understood and just needs doing —
+        the kind of issue someone new to the codebase can pick up without a long
+        discussion first.
+
+        A good task states **why** it matters, has acceptance criteria that make
+        "done" unambiguous, and names the files involved so nobody has to hunt.
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: What is missing or wrong today, and why does it matter to someone using the app?
+      placeholder: |
+        Today X isn't possible, so anyone who wants Y has to work around it by ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: existing-work
+    attributes:
+      label: What already exists
+      description: >
+        Any model, helper, or tested logic already in the codebase that this should
+        build on. Say plainly if the hard part is done and only the UI is missing —
+        that is the single most useful thing you can tell a newcomer.
+      placeholder: |
+        `Foo.swift` already provides `bar(_:)` with N passing tests in `LogueTests/FooTests.swift`.
+        This task is UI only — please don't write a second implementation.
+    validations:
+      required: false
+
+  - type: textarea
+    id: what-to-do
+    attributes:
+      label: What to do
+      description: The change being asked for, in a sentence or two. Not a design doc.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: A checklist that makes "done" unambiguous. Include the edge cases and the things that must NOT regress.
+      value: |
+        - [ ]
+        - [ ] Existing tests still pass
+        - [ ] No new `swiftlint:disable` without a comment explaining why
+    validations:
+      required: true
+
+  - type: textarea
+    id: pointers
+    attributes:
+      label: Files and pointers
+      description: Where to start looking. Include any existing code that is a good pattern to copy.
+      placeholder: |
+        - `Logue/Views/...` — where the UI goes
+        - `Logue/Models/...` — the model to extend
+        - See how `<similar feature>` was done; same shape.
+    validations:
+      required: true
+
+  - type: textarea
+    id: gotchas
+    attributes:
+      label: Gotchas
+      description: >
+        Traps that would cost someone an hour. Data-format constraints, non-obvious
+        invariants, things that look like bugs but are intentional.
+      placeholder: |
+        `Block`'s `Equatable` compares IDs, and `parse` mints fresh UUIDs — so
+        `parse(serialize(x)) == x` is always false. Compare structural content instead.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: difficulty
+    attributes:
+      label: Rough size
+      options:
+        - Small — an hour or two, few files
+        - Medium — a focused session
+        - Large — please comment before starting so we can agree the approach
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: discuss-first
+    attributes:
+      label: Before you start
+      options:
+        - label: This task has design decisions worth agreeing on in a comment before building.
+          required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,8 +11,10 @@ See CONTRIBUTING.md for the standards enforced on every PR.
 
 <!-- Describe how you tested the change: built the app, ran which tests, manual steps. -->
 
+- [ ] Ran `make setup` at least once, so the pre-commit hooks are installed
 - [ ] Builds cleanly (`xcodebuild build -project Logue.xcodeproj -scheme Logue -destination 'platform=macOS'`)
-- [ ] Lints cleanly (`make lint`) — no new `swiftlint:disable` without justification
+- [ ] Lints cleanly (`make lint`) — runs SwiftFormat **and** SwiftLint in strict mode, the same two checks as CI. Use `make format` to auto-fix formatting.
+- [ ] No new `swiftlint:disable` without justification
 - [ ] Added/updated tests where it makes sense
 - [ ] Ran `xcodegen generate` if I added/removed `.swift` files or changed `project.yml`
 

--- a/Makefile
+++ b/Makefile
@@ -124,9 +124,13 @@ generate:
 format:
 	swiftformat Logue/
 
-# Lint Swift files with SwiftLint
+# Lint Swift files exactly as CI does: SwiftFormat first, then SwiftLint in
+# strict mode. These two commands must stay in sync with .github/workflows/ci.yml
+# — if `make lint` is more lenient than CI, a green local run means nothing.
+# Run `make format` to auto-fix the SwiftFormat failures this reports.
 lint:
-	swiftlint lint Logue/
+	cd Logue && swiftformat --lint .
+	swiftlint lint --strict Logue/
 
 # Build the project (no code signing for local/CI builds)
 build: generate


### PR DESCRIPTION
## Summary

`make lint` was more lenient than CI, so a green local run meant nothing — and the pull-request template pointed contributors at exactly that weaker command as their verification step.

```make
# before
lint:
	swiftlint lint Logue/
```

CI (`.github/workflows/ci.yml`) runs **two** checks:

```bash
swiftformat --lint .        # working-directory: Logue
swiftlint lint --strict Logue/
```

So `make lint` skipped SwiftFormat entirely and dropped `--strict`. A contributor could verify locally, push, and fail CI on formatting they were never told to check. This happened on #7.

Also adds a `contribution_task.yml` issue form, for the scoped ready-to-pick-up work now filed as #9–#20.

## Changes

| File | Change |
| --- | --- |
| `Makefile` | `lint` runs SwiftFormat then SwiftLint `--strict`, matching CI exactly |
| `.github/PULL_REQUEST_TEMPLATE.md` | References the corrected command, mentions `make format` for auto-fixing, adds a `make setup` item |
| `.github/ISSUE_TEMPLATE/contribution_task.yml` | New issue form for scoped contributor tasks |

The `make setup` checklist item matters because the pre-commit hooks live in `.git/hooks`, which is not version controlled — nothing in the repo can enforce that they exist, so a fresh clone silently has no hooks.

The new issue form is shaped around what made #9–#20 useful to a newcomer: a **"What already exists"** field (so a contributor is told when the hard part is done and only wiring is left), unambiguous acceptance criteria, file pointers, and a **Gotchas** field for traps that would otherwise cost an hour.

## How was this verified?

- `make lint` passes on a clean tree — 0 violations across 406 files
- **Negative test:** added a deliberately misformatted file, confirmed `make lint` exits 2 and reports the SwiftFormat errors (`blankLineAfterImports`, `spaceAroundBraces`, `spaceInsideBraces`), then removed it. A passing run alone would not have proven the check works.
- `contribution_task.yml` parses as valid YAML and uses only valid GitHub issue-form field types; 5 required fields resolve as intended

- [x] Ran `make setup` at least once, so the pre-commit hooks are installed
- [ ] Builds cleanly — not applicable, no Swift source changed
- [x] Lints cleanly (`make lint`)
- [x] No new `swiftlint:disable`
- [ ] Added/updated tests — not applicable, no Swift source changed
- [ ] Ran `xcodegen generate` — not applicable, no `.swift` files or `project.yml` changed

## Checklist

- [x] Keeps all AI inference and data processing on-device — no runtime code changed
- [x] No secrets, API keys, or personal data committed
- [x] Followed the standards in CONTRIBUTING.md / CLAUDE.md

## Notes for reviewers

**This makes local linting stricter than it was.** It passes on `main` as of this branch, so there's no backlog to clear — but any future `make lint` failure should be treated as a real violation rather than a regression from this change.

Worth a separate decision: `config.yml` sets `blank_issues_enabled: false`, so contributors cannot open a free-form issue. Anyone whose report fits none of the templates has only the support email. Reasonable as-is, but more consequential now that there's a public contributor surface.
