### PR TITLE
fix: disable App Sandbox so Logue appears in Accessibility settings (#22)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,25 @@ jobs:
       - name: Run SwiftLint
         run: swiftlint lint --strict Logue/
 
+      # Logue must not be sandboxed: a sandboxed process cannot be an Accessibility
+      # API client, so macOS never lists it under Privacy & Security → Accessibility
+      # and every Logue/CrossApp feature (⌘⌃I, global hotkeys, Command Center, text
+      # replacement) silently stops working. That shipped in 1.0.0 as issue #22.
+      # Nothing fails at build time if this regresses, so it is checked explicitly.
+      - name: Verify app sandbox stays disabled
+        run: |
+          rc=0
+          for plist in Logue/Resources/Logue.entitlements Logue/Resources/Logue.release.entitlements; do
+            value=$(/usr/libexec/PlistBuddy -c "Print :com.apple.security.app-sandbox" "$plist" 2>/dev/null || echo "missing")
+            if [ "$value" != "false" ]; then
+              echo "::error file=$plist::app-sandbox is '$value', expected 'false' (see issue #22)"
+              rc=1
+            else
+              echo "OK: $plist has app-sandbox = false"
+            fi
+          done
+          exit $rc
+
   build:
     name: Build
     runs-on: macos-15

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,9 +210,15 @@ jobs:
             codesign --force --options runtime --sign "$SIGNING_IDENTITY" --timestamp "$item"
           done
 
-          # 3. Sign XPC services with proper entitlements for sandboxed Sparkle updates.
-          #    - Downloader.xpc: MUST be sandboxed with network access (downloads update ZIP)
-          #    - Installer.xpc: MUST NOT be sandboxed (needs to write to /Applications)
+          # 3. Sign Sparkle's XPC services.
+          #    Logue is no longer sandboxed, so Sparkle does not use these at all — it
+          #    installs directly via Autoupdate/Updater.app. They still ship inside
+          #    Sparkle.framework, so they must carry a valid signature or the outer
+          #    bundle fails verification. The sandboxed/non-sandboxed split below is
+          #    kept as Sparkle documents it, so re-enabling the sandbox does not
+          #    silently produce a broken updater.
+          #    - Downloader.xpc: sandboxed with network access (downloads update ZIP)
+          #    - Installer.xpc: NOT sandboxed (needs to write to /Applications)
           DOWNLOADER_ENT=$(mktemp)
           cat > "$DOWNLOADER_ENT" << 'ENTEOF'
           <?xml version="1.0" encoding="UTF-8"?>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,8 +75,10 @@ macOS app (macOS 26+ / Tahoe): AI-powered meeting notes + document editing. Priv
 - **Sparkle EdDSA private key** lives only in the GitHub Actions secret `SPARKLE_PRIVATE_KEY` — never store it in the repo. The public key (`SUPublicEDKey`) is embedded in `Info.plist` via `project.yml`. Updates are served entirely from GitHub (appcast in-repo, assets on GitHub Releases) — there is no backend.
 - **Use typed constants for notification userInfo keys** — never string literals like `"success"` in `userInfo` dictionaries.
 - **Entitlements:**
-  - Dev builds: sandbox OFF for development convenience (documented in comments)
-  - Release builds: sandbox ON via `Logue.release.entitlements`
+  - **App Sandbox is OFF in both Debug and Release — do not re-enable it.** A sandboxed process cannot be an Accessibility API client, so macOS never lists the app under Privacy & Security → Accessibility and the user cannot add it manually. That silently kills every `Logue/CrossApp` feature (⌘⌃I inline assistant, global hotkeys, Command Center, text replacement). This shipped in 1.0.0 as issue #22. Guarded by `LogueTests/ReleaseEntitlementsTests.swift` and a CI step.
+  - Distribution is Developer ID + notarization via GitHub Releases and Sparkle — not the Mac App Store — so the sandbox is not required. **Hardened Runtime stays ON.**
+  - Sparkle needs no XPC services or `SUEnableInstallerLauncherService` when unsandboxed; those exist solely to work around the sandbox.
+  - Debug (`Logue.entitlements`) and Release (`Logue.release.entitlements`) still differ: Debug carries the iCloud entitlements, Release does not.
   - Every security exception (`allow-jit`, `disable-library-validation`, etc.) must have a comment explaining why it's needed
 
 ### Concurrency and Thread Safety
@@ -165,4 +167,5 @@ macOS app (macOS 26+ / Tahoe): AI-powered meeting notes + document editing. Priv
 | `Engine/LLMClient.swift` | External LLM provider clients (OpenAI/Anthropic-compatible) — optional, user-configured |
 | `Services/RecordingSessionManager.swift` | Recording lifecycle (`RecordingState` enum) |
 | `Services/EncryptionManager.swift` | AES-256-GCM encryption at rest (7-day migration window) |
+| `Services/SandboxContainerMigrator.swift` | One-time move of user data out of the pre-1.0.1 sandbox container (runs in `LogueApp.init()`) |
 | `App/AppConstants.swift` | All constants: `LLMDefaults`, `Audio`, `Diarization`, `Delays` |

--- a/Logue.xcodeproj/project.pbxproj
+++ b/Logue.xcodeproj/project.pbxproj
@@ -432,6 +432,7 @@
 		FA0EBF1706531E854E711B5E /* PIICategoryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68896D3492B91AC825FEC46E /* PIICategoryCard.swift */; };
 		FB2DCEFD67348622524BEB81 /* RecentContentPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63AC1DBC374C162B470E69D4 /* RecentContentPane.swift */; };
 		FB715269552DA5B0A80404E1 /* OverviewPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6042105E2C13EF05700916B6 /* OverviewPane.swift */; };
+		FD7360D41D7027945F5BE947 /* SandboxContainerMigratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A5F89112EFC50A714AFD79 /* SandboxContainerMigratorTests.swift */; };
 		FDA9B040A07F32E153F7CFA7 /* InlineRewritePopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A27F72324468131F61DCF8 /* InlineRewritePopover.swift */; };
 		FE2793A4972BDC2CEB93C018 /* MenuBarIcon.png in Resources */ = {isa = PBXBuildFile; fileRef = EF7B96F52DB280D23D637F33 /* MenuBarIcon.png */; };
 		FEA46F7D5BB9F4D69448D52D /* TableBlockData.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB031A0FCAED343F68FB194A /* TableBlockData.swift */; };
