### PR TITLE
docs: add project growth section to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,3 +256,31 @@ Logue is open source under the [MIT License](LICENSE) — © 2026 [Bitwize](http
 
 Some vendored dependencies under [`Vendor/`](/Vendor) are licensed separately (MIT, BSD,
 Apache-2.0); see each package for details.
+
+## 📈 Project Growth
+
+<p align="center">
+  <a href="https://star-history.com/#bitwize-ai/Logue&Date">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=bitwize-ai/Logue&type=Date&theme=dark">
+      <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=bitwize-ai/Logue&type=Date">
+      <img alt="Star history chart for Logue" src="https://api.star-history.com/svg?repos=bitwize-ai/Logue&type=Date" width="600">
+    </picture>
+  </a>
+</p>
+
+<p align="center">
+  <a aria-label="Stargazers" href="https://github.com/bitwize-ai/Logue/stargazers" target="_blank">
+    <img alt="GitHub stars" src="https://img.shields.io/github/stars/bitwize-ai/Logue?style=flat-square&labelColor=000000&color=4630EB">
+  </a>
+&ensp;
+  <a aria-label="Forks" href="https://github.com/bitwize-ai/Logue/forks" target="_blank">
+    <img alt="GitHub forks" src="https://img.shields.io/github/forks/bitwize-ai/Logue?style=flat-square&labelColor=000000&color=4630EB">
+  </a>
+&ensp;
+  <img alt="Repository views" src="https://hits.sh/github.com/bitwize-ai/Logue.svg?style=flat-square&label=views&labelColor=000000&color=4630EB">
+</p>
+
+<p align="center">
+  If Logue is useful to you, a ⭐ helps other privacy-minded people find it.
+</p>


### PR DESCRIPTION
## Summary

Adds a **Project Growth** section at the bottom of the README, below the licence: a star-history chart, stars/forks badges, and a repository view counter.

- **Star history chart** — wrapped in a `<picture>` with `prefers-color-scheme`, so it renders correctly in both light and dark GitHub themes rather than showing a white card on dark.
- **Badges** — stars, forks, and views, all matching the existing badge style at the top of the README (`flat-square`, `labelColor=000000`, brand `#4630EB`) so the footer does not look bolted on.
- A one-line prompt that a star helps other privacy-minded people find the project.

Docs only. No source, build, or workflow changes.

## How was this verified?

Each endpoint was requested directly rather than assumed:

| Endpoint | Result |
| --- | --- |
| `img.shields.io` stars | HTTP 200, `image/svg+xml` |
| `img.shields.io` forks | HTTP 200, `image/svg+xml` |
| `hits.sh` views | HTTP 200, `image/svg+xml` |
| `api.star-history.com` | **5xx/404 at the time of writing** |

⚠️ **Worth a look before merging.** The star-history service was returning errors while this was prepared — including for `sindresorhus/awesome`, so it is a service-wide outage rather than anything specific to this repo or a malformed URL. The URL is the canonical form used across many READMEs, and this repo has enough history to chart, so it should render once the service recovers. If it stays unreliable, `https://starchart.cc/bitwize-ai/Logue.svg` is a drop-in replacement.

## Note on the view counter

GitHub proxies README images through its camo cache, so the counter service sees GitHub's proxy rather than visitor IP addresses — which suits the project's privacy positioning. The trade-off is that camo caching suppresses some hits, so the number is approximate rather than exact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)