### PR TITLE
Support pasting over a multi-block selection (Cmd+V)

### DIFF
--- a/Logue.xcodeproj/project.pbxproj
+++ b/Logue.xcodeproj/project.pbxproj
@@ -214,6 +214,7 @@
 		6D86DD0D26811B19EEE00299 /* AIContentScorer.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCC95C3045D2301DCC960849 /* AIContentScorer.swift */; };
 		6E33CC2D3A37790D824199A3 /* MeetingStore+Diarization.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7FD01A02C6FB9C64A0238CF /* MeetingStore+Diarization.swift */; };
 		6E577F8B48F4A11B36E16B66 /* SelectableOptionCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54288BA1E89F95FD74442B71 /* SelectableOptionCard.swift */; };
+		6E66E9B993B63623F605E552 /* BlockPasteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88C42C0A1E60F8FC22AC2EF3 /* BlockPasteTests.swift */; };
 		6EE6B461C7E6CA280E8C8661 /* HierarchicalSpaceMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4714BA50A68B3093B932CB4 /* HierarchicalSpaceMenu.swift */; };
 		6EF0995F3E06CB5ED24FD625 /* DocumentListContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A864D7C5937FF77CB9835242 /* DocumentListContentView.swift */; };
 		70A6886DC7BEF1D8F93BCC40 /* LocationTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DFCD2049B54A1F08F0C8E89 /* LocationTool.swift */; };
@@ -666,6 +667,7 @@
 		87A5F89112EFC50A714AFD79 /* SandboxContainerMigratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SandboxContainerMigratorTests.swift; sourceTree = "<group>"; };
 		88018F4CBB121A88EF363BBE /* MeetingListContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingListContentView.swift; sourceTree = "<group>"; };
 		8876D7837082707205CBFC6D /* LogueApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogueApp.swift; sourceTree = "<group>"; };
+		88C42C0A1E60F8FC22AC2EF3 /* BlockPasteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockPasteTests.swift; sourceTree = "<group>"; };
 		89916892E9BF400CDC89E1FF /* WebSearchTools.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSearchTools.swift; sourceTree = "<group>"; };
 		89D2D180775E0F9C8735345F /* ShortcutsSettingsTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutsSettingsTab.swift; sourceTree = "<group>"; };
 		8A5EAC4820F6E13CFDE208D0 /* MeetingAIChatPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingAIChatPanelView.swift; sourceTree = "<group>"; };
@@ -943,6 +945,7 @@
 			children = (
 				79C6BA7C0C06C035AC3BFBD1 /* LLMIntegration */,
 				8D204801C0C2BADD68D406D7 /* BlockMoveTests.swift */,
+				88C42C0A1E60F8FC22AC2EF3 /* BlockPasteTests.swift */,
 				7A450984B8338837BFDFF868 /* BlockTypeSlashMenuTests.swift */,
 				263E3C59B8D03346E04E7C92 /* DeepLinkRoutingTests.swift */,
 				EB27F11A2333C941E28C916E /* DeepLinkTests.swift */,
@@ -1859,6 +1862,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				362E757F0940BDB7CB5E560A /* BlockMoveTests.swift in Sources */,
+				6E66E9B993B63623F605E552 /* BlockPasteTests.swift in Sources */,
 				F990F4EC5E8A9FEBA4C9FD3F /* BlockTypeSlashMenuTests.swift in Sources */,
 				8837715694AEB1053618212A /* DeepLinkRoutingTests.swift in Sources */,
 				52B089BBC06F1A4DC8CFA5CE /* DeepLinkTests.swift in Sources */,

--- a/Logue/Views/Editor/BlockEditor/Model/BlockEditorDocument.swift
+++ b/Logue/Views/Editor/BlockEditor/Model/BlockEditorDocument.swift
@@ -123,6 +123,36 @@ final class BlockEditorDocument {
         }
     }
 