@@ -662,6 +663,7 @@
 		86F393DC727834A59AB47A62 /* AIChatPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatPanelView.swift; sourceTree = "<group>"; };
 		8756576B17C7D359AC9FC6A0 /* VerifyPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerifyPanelView.swift; sourceTree = "<group>"; };
 		876B3EAA03844355C80F1817 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		87A5F89112EFC50A714AFD79 /* SandboxContainerMigratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SandboxContainerMigratorTests.swift; sourceTree = "<group>"; };
 		88018F4CBB121A88EF363BBE /* MeetingListContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingListContentView.swift; sourceTree = "<group>"; };
 		8876D7837082707205CBFC6D /* LogueApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogueApp.swift; sourceTree = "<group>"; };
 		89916892E9BF400CDC89E1FF /* WebSearchTools.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSearchTools.swift; sourceTree = "<group>"; };
@@ -954,6 +956,7 @@
 				EAAA4BF89D7A99D017BB1C8E /* PromptBuilderTests.swift */,
 				B37427E70D5B05A2E6C5B253 /* QuickOpenTests.swift */,
 				EFE448FDFB9D86AB13035E23 /* ReleaseEntitlementsTests.swift */,
+				87A5F89112EFC50A714AFD79 /* SandboxContainerMigratorTests.swift */,
 				5C461874879489EBFF0BE683 /* SuggestionParserTests.swift */,
 				8D2D61B85F962E88AA1E5062 /* TextAnalysisRequestTests.swift */,
 				818DBC353FE8A22EC01DCB37 /* WritingDocumentTests.swift */,
@@ -1876,6 +1879,7 @@
 				CADF664CE3E27718367FEA0F /* ReleaseEntitlementsTests.swift in Sources */,
 				C72506A4CA87BDD44FF88766 /* ReviewPanelLLMTests.swift in Sources */,
 				0EA7AB55C23D022F1C35E001 /* RewritePanelLLMTests.swift in Sources */,
+				FD7360D41D7027945F5BE947 /* SandboxContainerMigratorTests.swift in Sources */,
 				EFB8555797ACCB5E2120C1AA /* SuggestionParserTests.swift in Sources */,
 				A30AAC62CDAE227B36E45511 /* TextAnalysisRequestTests.swift in Sources */,
 				073F4389E29E0F214606228C /* VerifyPanelLLMTests.swift in Sources */,

--- a/Logue.xcodeproj/project.pbxproj
+++ b/Logue.xcodeproj/project.pbxproj
@@ -171,6 +171,7 @@
 		58383E0A1CA89E1D4BC10EC4 /* StopGeneratingPill.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0D79E3FE30ED849DAD9A68C /* StopGeneratingPill.swift */; };
 		58CA6E17E4069C3C5F06F846 /* ModelsSettingsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D03A33B16F78827FBD8EDC /* ModelsSettingsTab.swift */; };
 		59AA097C69B46F3E88E42062 /* MLXLMTransformers in Frameworks */ = {isa = PBXBuildFile; productRef = CC75CD4CA4D3EADBB868CBF3 /* MLXLMTransformers */; };
+		5A166534FD1D8C275234BA7E /* SandboxContainerMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FA779998563196E65B54138 /* SandboxContainerMigrator.swift */; };
 		5AAAF36F01B586D73D6A35EF /* ContactsTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFA4DB05B86C453078B1E5E6 /* ContactsTool.swift */; };
 		5AB6B868E9F97AEEEC43AFC5 /* MeetingTimeTrendCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23DED725F174E9C0F6E8F30E /* MeetingTimeTrendCard.swift */; };
 		5ABF0C44B73774A18BE7F417 /* SuggestionPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 126A669ACEBF8395600EC8EE /* SuggestionPanelView.swift */; };
@@ -339,6 +340,7 @@
 		C93B740F016517506C75927B /* Textual in Frameworks */ = {isa = PBXBuildFile; productRef = 238CBA6C9E115714DDE75D3D /* Textual */; };
 		C9CC41E7FFAB99BAEEC29E4D /* TranscriptTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05509BDEDCFFC620AB9B8777 /* TranscriptTimelineView.swift */; };
 		CA56A6CBBDDCD1F751696437 /* WebSearchTools.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89916892E9BF400CDC89E1FF /* WebSearchTools.swift */; };
+		CADF664CE3E27718367FEA0F /* ReleaseEntitlementsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFE448FDFB9D86AB13035E23 /* ReleaseEntitlementsTests.swift */; };
 		CBFB8E3030659A2F66D8A54A /* AgentCoordinator+Approval.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0027C5C3EE6CAEEB887EAEC7 /* AgentCoordinator+Approval.swift */; };
 		CCA2748ACA502E36CD99A964 /* MeetingGridCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD6FE3B101005521F444593D /* MeetingGridCardView.swift */; };
 		CCD1A1E6938412C9D24E066E /* LangGraph in Frameworks */ = {isa = PBXBuildFile; productRef = 7EFECA56D85500BA67B0D907 /* LangGraph */; };
@@ -494,6 +496,7 @@
 		1C62A52E0C3465F6EB34290E /* SpaceAIPopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceAIPopover.swift; sourceTree = "<group>"; };
 		1C843F0CCD12C0AFFD804F85 /* PromptRegistry+Writing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PromptRegistry+Writing.swift"; sourceTree = "<group>"; };
 		1E5007DA0D26B354ACEDDE7D /* HomeCardShell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCardShell.swift; sourceTree = "<group>"; };
+		1FA779998563196E65B54138 /* SandboxContainerMigrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SandboxContainerMigrator.swift; sourceTree = "<group>"; };
 		1FB93A6E198E565413AD03FC /* BlockRowView+Actions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlockRowView+Actions.swift"; sourceTree = "<group>"; };
 		207FDDB5AF3841198B2438E4 /* ChatHomeEmptyState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatHomeEmptyState.swift; sourceTree = "<group>"; };
 		20FC98B65B556E8B97D9660A /* AudioLevelNormalizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioLevelNormalizer.swift; sourceTree = "<group>"; };
@@ -850,6 +853,7 @@
 		ECB1EE6AF1D9283E7F15E6C3 /* DocumentWorkspaceView+Toolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DocumentWorkspaceView+Toolbar.swift"; sourceTree = "<group>"; };
 		ED35C64E018F0B223D5FE487 /* OverviewQuickActionsCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverviewQuickActionsCard.swift; sourceTree = "<group>"; };
 		EF7B96F52DB280D23D637F33 /* MenuBarIcon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = MenuBarIcon.png; sourceTree = "<group>"; };
+		EFE448FDFB9D86AB13035E23 /* ReleaseEntitlementsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseEntitlementsTests.swift; sourceTree = "<group>"; };
 		F06E61F5499F68059FF8775B /* TableCellTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableCellTextView.swift; sourceTree = "<group>"; };
 		F30E821E71C80A341EEC3F68 /* BlockEditorView+Reorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlockEditorView+Reorder.swift"; sourceTree = "<group>"; };
 		F4837D7E60145F15B37A2310 /* GraphRetriever.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphRetriever.swift; sourceTree = "<group>"; };
@@ -949,6 +953,7 @@
 				9226B7B10683E42ABEB71810 /* HighlightMarkTests.swift */,
 				EAAA4BF89D7A99D017BB1C8E /* PromptBuilderTests.swift */,
 				B37427E70D5B05A2E6C5B253 /* QuickOpenTests.swift */,
+				EFE448FDFB9D86AB13035E23 /* ReleaseEntitlementsTests.swift */,
 				5C461874879489EBFF0BE683 /* SuggestionParserTests.swift */,
 				8D2D61B85F962E88AA1E5062 /* TextAnalysisRequestTests.swift */,
 				818DBC353FE8A22EC01DCB37 /* WritingDocumentTests.swift */,
@@ -1143,6 +1148,7 @@
 				81952E09E4EEE636EC5766F7 /* RecordingSessionManager+Diarization.swift */,
 				6ED5A7948FEFC3B58D925DFC /* ReminderManager.swift */,
 				263421D41C830238A47CD829 /* ResourceUsageMonitor.swift */,
+				1FA779998563196E65B54138 /* SandboxContainerMigrator.swift */,
 				A0B951849FD3761363C96A27 /* ScheduledTaskManager.swift */,
 				46D6419EB91D515BAD26FEF7 /* ScheduledTaskManager+WeeklyReview.swift */,
 				FB395EE9C9C26DE9E0F65678 /* SemanticIndex.swift */,
@@ -1867,6 +1873,7 @@
 				7685B4E18D7F1A25AE0F6738 /* MeetingLLMTests.swift in Sources */,
 				957DBF3D45C9A998D610B8B2 /* PromptBuilderTests.swift in Sources */,
 				4371B1C1354F8BF50EFECCBB /* QuickOpenTests.swift in Sources */,
+				CADF664CE3E27718367FEA0F /* ReleaseEntitlementsTests.swift in Sources */,
 				C72506A4CA87BDD44FF88766 /* ReviewPanelLLMTests.swift in Sources */,
 				0EA7AB55C23D022F1C35E001 /* RewritePanelLLMTests.swift in Sources */,
 				EFB8555797ACCB5E2120C1AA /* SuggestionParserTests.swift in Sources */,
@@ -2162,6 +2169,7 @@
 				4E90B4EE5AB06A18C7B15717 /* RichTextEditor.swift in Sources */,
 				E8841BD73095D797A512A0FC /* RichTextEditorHelpers.swift in Sources */,
 				85BFFE25C6715ABAE40DFB2C /* RightIconToolbar.swift in Sources */,
+				5A166534FD1D8C275234BA7E /* SandboxContainerMigrator.swift in Sources */,
 				C4199264EB8DE658B14B4C9D /* SaveAsTemplateSheet.swift in Sources */,
 				B7B53337BC65FF52350811CA /* SaveSummaryToDocumentSheet.swift in Sources */,
 				5FE5B603740CF6AB60C95616 /* ScheduledTask.swift in Sources */,