+    /// Replaces the selected blocks with the blocks parsed from `markdown`.
+    ///
+    /// Used when pasting over a multi-block selection. A non-contiguous selection is
+    /// removed in full and the pasted blocks land at the first selected position —
+    /// unlike a move, there is no ordering to scramble, so collapsing the gap is safe.
+    ///
+    /// Returns the ID of the last pasted block, for placing the caret.
+    @discardableResult
+    func replaceBlocks(ids selectedIDs: Set<BlockID>, withMarkdown markdown: String) -> BlockID? {
+        guard !selectedIDs.isEmpty,
+              !markdown.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              let insertIndex = blocks.firstIndex(where: { selectedIDs.contains($0.id) })
+        else { return nil }
+
+        let pasted = BlockSerializer.parse(markdown: markdown)
+        guard !pasted.isEmpty else { return nil }
+
+        recordUndo()
+        blocks.removeAll { selectedIDs.contains($0.id) }
+        blocks.insert(contentsOf: pasted, at: min(insertIndex, blocks.count))
+
+        // `parse` never returns an empty array, so the document cannot end up empty
+        // here — but keep the invariant explicit alongside the other mutators.
+        if blocks.isEmpty {
+            blocks.append(.emptyParagraph())
+        }
+
+        return pasted.last?.id
+    }
+
     // MARK: - Update Text
 
     func updateText(blockID: BlockID, text: String) {

--- a/Logue/Views/Editor/BlockEditor/Views/BlockEditorView+Reorder.swift
+++ b/Logue/Views/Editor/BlockEditor/Views/BlockEditorView+Reorder.swift
@@ -23,6 +23,29 @@ extension BlockEditorView {
     }
 }
 
+// MARK: - Block Paste
+
+extension BlockEditorView {
+    /// Replaces the multi-block selection with the clipboard's markdown.
+    ///
+    /// Only acts while a multi-block selection is active — inside a focused text
+    /// block, `BlockTextView.paste(_:)` owns the clipboard instead.
+    func pasteOverSelectedBlocks() {
+        guard multiBlockSelection.isActive,
+              let markdown = NSPasteboard.general.string(forType: .string)
+        else { return }
+
+        let selectedIDs = multiBlockSelection.selectedBlockIDs
+        multiBlockSelection.clear()
+
+        guard let focusTarget = document.replaceBlocks(ids: selectedIDs, withMarkdown: markdown)
+        else { return }
+
+        focusedBlockID = focusTarget
+        syncMarkdownFromBlocks()
+    }
+}
+
 // MARK: - Markdown Sync
 
 extension BlockEditorView {

--- a/Logue/Views/Editor/BlockEditor/Views/BlockEditorView.swift
+++ b/Logue/Views/Editor/BlockEditor/Views/BlockEditorView.swift
@@ -193,6 +193,7 @@ struct BlockEditorView: View {
                                 pendingCursorOffset = 0
                             }
                         },
+                        onPaste: { pasteOverSelectedBlocks() },
                         onMoveUp: { moveSelectedBlocks(.up) },
                         onMoveDown: { moveSelectedBlocks(.down) }
                     )

--- a/Logue/Views/Editor/BlockEditor/Views/MultiBlockKeyHandler.swift
+++ b/Logue/Views/Editor/BlockEditor/Views/MultiBlockKeyHandler.swift
@@ -12,6 +12,8 @@ struct MultiBlockKeyHandler: NSViewRepresentable {
     var onEscape: () -> Void
     /// Called when user types a character — clears selection and starts typing.
     var onTyping: ((_ character: String) -> Void)?
+    /// Cmd+V — replace the selected blocks with the clipboard contents.
+    var onPaste: (() -> Void)?
     /// Cmd+Shift+Up — move the selected blocks up one position.
     var onMoveUp: (() -> Void)?
     /// Cmd+Shift+Down — move the selected blocks down one position.
@@ -36,7 +38,8 @@ struct MultiBlockKeyHandler: NSViewRepresentable {
             onEscape: onEscape,
             onTyping: onTyping,
             onMoveUp: onMoveUp,
-            onMoveDown: onMoveDown
+            onMoveDown: onMoveDown,
+            onPaste: onPaste
         )
     }
 
@@ -49,6 +52,7 @@ struct MultiBlockKeyHandler: NSViewRepresentable {
         var onTyping: ((_ character: String) -> Void)?
         var onMoveUp: (() -> Void)?
         var onMoveDown: (() -> Void)?
+        var onPaste: (() -> Void)?
 
         init(
             onCopy: @escaping () -> Void,
@@ -58,7 +62,8 @@ struct MultiBlockKeyHandler: NSViewRepresentable {
             onEscape: @escaping () -> Void,
             onTyping: ((_ character: String) -> Void)?,
             onMoveUp: (() -> Void)?,
-            onMoveDown: (() -> Void)?
+            onMoveDown: (() -> Void)?,
+            onPaste: (() -> Void)?
         ) {
             self.onCopy = onCopy
             self.onCut = onCut
@@ -68,6 +73,7 @@ struct MultiBlockKeyHandler: NSViewRepresentable {
             self.onTyping = onTyping
             self.onMoveUp = onMoveUp
             self.onMoveDown = onMoveDown
+            self.onPaste = onPaste
         }
     }
 }
@@ -97,6 +103,9 @@ final class KeyHandlerNSView: NSView {
             return true
         case "a":
             coordinator?.onSelectAll()
+            return true
+        case "v":
+            coordinator?.onPaste?()
             return true
         default:
             return super.performKeyEquivalent(with: event)

--- a/LogueTests/BlockPasteTests.swift
+++ b/LogueTests/BlockPasteTests.swift
@@ -1,0 +1,107 @@
+import Foundation
+@testable import Logue
+import Testing
+
+/// Pasting over a multi-block selection: the selected blocks are replaced by the
+/// blocks parsed from the pasted markdown.
+@Suite("BlockPaste")
+@MainActor
+struct BlockPasteTests {
+    private func document(count: Int) -> BlockEditorDocument {
+        let doc = BlockEditorDocument()
+        doc.blocks = (0 ..< count).map { .paragraph(id: UUID(), text: "block \($0)") }
+        return doc
+    }
+
+    private func texts(_ doc: BlockEditorDocument) -> [String] {
+        doc.blocks.compactMap(\.textContent)
+    }
+
+    @Test("Pasting over one selected block replaces it")
+    func replacesSingleBlock() {
+        let doc = document(count: 3)
+        doc.replaceBlocks(ids: [doc.blocks[1].id], withMarkdown: "pasted")
+        #expect(texts(doc) == ["block 0", "pasted", "block 2"])
+    }
+
+    @Test("Pasting over a contiguous selection replaces the whole run")
+    func replacesContiguousRun() {
+        let doc = document(count: 4)
+        let ids: Set<BlockID> = [doc.blocks[1].id, doc.blocks[2].id]
+        doc.replaceBlocks(ids: ids, withMarkdown: "pasted")
+        #expect(texts(doc) == ["block 0", "pasted", "block 3"])
+    }
+
+    @Test("Multi-block markdown expands into multiple blocks")
+    func expandsIntoMultipleBlocks() {
+        let doc = document(count: 2)
+        doc.replaceBlocks(ids: [doc.blocks[0].id], withMarkdown: "one\n\ntwo")
+        #expect(texts(doc) == ["one", "two", "block 1"])
+    }
+
+    @Test("Pasted markdown keeps its block structure")
+    func preservesBlockStructure() {
+        let doc = document(count: 1)
+        doc.replaceBlocks(ids: [doc.blocks[0].id], withMarkdown: "# Heading\n\nbody")
+
+        #expect(doc.blocks.count == 2)
+        guard case let .heading(_, level, text) = doc.blocks[0] else {
+            Issue.record("Expected a heading, got \(doc.blocks[0])")
+            return
+        }
+        #expect(level == 1)
+        #expect(text == "Heading")
+    }
+
+    @Test("The returned focus target is the last pasted block")
+    func returnsLastPastedBlockAsFocusTarget() {
+        let doc = document(count: 2)
+        let focus = doc.replaceBlocks(ids: [doc.blocks[0].id], withMarkdown: "one\n\ntwo")
+        #expect(focus == doc.blocks[1].id)
+    }
+
+    @Test("Pasting empty markdown leaves the document unchanged")
+    func emptyMarkdownIsNoOp() {
+        let doc = document(count: 2)
+        doc.replaceBlocks(ids: [doc.blocks[0].id], withMarkdown: "   ")
+        #expect(texts(doc) == ["block 0", "block 1"])
+    }
+
+    @Test("Pasting with no selection leaves the document unchanged")
+    func emptySelectionIsNoOp() {
+        let doc = document(count: 2)
+        doc.replaceBlocks(ids: [], withMarkdown: "pasted")
+        #expect(texts(doc) == ["block 0", "block 1"])
+    }
+
+    @Test("Unknown block IDs are ignored")
+    func unknownIDsAreIgnored() {
+        let doc = document(count: 2)
+        doc.replaceBlocks(ids: [UUID()], withMarkdown: "pasted")
+        #expect(texts(doc) == ["block 0", "block 1"])
+    }
+
+    @Test("Replacing every block leaves a non-empty document")
+    func documentNeverBecomesEmpty() {
+        let doc = document(count: 2)
+        doc.replaceBlocks(ids: Set(doc.blocks.map(\.id)), withMarkdown: "only")
+        #expect(texts(doc) == ["only"])
+        #expect(doc.blocks.isEmpty == false)
+    }
+
+    @Test("A non-contiguous selection is replaced at the first selected position")
+    func nonContiguousSelectionCollapsesToFirstPosition() {
+        let doc = document(count: 4)
+        let ids: Set<BlockID> = [doc.blocks[1].id, doc.blocks[3].id]
+        doc.replaceBlocks(ids: ids, withMarkdown: "pasted")
+        #expect(texts(doc) == ["block 0", "pasted", "block 2"])
+    }
+
+    /// Guardrail: text paths must be exercised with multi-UTF-16 content, not only ASCII.
+    @Test("Emoji and CJK content pastes intact")
+    func unicodeContentSurvives() {
+        let doc = document(count: 1)
+        doc.replaceBlocks(ids: [doc.blocks[0].id], withMarkdown: "👩‍💻 記録 done")
+        #expect(texts(doc) == ["👩‍💻 記録 done"])
+    }
+}


### PR DESCRIPTION
## Summary

Multi-block selection supported Copy, Cut, Select All and Delete — but not Paste. `MultiBlockKeyHandler` had no `"v"` case, so `Cmd+V` did nothing while blocks were selected. You could copy a run of blocks and delete a run, but never replace one.

Adds `BlockEditorDocument.replaceBlocks(ids:withMarkdown:)`: removes the selected blocks, inserts the blocks parsed from the pasted markdown at the first selected position, and returns the last pasted block so the caret can be placed.

A non-contiguous selection collapses to that position. That differs from block *move*, which rejects non-contiguous selections — because a move would scramble document order, whereas a replace has no ordering left to preserve.

Paste inside a focused text block is untouched: `BlockTextView.paste(_:)` still owns the clipboard there, and this path only runs while `multiBlockSelection.isActive`.

## How was this verified?

- **11 new tests** — single and contiguous replacement, multi-block expansion, block-structure preservation, returned focus target, the three no-op cases (empty markdown, empty selection, unknown IDs), the non-empty-document invariant, and non-contiguous selection
- **159 tests pass, 0 fail** across all non-LLM suites — no regressions
- `make lint` clean: 0 violations in 410 files (SwiftFormat + SwiftLint `--strict`)
- Build succeeds with no new warnings

- [x] Ran `make setup` at least once, so the pre-commit hooks are installed
- [x] Builds cleanly
- [x] Lints cleanly (`make lint`)
- [x] No new `swiftlint:disable`
- [x] Added/updated tests
- [x] Ran `xcodegen generate`

## Checklist

- [x] Keeps all AI inference and data processing on-device — no network or inference code touched
- [x] No secrets, API keys, or personal data committed
- [x] Followed the standards in CONTRIBUTING.md / CLAUDE.md

## Notes for reviewers

The test suite includes an **emoji + CJK** case deliberately. `1e83485` recently fixed a whole-word find bug that trapped on multi-UTF-16 input, and it survived review partly because the surrounding tests used only ASCII (`"cat"`, `"dog"`, `"aaaa"`). Any text path in this codebase bridges `NSString` UTF-16 offsets and Swift `String` grapheme indices, so multi-byte coverage should be table stakes here.

Manual check worth doing: select several blocks, `Cmd+C`, select a different run, `Cmd+V`. The keyboard dispatch itself has no automated coverage — only the document mutation underneath does.