--- a/Logue/App/AppConstants.swift
+++ b/Logue/App/AppConstants.swift
@@ -8,6 +8,10 @@ enum AppConstants {
         static let activeModelID = "activeModelID"
         static let hasCompletedOnboarding = "hasCompletedOnboarding"
 
+        /// Set once `SandboxContainerMigrator` has moved data out of the legacy
+        /// (pre-1.0.1, sandboxed) container. See that type for why the sandbox went away.
+        static let sandboxContainerMigrationCompleted = "sandboxContainerMigrationCompleted"
+
         static let writingGoalMode = "writingGoalMode"
         static let actionModelMap = "ActionModelMap"
         static let documentViewMode = "documentViewMode"

--- a/Logue/App/LogueApp.swift
+++ b/Logue/App/LogueApp.swift
@@ -25,6 +25,12 @@ struct LogueApp: App {
     @AppStorage(AppConstants.UserDefaultsKeys.editorZoomScale) private var zoomScale: Double =
         AppConstants.Editor.defaultZoom
 
+    init() {
+        // Must run before any store singleton resolves its Application Support
+        // directory or reads UserDefaults — see SandboxContainerMigrator.
+        SandboxContainerMigrator.migrateIfNeeded()
+    }
+
     var body: some Scene {
         // ── Main document window ──────────────────────────────────────────────
         WindowGroup("Logue") {

--- a/Logue/Models/MeetingNote.swift
+++ b/Logue/Models/MeetingNote.swift
@@ -141,7 +141,13 @@ struct MeetingNote: Identifiable, Codable {
         chatMessages = try container.decodeIfPresent([MeetingChatMessage].self, forKey: .chatMessages) ?? []
         isTrashed = try container.decodeIfPresent(Bool.self, forKey: .isTrashed) ?? false
         trashedAt = try container.decodeIfPresent(Date.self, forKey: .trashedAt)
-        audioFileURL = try container.decodeIfPresent(URL.self, forKey: .audioFileURL)
+        // Recordings made by a sandboxed build (≤ 1.0.0) persisted an absolute path
+        // inside the app container. SandboxContainerMigrator moves the file out to the
+        // real home directory but cannot rewrite paths already baked into stored JSON,
+        // so re-point it here — otherwise the player renders and plays nothing.
+        audioFileURL = try SandboxContainerMigrator.resolvingLegacyContainerPath(
+            container.decodeIfPresent(URL.self, forKey: .audioFileURL)
+        )
     }
 
     // MARK: - Computed

--- a/Logue/Resources/Info.plist
+++ b/Logue/Resources/Info.plist
@@ -63,8 +63,6 @@
 	<false/>
 	<key>SUEnableAutomaticChecks</key>
 	<true/>
-	<key>SUEnableInstallerLauncherService</key>
-	<true/>
 	<key>SUFeedURL</key>
 	<string>https://raw.githubusercontent.com/bitwize-ai/Logue/main/appcast.xml</string>
 	<key>SUPublicEDKey</key>

--- a/Logue/Resources/Logue.release.entitlements
+++ b/Logue/Resources/Logue.release.entitlements
@@ -23,8 +23,10 @@
 	     runtime exception below is justified individually.
 
 	     If the sandbox is ever re-enabled, the entire Logue/CrossApp feature set stops
-	     working — see LogueTests/ReleaseEntitlementsTests.swift, which fails the build
-	     if this flips back to true. -->
+	     working, and nothing fails at build time to tell you. Two guards catch it: the
+	     "Verify app sandbox stays disabled" step in .github/workflows/ci.yml, which is
+	     what actually gates a PR because CI does not run tests, and
+	     LogueTests/ReleaseEntitlementsTests.swift for local test runs. -->
 	<key>com.apple.security.app-sandbox</key>
 	<false/>
 	<key>com.apple.security.automation.apple-events</key>

--- a/Logue/Resources/Logue.release.entitlements
+++ b/Logue/Resources/Logue.release.entitlements
@@ -2,10 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<!-- App Sandbox is intentionally OFF.
+
+	     Logue is a cross-app writing assistant: ⌘⌃I reads the selected text out of
+	     whatever app is frontmost, inserts/replaces text at the cursor, and listens
+	     for a global hotkey. All of that requires being an Accessibility API *client*
+	     (AXUIElementCopyAttributeValue against another process, synthetic CGEvents,
+	     NSEvent global monitors).
+
+	     macOS does not allow a sandboxed process to be an Accessibility client. There
+	     is no entitlement that grants it. A sandboxed app calling
+	     AXIsProcessTrustedWithOptions(prompt: true) gets `false` back, no prompt is
+	     shown, and — critically — TCC never creates an entry, so the app never appears
+	     in System Settings → Privacy & Security → Accessibility and the user cannot
+	     even add it manually. That was https://github.com/bitwize-ai/Logue/issues/22.
+
+	     Logue is distributed with Developer ID + notarization via GitHub Releases and
+	     Sparkle, not the Mac App Store, so the sandbox is not required. Hardened
+	     Runtime stays ON (ENABLE_HARDENED_RUNTIME in project.yml) and every hardened
+	     runtime exception below is justified individually.
+
+	     If the sandbox is ever re-enabled, the entire Logue/CrossApp feature set stops
+	     working — see LogueTests/ReleaseEntitlementsTests.swift, which fails the build
+	     if this flips back to true. -->
 	<key>com.apple.security.app-sandbox</key>
-	<true/>
-	<key>com.apple.security.files.user-selected.read-write</key>
-	<true/>
+	<false/>
 	<key>com.apple.security.automation.apple-events</key>
 	<true/>
 	<!-- Required by MLX framework for Metal compute shader JIT compilation -->
@@ -17,6 +38,10 @@
 	<!-- Required to load MLX and FluidAudio dynamic frameworks -->
 	<key>com.apple.security.cs.disable-library-validation</key>
 	<true/>
+	<!-- The entitlements below are sandbox-only and inert while the sandbox is off.
+	     They are kept so the declared capability set stays a truthful description of
+	     what the app touches, and so re-enabling the sandbox does not silently drop
+	     microphone / calendar / contacts / network access. -->
 	<key>com.apple.security.device.audio-input</key>
 	<true/>
 	<key>com.apple.security.personal-information.calendars</key>
@@ -26,13 +51,5 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
-	<!-- Required for Sparkle auto-update in sandboxed app: allows Mach IPC with the
-	     out-of-sandbox Installer and StatusInfo helpers launched by Sparkle's XPC services.
-	     See: https://sparkle-project.org/documentation/sandboxing/ -->
-	<key>com.apple.security.temporary-exception.mach-lookup.global-name</key>
-	<array>
-		<string>com.bitwize.logue-spki</string>
-		<string>com.bitwize.logue-spks</string>
-	</array>
 </dict>
 </plist>

--- a/Logue/Services/SandboxContainerMigrator.swift
+++ b/Logue/Services/SandboxContainerMigrator.swift
@@ -1,0 +1,159 @@
+import Foundation
+import os.log
+
+/// One-time relocation of user data out of the legacy App Sandbox container.
+///
+/// Releases up to and including 1.0.0 shipped sandboxed. Under the sandbox,
+/// `URL.applicationSupportDirectory`, `NSHomeDirectory()` and `UserDefaults` all
+/// resolve inside `~/Library/Containers/com.bitwize.logue/Data/…`.
+///
+/// The sandbox was removed so Logue can act as an Accessibility API client — macOS
+/// refuses to list a sandboxed app in Privacy & Security → Accessibility at all
+/// (https://github.com/bitwize-ai/Logue/issues/22). That flip re-points every one of
+/// those lookups at the real home directory, which would orphan an upgrading user's
+/// meetings, documents, spaces, vector store and several GB of downloaded models.
+///
+/// This runs once, as early as possible in `LogueApp.init()` — before any store
+/// singleton resolves its directory — and moves the container's contents to their
+/// unsandboxed equivalents.
+enum SandboxContainerMigrator {
+    private static let logger = Logger(subsystem: AppConstants.bundleID, category: "SandboxMigration")
+
+    /// Paths to relocate. The container mirrors the home directory layout, so the
+    /// same relative path describes both the source and the destination.
+    private static let relativePaths = [
+        "Library/Application Support/Logue", // meetings, documents, templates, spaces, scheduled tasks
+        "Library/Application Support/\(AppConstants.bundleID)", // vector store + meeting memory index
+        "Library/Application Support/FluidAudio", // diarization models (~700 MB)
+        "Library/Application Support/LocalLLM", // MLX models, when stored under Application Support
+        ".localllmclient", // MLX model store (~2 GB)
+        ".cache/huggingface", // Hugging Face download cache
+    ]
+
+    // MARK: - Entry Point
+
+    /// Moves legacy container data into place if this is the first unsandboxed launch.
+    ///
+    /// Safe to call unconditionally: it no-ops once the migration has run, when no
+    /// container exists (clean install), and when still running sandboxed.
+    static func migrateIfNeeded() {
+        let defaults = UserDefaults.standard
+        guard !defaults.bool(forKey: AppConstants.UserDefaultsKeys.sandboxContainerMigrationCompleted) else { return }
+
+        guard let container = legacyContainerDataDirectory else {
+            // Nothing to migrate — record it so we stop looking on every launch.
+            defaults.set(true, forKey: AppConstants.UserDefaultsKeys.sandboxContainerMigrationCompleted)
+            return
+        }
+
+        logger.info("Legacy sandbox container found — migrating user data out of it")
+        migratePreferences(from: container)
+        for relativePath in relativePaths {
+            migrateItem(relativePath, from: container)
+        }
+
+        defaults.set(true, forKey: AppConstants.UserDefaultsKeys.sandboxContainerMigrationCompleted)
+        logger.info("Sandbox container migration complete")
+    }
+
+    // MARK: - Location
+
+    /// The legacy container's `Data` directory, or `nil` when there is nothing to migrate.
+    private static var legacyContainerDataDirectory: URL? {
+        // Inside a sandbox `NSHomeDirectory()` *is* the container, so the migration is
+        // both meaningless and destructive. Bail out.
+        guard !isSandboxed else { return nil }
+
+        let container = url(
+            realHomeDirectory,
+            "Library/Containers/\(AppConstants.bundleID)/Data"
+        )
+        return FileManager.default.fileExists(atPath: container.path) ? container : nil
+    }
+
+    private static var realHomeDirectory: URL {
+        URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
+    }
+
+    /// `APP_SANDBOX_CONTAINER_ID` is injected into the environment of every sandboxed
+    /// process, so its presence is a reliable runtime sandbox check.
+    private static var isSandboxed: Bool {
+        ProcessInfo.processInfo.environment["APP_SANDBOX_CONTAINER_ID"] != nil
+    }
+
+    /// Appends a `/`-separated relative path one component at a time so directory
+    /// names containing spaces ("Application Support") are handled correctly.
+    private static func url(_ base: URL, _ relativePath: String) -> URL {
+        relativePath
+            .split(separator: "/")
+            .reduce(base) { $0.appendingPathComponent(String($1)) }
+    }
+
+    // MARK: - Files
+
+    private static func migrateItem(_ relativePath: String, from container: URL) {
+        let fileManager = FileManager.default
+        let source = url(container, relativePath)
+        guard fileManager.fileExists(atPath: source.path) else { return }
+
+        let destination = url(realHomeDirectory, relativePath)
+        guard !fileManager.fileExists(atPath: destination.path) else {
+            // Never clobber data an unsandboxed build already wrote. This happens on
+            // machines that ran both a sandboxed release and a local Debug build.
+            logger.notice("Skipping \(relativePath, privacy: .public) — destination already exists")
+            return
+        }
+
+        do {
+            try fileManager.createDirectory(
+                at: destination.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            // Container and home are on the same volume, so this is a rename: instant,
+            // and it needs no extra free space — which matters for the multi-GB models.
+            try fileManager.moveItem(at: source, to: destination)
+            logger.info("Migrated \(relativePath, privacy: .public) out of the sandbox container")
+        } catch {
+            logger.error(
+                "Failed to migrate \(relativePath, privacy: .public): \(error.localizedDescription, privacy: .public)"
+            )
+        }
+    }
+
+    // MARK: - Preferences
+
+    /// Copies the container's preference domain into the real one, without overwriting
+    /// anything the unsandboxed domain has already set.
+    private static func migratePreferences(from container: URL) {
+        let plist = url(container, "Library/Preferences/\(AppConstants.bundleID).plist")
+        guard FileManager.default.fileExists(atPath: plist.path) else { return }
+
+        guard let legacy = readPreferences(at: plist) else { return }
+
+        let defaults = UserDefaults.standard
+        var migrated = 0
+        for (key, value) in legacy where defaults.object(forKey: key) == nil {
+            // System-managed domains rebuild themselves; carrying them over can
+            // resurrect stale sandbox-era state.
+            guard !key.hasPrefix("com.apple.") else { continue }
+            defaults.set(value, forKey: key)
+            migrated += 1
+        }
+        logger.info("Migrated \(migrated) preference key(s) out of the sandbox container")
+    }
+
+    private static func readPreferences(at plist: URL) -> [String: Any]? {
+        do {
+            let data = try Data(contentsOf: plist)
+            let parsed = try PropertyListSerialization.propertyList(from: data, format: nil)
+            guard let dictionary = parsed as? [String: Any] else {
+                logger.error("Legacy preferences plist was not a dictionary — skipping")
+                return nil
+            }
+            return dictionary
+        } catch {
+            logger.error("Failed to read legacy preferences: \(error.localizedDescription, privacy: .public)")
+            return nil
+        }
+    }
+}

--- a/Logue/Services/SandboxContainerMigrator.swift
+++ b/Logue/Services/SandboxContainerMigrator.swift
@@ -92,32 +92,105 @@ enum SandboxContainerMigrator {
     // MARK: - Files
 
     private static func migrateItem(_ relativePath: String, from container: URL) {
-        let fileManager = FileManager.default
         let source = url(container, relativePath)
-        guard fileManager.fileExists(atPath: source.path) else { return }
+        guard FileManager.default.fileExists(atPath: source.path) else { return }
+        move(source, to: url(realHomeDirectory, relativePath), label: relativePath)
+    }
 
-        let destination = url(realHomeDirectory, relativePath)
-        guard !fileManager.fileExists(atPath: destination.path) else {
-            // Never clobber data an unsandboxed build already wrote. This happens on
-            // machines that ran both a sandboxed release and a local Debug build.
-            logger.notice("Skipping \(relativePath, privacy: .public) — destination already exists")
+    /// Moves `source` onto `destination`, merging directories that already exist.
+    ///
+    /// Never overwrites: anything already present at the destination wins and the
+    /// container copy is left in place and logged, so a machine that ran both a
+    /// sandboxed release and a local Debug build cannot lose either side.
+    ///
+    /// Merging rather than skipping the whole tree matters for shared locations like
+    /// `~/.cache/huggingface`, which already exists on any machine that has touched
+    /// Hugging Face tooling — skipping it wholesale would strand gigabytes of models
+    /// in the container and force a re-download.
+    /// Internal rather than private so `SandboxContainerMigratorTests` can exercise the
+    /// merge and non-clobber rules against a scratch directory. Call only from
+    /// `migrateItem` and its own recursion.
+    static func move(_ source: URL, to destination: URL, label: String) {
+        let fileManager = FileManager.default
+
+        guard fileManager.fileExists(atPath: destination.path) else {
+            do {
+                try fileManager.createDirectory(
+                    at: destination.deletingLastPathComponent(),
+                    withIntermediateDirectories: true
+                )
+                // Container and home are on the same volume, so this is a rename:
+                // instant, and it needs no extra free space — which matters for the
+                // multi-GB model directories.
+                try fileManager.moveItem(at: source, to: destination)
+                logger.info("Migrated \(label, privacy: .public) out of the sandbox container")
+            } catch {
+                logger.error(
+                    "Failed to migrate \(label, privacy: .public): \(error.localizedDescription, privacy: .public)"
+                )
+            }
             return
         }
 
+        guard isDirectory(source), isDirectory(destination) else {
+            logger.notice("Left \(label, privacy: .public) in the container — destination already exists")
+            return
+        }
+
+        // Both sides are directories: recurse so non-colliding children still migrate.
+        let children: [String]
         do {
-            try fileManager.createDirectory(
-                at: destination.deletingLastPathComponent(),
-                withIntermediateDirectories: true
-            )
-            // Container and home are on the same volume, so this is a rename: instant,
-            // and it needs no extra free space — which matters for the multi-GB models.
-            try fileManager.moveItem(at: source, to: destination)
-            logger.info("Migrated \(relativePath, privacy: .public) out of the sandbox container")
+            children = try fileManager.contentsOfDirectory(atPath: source.path)
         } catch {
             logger.error(
-                "Failed to migrate \(relativePath, privacy: .public): \(error.localizedDescription, privacy: .public)"
+                "Failed to enumerate \(label, privacy: .public): \(error.localizedDescription, privacy: .public)"
+            )
+            return
+        }
+        for child in children {
+            move(
+                source.appendingPathComponent(child),
+                to: destination.appendingPathComponent(child),
+                label: "\(label)/\(child)"
             )
         }
+    }
+
+    private static func isDirectory(_ url: URL) -> Bool {
+        var isDirectory: ObjCBool = false
+        let exists = FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory)
+        return exists && isDirectory.boolValue
+    }
+
+    // MARK: - Stale Absolute Paths
+
+    /// The path segment the sandbox inserted in front of every absolute path.
+    static var containerPathSegment: String {
+        "/Library/Containers/\(AppConstants.bundleID)/Data"
+    }
+
+    /// Rewrites an absolute file URL captured while sandboxed so it points at the
+    /// migrated location.
+    ///
+    /// `MeetingNote.audioFileURL` is the only absolute path Logue persists. It is
+    /// recorded when a recording finishes and stored verbatim, so meetings captured by
+    /// a sandboxed build (≤ 1.0.0) still reference
+    /// `…/Library/Containers/com.bitwize.logue/Data/Library/Application Support/…`
+    /// after `migrateIfNeeded()` has moved the file out to the real home directory.
+    /// Without this rewrite `AudioPlaybackView` renders a player for a file that is no
+    /// longer at that path and playback silently does nothing.
+    ///
+    /// Returns the original URL when nothing exists at the rewritten path — the file is
+    /// still in the container whenever a migration step was skipped as a non-clobber.
+    static func resolvingLegacyContainerPath(_ url: URL?) -> URL? {
+        guard let url, url.isFileURL else { return url }
+
+        let path = url.path(percentEncoded: false)
+        guard let segment = path.range(of: containerPathSegment) else { return url }
+
+        let rewritten = path.replacingCharacters(in: segment, with: "")
+        guard FileManager.default.fileExists(atPath: rewritten) else { return url }
+        return URL(fileURLWithPath: rewritten)
     }
 
     // MARK: - Preferences

--- a/LogueTests/DocumentReplaceTests.swift
+++ b/LogueTests/DocumentReplaceTests.swift
@@ -141,8 +141,8 @@ struct DocumentReplaceTests {
         #expect(doc.blocks[0].textContent == "nothing here")
     }
 
-    // A multi-UTF-16 character (emoji) before the match makes the UTF-16 offset
-    // exceed the grapheme count; indexing the String with that offset used to trap.
+    /// A multi-UTF-16 character (emoji) before the match makes the UTF-16 offset
+    /// exceed the grapheme count; indexing the String with that offset used to trap.
     @Test("Whole-word search is safe and correct with an emoji before the match")
     func wholeWordSearchWithLeadingEmoji() throws {
         let doc = document([.paragraph(id: UUID(), text: "👩‍💻 word and words")])
@@ -155,7 +155,7 @@ struct DocumentReplaceTests {
         // Only the standalone "word" matches; the emoji is a boundary and "words" is excluded.
         #expect(state.matches.count == 1)
         let match = try #require(state.matches.first)
-        let text = doc.blocks[0].textContent as NSString
+        let text = try #require(doc.blocks[0].textContent) as NSString
         #expect(text.substring(with: match.range) == "word")
     }
 }

--- a/LogueTests/ReleaseEntitlementsTests.swift
+++ b/LogueTests/ReleaseEntitlementsTests.swift
@@ -1,0 +1,70 @@
+import Foundation
+@testable import Logue
+import Testing
+
+/// Guards the entitlement that broke cross-app features in 1.0.0.
+///
+/// Release shipped with `com.apple.security.app-sandbox = true`, and a sandboxed
+/// process cannot be an Accessibility API client: `AXIsProcessTrustedWithOptions`
+/// returns false, no prompt appears, and TCC never lists the app under
+/// Privacy & Security → Accessibility (issue #22). Re-enabling the sandbox silently
+/// kills ⌘⌃I, global hotkeys, Command Center and text replacement — nothing fails
+/// loudly at build time, so it is checked here instead.
+@Suite("Release entitlements")
+struct ReleaseEntitlementsTests {
+    /// Repo root, derived from this file's location so the test does not depend on
+    /// the test bundle's resources or the working directory.
+    private static var repositoryRoot: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent() // LogueTests/
+            .deletingLastPathComponent() // repo root
+    }
+
+    private func entitlements(named name: String) throws -> [String: Any] {
+        let url = Self.repositoryRoot
+            .appendingPathComponent("Logue")
+            .appendingPathComponent("Resources")
+            .appendingPathComponent(name)
+        let data = try Data(contentsOf: url)
+        let parsed = try PropertyListSerialization.propertyList(from: data, format: nil)
+        return try #require(parsed as? [String: Any], "\(name) is not a plist dictionary")
+    }
+
+    @Test("Release is not sandboxed, so it can be an Accessibility API client")
+    func releaseIsNotSandboxed() throws {
+        let plist = try entitlements(named: "Logue.release.entitlements")
+        let sandbox = try #require(
+            plist["com.apple.security.app-sandbox"] as? Bool,
+            "Release entitlements must state the sandbox setting explicitly"
+        )
+        #expect(sandbox == false, "Enabling the sandbox breaks every Logue/CrossApp feature — see issue #22")
+    }
+
+    @Test("Debug is not sandboxed either, so Debug and Release behave the same")
+    func debugIsNotSandboxed() throws {
+        let plist = try entitlements(named: "Logue.entitlements")
+        let sandbox = try #require(plist["com.apple.security.app-sandbox"] as? Bool)
+        #expect(sandbox == false)
+    }
+
+    @Test("Release keeps the hardened-runtime exceptions MLX needs")
+    func releaseKeepsHardenedRuntimeExceptions() throws {
+        let plist = try entitlements(named: "Logue.release.entitlements")
+        for key in [
+            "com.apple.security.cs.allow-jit",
+            "com.apple.security.cs.allow-unsigned-executable-memory",
+            "com.apple.security.cs.disable-library-validation",
+        ] {
+            #expect(plist[key] as? Bool == true, "Release is missing \(key)")
+        }
+    }
+
+    @Test("Release drops the sandbox-only Sparkle mach-lookup exception")
+    func releaseDropsSandboxOnlySparkleException() throws {
+        let plist = try entitlements(named: "Logue.release.entitlements")
+        #expect(
+            plist["com.apple.security.temporary-exception.mach-lookup.global-name"] == nil,
+            "Sparkle's XPC mach-lookup exception is sandbox-only and inert without the sandbox"
+        )
+    }
+}

--- a/LogueTests/SandboxContainerMigratorTests.swift
+++ b/LogueTests/SandboxContainerMigratorTests.swift
@@ -1,0 +1,175 @@
+import Foundation
+@testable import Logue
+import Testing
+
+/// Covers the two ways the unsandboxing migration could lose or strand user data:
+/// stale absolute paths baked into stored meetings, and destinations that already
+/// exist on machines that ran both a sandboxed release and a local Debug build.
+@Suite("SandboxContainerMigrator")
+struct SandboxContainerMigratorTests {
+    // MARK: - Scratch Helpers
+
+    /// A unique scratch directory. The migrator only ever looks for the container path
+    /// *segment*, so an arbitrary prefix stands in for the real home directory.
+    private func makeScratch() throws -> URL {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("SandboxMigratorTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return root
+    }
+
+    private func write(_ contents: String, to url: URL) throws {
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data(contents.utf8).write(to: url)
+    }
+
+    private func read(_ url: URL) -> String? {
+        guard let data = FileManager.default.contents(atPath: url.path) else { return nil }
+        return String(bytes: data, encoding: .utf8)
+    }
+
+    private func exists(_ url: URL) -> Bool {
+        FileManager.default.fileExists(atPath: url.path)
+    }
+
+    // MARK: - Stale Absolute Paths
+
+    @Test("A container audio path is rewritten once the file has been migrated")
+    func rewritesMigratedContainerPath() throws {
+        let scratch = try makeScratch()
+        defer { try? FileManager.default.removeItem(at: scratch) }
+
+        let relative = "Library/Application Support/\(AppConstants.bundleID)/Recordings/meeting.m4a"
+        let migrated = scratch.appendingPathComponent(relative)
+        try write("audio", to: migrated)
+
+        // What a sandboxed 1.0.0 build would have persisted.
+        let stale = scratch
+            .appendingPathComponent("Library/Containers/\(AppConstants.bundleID)/Data")
+            .appendingPathComponent(relative)
+
+        let resolved = SandboxContainerMigrator.resolvingLegacyContainerPath(stale)
+        #expect(resolved?.path == migrated.path)
+    }
+
+    @Test("A container audio path is left alone when the file was not migrated")
+    func keepsUnmigratedContainerPath() throws {
+        let scratch = try makeScratch()
+        defer { try? FileManager.default.removeItem(at: scratch) }
+
+        // The file is still in the container — a migration step was skipped as a
+        // non-clobber, so the original path is the one that actually works.
+        let stale = scratch
+            .appendingPathComponent("Library/Containers/\(AppConstants.bundleID)/Data")
+            .appendingPathComponent("Library/Application Support/Logue/Recordings/meeting.m4a")
+        try write("audio", to: stale)
+
+        #expect(SandboxContainerMigrator.resolvingLegacyContainerPath(stale)?.path == stale.path)
+    }
+
+    @Test("Paths outside the container and nil are passed through untouched")
+    func passesThroughNonContainerPaths() throws {
+        let scratch = try makeScratch()
+        defer { try? FileManager.default.removeItem(at: scratch) }
+
+        let ordinary = scratch.appendingPathComponent("Library/Application Support/Logue/a.m4a")
+        try write("audio", to: ordinary)
+
+        #expect(SandboxContainerMigrator.resolvingLegacyContainerPath(ordinary)?.path == ordinary.path)
+        #expect(SandboxContainerMigrator.resolvingLegacyContainerPath(nil) == nil)
+
+        let remote = try #require(URL(string: "https://example.com/a.m4a"))
+        #expect(SandboxContainerMigrator.resolvingLegacyContainerPath(remote) == remote)
+    }
+
+    @Test("Decoding a meeting recorded under the sandbox re-points its audio URL")
+    func decodingRewritesStaleAudioURL() throws {
+        let scratch = try makeScratch()
+        defer { try? FileManager.default.removeItem(at: scratch) }
+
+        let relative = "Library/Application Support/\(AppConstants.bundleID)/Recordings/meeting.m4a"
+        let migrated = scratch.appendingPathComponent(relative)
+        try write("audio", to: migrated)
+
+        let stale = scratch
+            .appendingPathComponent("Library/Containers/\(AppConstants.bundleID)/Data")
+            .appendingPathComponent(relative)
+
+        var meeting = MeetingNote()
+        meeting.audioFileURL = stale
+        let encoded = try JSONEncoder().encode(meeting)
+
+        let decoded = try JSONDecoder().decode(MeetingNote.self, from: encoded)
+        #expect(decoded.audioFileURL?.path == migrated.path)
+    }
+
+    // MARK: - Merge / Non-Clobber
+
+    @Test("A missing destination is moved wholesale")
+    func movesWhenDestinationIsAbsent() throws {
+        let scratch = try makeScratch()
+        defer { try? FileManager.default.removeItem(at: scratch) }
+
+        let source = scratch.appendingPathComponent("src/models")
+        let destination = scratch.appendingPathComponent("dst/models")
+        try write("weights", to: source.appendingPathComponent("a.bin"))
+
+        SandboxContainerMigrator.move(source, to: destination, label: "models")
+
+        #expect(read(destination.appendingPathComponent("a.bin")) == "weights")
+        #expect(!exists(source))
+    }
+
+    @Test("An existing directory is merged, not skipped, so nothing is stranded")
+    func mergesIntoExistingDirectory() throws {
+        let scratch = try makeScratch()
+        defer { try? FileManager.default.removeItem(at: scratch) }
+
+        let source = scratch.appendingPathComponent("src/cache")
+        let destination = scratch.appendingPathComponent("dst/cache")
+        try write("from-container", to: source.appendingPathComponent("only-in-container.bin"))
+        try write("existing", to: destination.appendingPathComponent("only-in-home.bin"))
+
+        SandboxContainerMigrator.move(source, to: destination, label: "cache")
+
+        // The non-colliding child migrates instead of being stranded with the parent.
+        #expect(read(destination.appendingPathComponent("only-in-container.bin")) == "from-container")
+        #expect(read(destination.appendingPathComponent("only-in-home.bin")) == "existing")
+    }
+
+    @Test("A colliding file is never overwritten and stays in the container")
+    func neverOverwritesExistingFile() throws {
+        let scratch = try makeScratch()
+        defer { try? FileManager.default.removeItem(at: scratch) }
+
+        let source = scratch.appendingPathComponent("src/cache")
+        let destination = scratch.appendingPathComponent("dst/cache")
+        try write("container-copy", to: source.appendingPathComponent("shared.bin"))
+        try write("home-copy", to: destination.appendingPathComponent("shared.bin"))
+
+        SandboxContainerMigrator.move(source, to: destination, label: "cache")
+
+        #expect(read(destination.appendingPathComponent("shared.bin")) == "home-copy")
+        // Neither copy is lost — the container one is left behind for recovery.
+        #expect(read(source.appendingPathComponent("shared.bin")) == "container-copy")
+    }
+
+    @Test("Merging recurses into nested directories that exist on both sides")
+    func mergesNestedDirectories() throws {
+        let scratch = try makeScratch()
+        defer { try? FileManager.default.removeItem(at: scratch) }
+
+        let source = scratch.appendingPathComponent("src/Logue")
+        let destination = scratch.appendingPathComponent("dst/Logue")
+        try write("old", to: source.appendingPathComponent("meetings/a.json"))
+        try write("new", to: destination.appendingPathComponent("meetings/b.json"))
+
+        SandboxContainerMigrator.move(source, to: destination, label: "Logue")
+
+        #expect(read(destination.appendingPathComponent("meetings/a.json")) == "old")
+        #expect(read(destination.appendingPathComponent("meetings/b.json")) == "new")
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -84,10 +84,11 @@ targets:
         SUPublicEDKey: "ZjxgaWvBg01MnO4Nsjb/19mzMPmTR4H5Bp3LMV8CJRs="
         SUEnableAutomaticChecks: true
         SUAutomaticallyUpdate: false
-        SUEnableInstallerLauncherService: true
     # Entitlements are static files (not generated here) so each build config can
-    # sign with its own: Debug → Logue.entitlements (sandbox off, dev convenience),
-    # Release → Logue.release.entitlements (sandboxed). Wired in settings.configs below.
+    # sign with its own: Debug → Logue.entitlements, Release → Logue.release.entitlements.
+    # Neither is sandboxed — Logue needs to be an Accessibility API client for its
+    # cross-app features, which the sandbox forbids (see the comment at the top of
+    # Logue.release.entitlements). Wired in settings.configs below.
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.bitwize.logue
@@ -100,9 +101,9 @@ targets:
         # Debug uses the non-sandboxed dev entitlements for development convenience.
         Debug:
           CODE_SIGN_ENTITLEMENTS: Logue/Resources/Logue.entitlements
-        # Release builds are sandboxed, so a local `xcodebuild archive -configuration
-        # Release` matches what the CI release workflow ships instead of silently
-        # producing an unsandboxed app.
+        # Release keeps its own entitlements file so a local `xcodebuild archive
+        # -configuration Release` signs with exactly what the CI release workflow
+        # ships (Release omits the iCloud entitlements Debug carries).
         Release:
           CODE_SIGN_ENTITLEMENTS: Logue/Resources/Logue.release.entitlements
     dependencies:


### PR DESCRIPTION
Fixes #22.

## Root cause

Release builds shipped with `com.apple.security.app-sandbox = true`. **A sandboxed process cannot be an Accessibility API client** — there is no entitlement that grants it. `AXIsProcessTrustedWithOptions(prompt: true)` in `AccessibilityService.checkAccessibilityPermission` returns `false`, no prompt is shown, and TCC never creates an entry. So Logue never appears in System Settings → Privacy & Security → Accessibility, and the user cannot add it manually either.

Mic / Speech / Calendar were unaffected because those *are* sandbox-compatible, which is why the reporter saw only Accessibility fail. Debug builds use `Logue.entitlements` with the sandbox **off**, so this never reproduced in development. `git log -S` confirms the sandbox has been on since the initial commit — no release has ever had working cross-app features.

**Verified on the shipped 1.0.0** in `/Applications`:
```
$ codesign -d --entitlements - /Applications/Logue.app
    [Key] com.apple.security.app-sandbox
        [Bool] true
```

### Blast radius is wider than the issue reports

The sandbox silently disabled everything else that needs the same trust:

| Broken | Where |
| --- | --- |
| ⌘⌃I inline assistant, global hotkeys | `NSEvent.addGlobalMonitorForEvents` in `ShortcutManager.swift:52`, `AppDelegate.swift:420`, `MenuBarCompanion.swift:28` |
| Command Center | `CommandCenterController.swift:385` |
| Text replacement / insertion | synthetic `CGEvent` Cmd+C / Cmd+V, `AccessibilityService.swift:369-423` |

## Fix

Logue is distributed Developer ID + notarized via GitHub Releases and Sparkle — **not the Mac App Store** — so the sandbox is not required. **Hardened Runtime stays ON** and every exception remains individually justified.

- **`Logue.release.entitlements`** — `app-sandbox` → `false`, with a comment explaining why it must stay off. Drops two keys that are inert without the sandbox: `files.user-selected.read-write` and the Sparkle `mach-lookup` temporary exception.
- **`project.yml`** — drops `SUEnableInstallerLauncherService`.

### Sparkle / auto-update is unaffected

Per [Sparkle's sandboxing guide](https://sparkle-project.org/documentation/sandboxing/), the XPC services and `SUEnableInstallerLauncherService` exist *only* to work around the sandbox — "if you do not sandbox your application, you should skip this guide." Unsandboxed Sparkle installs directly via `Autoupdate`/`Updater.app`.

Critically, the 1.0.0 → next upgrade is performed by the **already-installed sandboxed 1.0.0** using its own `Installer.xpc`. The new bundle's entitlements have no bearing on that, so the in-flight update path is untouched.

### Data migration — the part that would have bitten us

Unsandboxing re-points `URL.applicationSupportDirectory`, `NSHomeDirectory()` and `UserDefaults` from the container at the real home directory. Shipping the entitlement change alone would have made every upgrading user's data vanish. Measured in the container on a real 1.0.0 install:

| Path | Size |
| --- | --- |
| `Application Support/Logue` (meetings, documents, templates, spaces) | 464K |
| `Application Support/com.bitwize.logue` (vector store, memory index) | 372K |
| `Application Support/FluidAudio` (diarization models) | 697M |
| `.localllmclient` (MLX models) | 2.1G |
| `.cache/huggingface` | 2.1G |

New `SandboxContainerMigrator` runs once in `LogueApp.init()` — before any store resolves its directory — and:

- no-ops on a clean install, once migrated, and if somehow running sandboxed
- moves same-volume, so it is a rename: instant, and needs no extra free space for the ~3 GB of models
- **never overwrites an existing destination** (matters on machines that ran both a release and a local Debug build)
- merges the container's preference domain without clobbering existing keys, skipping `com.apple.*`
- logs every step through `do/catch`, no silent `try?`

Keychain is unaffected: `KeychainHelper` uses the legacy file keychain, whose ACLs are bound to the signing identity, which does not change.

## Regression guards

Nothing fails at build time if someone flips the sandbox back on, so this is checked explicitly in two places:

- `LogueTests/ReleaseEntitlementsTests.swift` (4 tests)
- a CI step in the lint job, since CI does not run tests

**Both were confirmed to actually fail** when `app-sandbox` is set back to `true`:
```
✘ Test "Release is not sandboxed, so it can be an Accessibility API client" failed:
  Expectation failed: (sandbox → true) == false
::error file=Logue/Resources/Logue.release.entitlements::app-sandbox is 'true', expected 'false'
```

## Verification

- `xcodebuild build -configuration Release` → **BUILD SUCCEEDED**
- Signed with the release entitlements → `app-sandbox = false`, `mach-lookup` gone
- `SUEnableInstallerLauncherService` absent from the built `Info.plist`; `SUFeedURL` intact
- `swiftformat --lint` (0/380) and `swiftlint --strict` (0 violations in 408 files) both clean
- 14 tests pass across `ReleaseEntitlementsTests` + `DocumentReplaceTests`

**Not verified end-to-end:** the actual TCC grant on a notarized build — that needs a real signed release. Worth confirming on the first 1.0.1 build before closing the issue.

## Unrelated drive-by

The test target did not compile: `DocumentReplaceTests.swift:158` broke when `textContent` became `String?` in 1e83485, plus a `docComments` lint violation in the same file. CI runs swiftformat only inside `Logue/` and does not run tests, so both went unnoticed. Fixed so the suite runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)