### PR TITLE
Attribute transcript segments to speakers by overlap, not midpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,7 +104,11 @@ __pycache__/
 *.pyc
 
 # Internal planning docs (not for public repo)
-docs/
+# `docs/*` rather than `docs/`: git does not descend into an excluded directory, so a
+# blanket `docs/` makes every negation below unreachable and drops new specs silently.
+docs/*
 !docs/dev-setup.md
 !docs/RELEASE_SETUP.md
 !docs/SPARKLE_UPDATE_FLOW.md
+# Design and spec documents are reviewed on their pull request, so they are tracked.
+!docs/specs/

--- a/Logue.xcodeproj/project.pbxproj
+++ b/Logue.xcodeproj/project.pbxproj
@@ -91,6 +91,7 @@
 		24C4E391A8A690C60D26E51A /* CanvasController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB988721E93C1D96F2216DF0 /* CanvasController.swift */; };
 		24C5EF79903E1BC7FC98A62E /* WikiLinkCompletion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24994CE786E8D4635390440F /* WikiLinkCompletion.swift */; };
 		2588490FBA16F79B755839A9 /* SuggestionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCEBD05BEF5831C92DDDE40E /* SuggestionParser.swift */; };
+		2671AD1CC1AF905D19DAA6DE /* SpeakerAlignmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19F1035412798A05B8612D79 /* SpeakerAlignmentTests.swift */; };
 		2748731D0D5427C49E8BDC34 /* FocusModeState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22BA5DBEE6DA4F70ABEEE59D /* FocusModeState.swift */; };
 		276FE55FD853C4367F2AE751 /* HorizontalInspectorTabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FCFF721CED209FFEDE4798 /* HorizontalInspectorTabBar.swift */; };
 		27F097B829A01B3B49CDA042 /* LinkRenamer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 347E49226D27CD7AF6B329EE /* LinkRenamer.swift */; };
@@ -153,6 +154,7 @@
 		477DF8B7B1F59630238F15A1 /* FilterChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1422ADE4317F2B8650E23D7 /* FilterChip.swift */; };
 		47AF1C29A0DE6C0767146BA6 /* LLMClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA90D7698CBC2EB6CBF52AFB /* LLMClient.swift */; };
 		47F884E259A02AE3967993F6 /* MeetingStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 505E45131ECB10200762FD54 /* MeetingStore.swift */; };
+		480E2F2ECBABB70296373573 /* SortformerTimelineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20A9DCED765C659BAD6BA11C /* SortformerTimelineTests.swift */; };
 		4813D83A3CF3D394DBA29606 /* WikiLinkStylingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6392D9C30DCF6BDFC18DCF63 /* WikiLinkStylingTests.swift */; };
 		486082E3815CD2D7A4249A82 /* CalendarWriteTools.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6AC347933D7E812C30B26A8 /* CalendarWriteTools.swift */; };
 		496062886BC3CE21CE0651CC /* WritingLayoutManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 448C84F276994CA3F884806B /* WritingLayoutManager.swift */; };
@@ -220,6 +222,7 @@
 		68A60F0021C2B996783F3F41 /* DocumentPropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB0075D6BBFD557576AAF966 /* DocumentPropertyTests.swift */; };
 		693843E5E8F7A5A45AAD99BA /* InlineDiagramView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2A85CBFCD11CDF2FB693F73 /* InlineDiagramView.swift */; };
 		697553876307B2C83EA86595 /* ReviewModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE44EB0DEEE58EA51F73402B /* ReviewModels.swift */; };
+		69C377EFFD3B01B060B81835 /* SpeakerAlignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD2339649C1FDB68C5155E1A /* SpeakerAlignment.swift */; };
 		6A0C82EEC2ED811BD717F3D8 /* String+MarkdownStripping.swift in Sources */ = {isa = PBXBuildFile; fileRef = A164C7557EDE48648C650F46 /* String+MarkdownStripping.swift */; };
 		6A4AA026F9B378C593F2EB60 /* DateGroupingHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4623149A8D1BB07A0CB7B26 /* DateGroupingHelper.swift */; };
 		6AF6E18086DF84F8D54D099E /* SearchBarField.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFC4D0D0481D8CD554E5892C /* SearchBarField.swift */; };
@@ -465,6 +468,7 @@
 		F56C246C018D65C01B8912E3 /* WriteDocumentTools.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7BB6836738E8815F0F59EBE /* WriteDocumentTools.swift */; };
 		F570DF852E1DEB0509282BE0 /* InlineLaTeXView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CCF492C5BB1691EC0946B25 /* InlineLaTeXView.swift */; };
 		F5D0756061ECC7E9DA91DB7B /* VoicePushToTalkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 312A712634E382D3B5619607 /* VoicePushToTalkManager.swift */; };
+		F626FAA4D0891863CF3B7E0C /* SortformerTimeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58D77A8F6311F520C9F7AAA3 /* SortformerTimeline.swift */; };
 		F707714ED0D3CE3D8EBCCD90 /* OnboardingView+ModelPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 153523A61D3B1E2AF4B2D108 /* OnboardingView+ModelPage.swift */; };
 		F709E83F5F91C7B68712F42D /* BufferConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A9894380C7367618CEBF956 /* BufferConverter.swift */; };
 		F74FEEF4D5EEE927F6FE1D58 /* WikiLinkClickTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BE9BA34E8404D7F7AB815F1 /* WikiLinkClickTests.swift */; };
@@ -535,6 +539,7 @@
 		1643D88F8D9EE575F4C03507 /* TextDiff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextDiff.swift; sourceTree = "<group>"; };
 		19129D8F0F9161BC3E21AA0F /* CommandCenterChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandCenterChatView.swift; sourceTree = "<group>"; };
 		19E3F885C9304AB29EE2748E /* GeneralSettingsTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralSettingsTab.swift; sourceTree = "<group>"; };
+		19F1035412798A05B8612D79 /* SpeakerAlignmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeakerAlignmentTests.swift; sourceTree = "<group>"; };
 		1ABF1E17FE2163DCFCF2C448 /* ChartTypeInferrer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartTypeInferrer.swift; sourceTree = "<group>"; };
 		1B122ABAFDC2934FB106C9C6 /* DocumentRowCompact.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentRowCompact.swift; sourceTree = "<group>"; };
 		1BEFD48C860C189F76D82545 /* ActionItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionItem.swift; sourceTree = "<group>"; };
@@ -545,6 +550,7 @@
 		1FA779998563196E65B54138 /* SandboxContainerMigrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SandboxContainerMigrator.swift; sourceTree = "<group>"; };
 		1FB93A6E198E565413AD03FC /* BlockRowView+Actions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlockRowView+Actions.swift"; sourceTree = "<group>"; };
 		207FDDB5AF3841198B2438E4 /* ChatHomeEmptyState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatHomeEmptyState.swift; sourceTree = "<group>"; };
+		20A9DCED765C659BAD6BA11C /* SortformerTimelineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortformerTimelineTests.swift; sourceTree = "<group>"; };
 		20FC98B65B556E8B97D9660A /* AudioLevelNormalizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioLevelNormalizer.swift; sourceTree = "<group>"; };
 		20FD91D8BED8E4CACE940391 /* PropertyValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PropertyValue.swift; sourceTree = "<group>"; };
 		2100148050D740B2B64AF673 /* WritingDocument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WritingDocument.swift; sourceTree = "<group>"; };
@@ -640,6 +646,7 @@
 		54533945F253EFE4459AC3A2 /* MemoryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryStore.swift; sourceTree = "<group>"; };
 		556A511293280EF4427934FA /* RelationshipFieldTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelationshipFieldTests.swift; sourceTree = "<group>"; };
 		5620656BB430181432F916B9 /* SpaceAIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceAIService.swift; sourceTree = "<group>"; };
+		58D77A8F6311F520C9F7AAA3 /* SortformerTimeline.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortformerTimeline.swift; sourceTree = "<group>"; };
 		5B1BA8536C1D15EB0A32717E /* TranscriptSegment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptSegment.swift; sourceTree = "<group>"; };
 		5B22ABF6CCA6E8E7D64ADF54 /* DocumentTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentTypeTests.swift; sourceTree = "<group>"; };
 		5BF8F4CE67B450542E7CFAD3 /* SourceMeetingChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceMeetingChip.swift; sourceTree = "<group>"; };
@@ -860,6 +867,7 @@
 		CCB1CD5106FDFE97F1CFC5EB /* ReviewPanelLLMTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewPanelLLMTests.swift; sourceTree = "<group>"; };
 		CCC4C9A99648838E46779A4D /* EditorZoom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorZoom.swift; sourceTree = "<group>"; };
 		CCEE1CC67630CF84E03498D5 /* MermaidRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MermaidRenderer.swift; sourceTree = "<group>"; };
+		CD2339649C1FDB68C5155E1A /* SpeakerAlignment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeakerAlignment.swift; sourceTree = "<group>"; };
 		CE4B9329DFE86A8D2B1629DE /* WritingGoalMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WritingGoalMode.swift; sourceTree = "<group>"; };
 		CF540C94525BF2C21BA389BF /* LogoBrandView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogoBrandView.swift; sourceTree = "<group>"; };
 		CF81895980E378C21F96AFD6 /* DocumentLLMTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentLLMTests.swift; sourceTree = "<group>"; };
@@ -1050,6 +1058,8 @@
 				EFE448FDFB9D86AB13035E23 /* ReleaseEntitlementsTests.swift */,
 				87A5F89112EFC50A714AFD79 /* SandboxContainerMigratorTests.swift */,
 				D238B8169934A609E62E8D9E /* SavedViewFilterTests.swift */,
+				20A9DCED765C659BAD6BA11C /* SortformerTimelineTests.swift */,
+				19F1035412798A05B8612D79 /* SpeakerAlignmentTests.swift */,
 				5C461874879489EBFF0BE683 /* SuggestionParserTests.swift */,
 				8D2D61B85F962E88AA1E5062 /* TextAnalysisRequestTests.swift */,
 				5CF05733C63217FB320DD8E1 /* WikiLinkCandidateTests.swift */,
@@ -1361,6 +1371,8 @@
 				1C843F0CCD12C0AFFD804F85 /* PromptRegistry+Writing.swift */,
 				70684260B4C198545C4A6AC2 /* RetryHelper.swift */,
 				AAF11921E9C36605B80954D2 /* SlideDeckBuilder.swift */,
+				58D77A8F6311F520C9F7AAA3 /* SortformerTimeline.swift */,
+				CD2339649C1FDB68C5155E1A /* SpeakerAlignment.swift */,
 				0D270AE60AD2503E159E4A50 /* SpeechTranscriberEngine.swift */,
 				FCEBD05BEF5831C92DDDE40E /* SuggestionParser.swift */,
 				E93998CDEA76314D90824839 /* SystemAudioCapture.swift */,
@@ -2013,6 +2025,8 @@
 				0EA7AB55C23D022F1C35E001 /* RewritePanelLLMTests.swift in Sources */,
 				FD7360D41D7027945F5BE947 /* SandboxContainerMigratorTests.swift in Sources */,
 				D1F8F911B34F47321D8B6631 /* SavedViewFilterTests.swift in Sources */,
+				480E2F2ECBABB70296373573 /* SortformerTimelineTests.swift in Sources */,
+				2671AD1CC1AF905D19DAA6DE /* SpeakerAlignmentTests.swift in Sources */,
 				EFB8555797ACCB5E2120C1AA /* SuggestionParserTests.swift in Sources */,
 				A30AAC62CDAE227B36E45511 /* TextAnalysisRequestTests.swift in Sources */,
 				073F4389E29E0F214606228C /* VerifyPanelLLMTests.swift in Sources */,
@@ -2353,6 +2367,7 @@
 				A3BB9CABAD3F8815F31B297F /* SlashCommandView.swift in Sources */,
 				FFC8FD3443FBDCF45F791FCF /* SlideDeckBuilder.swift in Sources */,
 				662398037CDC210681F909C7 /* SlideTools.swift in Sources */,
+				F626FAA4D0891863CF3B7E0C /* SortformerTimeline.swift in Sources */,
 				0DF9D55AFF9C181065A4C69E /* SourceMeetingChip.swift in Sources */,
 				31F088EDA786AF95FA1D2067 /* SourcesPanelView.swift in Sources */,
 				1279C086A49FA971B5137028 /* SpaceAIPopover.swift in Sources */,
@@ -2360,6 +2375,7 @@
 				0F40B34FE9CF24DC1B55D9F0 /* SpaceContentPane+Cards.swift in Sources */,
 				99798008D35E27D8502DAE0F /* SpaceContentPane.swift in Sources */,
 				ABEB7317A02B279F22E9AB8E /* SpaceContentTypes.swift in Sources */,
+				69C377EFFD3B01B060B81835 /* SpeakerAlignment.swift in Sources */,
 				2C9B1535EA2DC064913A2D04 /* SpeakerModels.swift in Sources */,
 				0FB26798FD61EEBC32BFD3A7 /* SpeechTranscriberEngine.swift in Sources */,
 				5B40660F3A0659483AC6ED30 /* StatItem.swift in Sources */,

--- a/Logue/App/AppConstants.swift
+++ b/Logue/App/AppConstants.swift
@@ -154,6 +154,11 @@ enum AppConstants {
         static let alternationWindowSeconds: TimeInterval = 0.8
         /// Largest silence left between normalized speaker segments before it is closed up
         static let timelineMaxGap: TimeInterval = 0.5
+        /// Widest silence worth closing at all. Beyond this the pause is real conversation rhythm,
+        /// not model jitter, and pulling the next speaker back over it would hand them time they
+        /// were audibly not speaking for — which alignment would then read as confident overlap for
+        /// anything transcribed in that window. Long silences are left as silence.
+        static let maxClosableGap: TimeInterval = 2.0
 
         // MARK: Transcript alignment
 

--- a/Logue/App/AppConstants.swift
+++ b/Logue/App/AppConstants.swift
@@ -140,6 +140,39 @@ enum AppConstants {
         static let vadSpeechPadding: TimeInterval = 0.25
         /// VAD: hysteresis offset — once speech starts, stays triggered until prob drops this far below threshold
         static let vadNegativeThresholdOffset: Float = 0.25
+
+        // MARK: Timeline normalization
+
+        /// Sortformer segments shorter than this are treated as fragments and discarded
+        static let minSpeakerSegmentDuration: TimeInterval = 0.7
+        /// Consecutive segments from the same speaker within this gap are merged into one
+        static let sameSpeakerMergeGap: TimeInterval = 0.25
+        /// An A-B-A speaker alternation completing within this window is collapsed to the dominant speaker
+        static let alternationWindowSeconds: TimeInterval = 0.8
+        /// Largest silence left between normalized speaker segments before it is closed up
+        static let timelineMaxGap: TimeInterval = 0.5
+
+        // MARK: Transcript alignment
+
+        /// Transcript segments longer than this are chunked for weighted majority voting
+        static let chunkThresholdSeconds: TimeInterval = 2.0
+        /// Width of each voting chunk when a long transcript segment is subdivided
+        static let chunkDurationSeconds: TimeInterval = 1.5
+        /// A runner-up speaker holding at least this fraction of the winner's overlap makes the
+        /// segment too close to call, so the previous segment's speaker is preferred instead
+        static let ambiguityOverlapRatio: Double = 0.70
+        /// Nearest-speaker fallback window used only when nothing overlaps the segment at all.
+        /// Deliberately far tighter than `speakerLabelTolerance`, which governs text gathering.
+        static let labelFallbackTolerance: TimeInterval = 0.5
+        /// Minimum overlap that makes a second speaker worth splitting a transcript segment for
+        static let minSplitOverlap: TimeInterval = 0.15
+        /// Split parts shorter than this are not worth creating
+        static let minSplitPartDuration: TimeInterval = 0.4
+        /// Upper bound on the parts a single transcript segment may be split into
+        static let maxSplitParts = 5
+        /// A single-segment speaker island longer than this is a real turn, not flapping,
+        /// so smoothing leaves it alone
+        static let maxSmoothedIslandDuration: TimeInterval = 0.8
     }
 
     // A-N13: Default title strings
@@ -222,8 +255,9 @@ enum AppConstants {
         /// -- Diarization --
         /// Polling interval while waiting for Sortformer processing lock to release
         static let sortformerPollInterval: Duration = .milliseconds(10)
-        /// Initial delay before starting periodic batch diarization
-        static let batchDiarizationInitialDelay: Duration = .seconds(15)
+        /// How long stop-recording waits for diarization models to finish initializing before
+        /// giving up and letting post-recording AI proceed without Sortformer
+        static let diarizationInitStopWait: Duration = .seconds(10)
 
         /// -- Audio Device Retry (exponential backoff) --
         /// Initial retry delay for AudioDeviceStart (doubles each attempt)

--- a/Logue/Engine/DiarizationManager.swift
+++ b/Logue/Engine/DiarizationManager.swift
@@ -396,95 +396,7 @@ final class DiarizationManager {
 
     // MARK: - Batch Fallback (used when Sortformer unavailable)
 
-    /// Start periodic batch processing (only used in fallback mode).
-    func startPeriodicProcessing(onUpdate: @escaping (DiarizationResult) -> Void) {
-        guard !isStreamingActive else { return } // Sortformer handles this
-
-        // Legacy periodic processing for batch fallback
-        let periodicTask = Task { [weak self] in
-            do { try await Task.sleep(for: AppConstants.Delays.batchDiarizationInitialDelay) } catch { return }
-            var interval: Duration = .seconds(15)
-            let maxInterval: Duration = .seconds(120)
-
-            while !Task.isCancelled {
-                if let result = await self?.processIncrementalChunk() {
-                    onUpdate(result)
-                }
-                interval = min(interval + .seconds(15), maxInterval)
-                do { try await Task.sleep(for: interval) } catch { break }
-            }
-        }
-        self.periodicTask = periodicTask
-    }
-
-    private var periodicTask: Task<Void, Never>?
-    private var lastProcessedSampleIndex: Int = 0
-    private var lastProcessedTime: TimeInterval = 0
-
-    func stopPeriodicProcessing() {
-        periodicTask?.cancel()
-        periodicTask = nil
-    }
-
-    private func processIncrementalChunk() async -> DiarizationResult? {
-        guard let diarizer = batchDiarizer else { return nil }
-        let currentCount = audioBuffer.count
-        let newSampleCount = currentCount - lastProcessedSampleIndex
-        let minChunkSamples = Int(sampleRate * 15)
-        guard newSampleCount >= minChunkSamples else { return nil }
-
-        let startIdx = lastProcessedSampleIndex
-        let chunkSamples = Array(audioBuffer[startIdx ..< currentCount])
-        let sr = Int(sampleRate)
-        let startTime = lastProcessedTime
-
-        lastProcessedSampleIndex = currentCount
-        lastProcessedTime += Double(newSampleCount) / Double(sampleRate)
-
-        let capturedLogger = logger
-        let result: DiarizationResult? = await Task.detached {
-            do {
-                return await try diarizer.performCompleteDiarization(chunkSamples, sampleRate: sr, atTime: startTime)
-            } catch {
-                capturedLogger.error("Incremental diarization failed: \(error.localizedDescription, privacy: .public)")
-                return nil
-            }
-        }.value
-
-        guard !Task.isCancelled, let result else { return nil }
-        return result
-    }
-
-    func processRemainingChunk() async -> DiarizationResult? {
-        guard let diarizer = batchDiarizer else { return nil }
-        let currentCount = audioBuffer.count
-        let newSampleCount = currentCount - lastProcessedSampleIndex
-        guard newSampleCount > 0 else { return nil }
-
-        let startIdx = lastProcessedSampleIndex
-        let chunkSamples = Array(audioBuffer[startIdx ..< currentCount])
-        let sr = Int(sampleRate)
-        let startTime = lastProcessedTime
-
-        lastProcessedSampleIndex = currentCount
-        lastProcessedTime += Double(newSampleCount) / Double(sampleRate)
-
-        let capturedLogger = logger
-        let result: DiarizationResult? = await Task.detached {
-            do {
-                return await try diarizer.performCompleteDiarization(chunkSamples, sampleRate: sr, atTime: startTime)
-            } catch {
-                capturedLogger.error("Remaining chunk diarization failed: \(error.localizedDescription, privacy: .public)")
-                return nil
-            }
-        }.value
-
-        guard let result else { return nil }
-        return result
-    }
-
     func finishProcessing() async -> DiarizationResult? {
-        stopPeriodicProcessing()
         guard isEnabled, isInitialized, !audioBuffer.isEmpty else { return nil }
         guard let diarizer = batchDiarizer else {
             audioBuffer.removeAll(keepingCapacity: false)
@@ -554,14 +466,11 @@ final class DiarizationManager {
     // MARK: - Reset
 
     func reset() {
-        stopPeriodicProcessing()
         sortformerDiarizer?.reset()
         audioBuffer.removeAll()
         lastError = nil
         resampler = nil
         resamplerInputFormat = nil
-        lastProcessedSampleIndex = 0
-        lastProcessedTime = 0
         samplesAccumulatedSinceLastProcess = 0
     }
 }

--- a/Logue/Engine/SortformerTimeline.swift
+++ b/Logue/Engine/SortformerTimeline.swift
@@ -90,8 +90,15 @@ enum SortformerTimeline {
 
     // MARK: - Continuity
 
-    /// Removes overlaps and oversized gaps so the timeline reads as one continuous conversation.
-    /// A segment entirely swallowed by its predecessor is dropped rather than inverted.
+    /// Removes overlaps, and closes gaps narrow enough to be model jitter, so the timeline reads as
+    /// one continuous conversation. A segment entirely swallowed by its predecessor is dropped
+    /// rather than inverted.
+    ///
+    /// A silence wider than `maxClosableGap` is left exactly as it is: closing it would move the
+    /// later speaker's start back across time nobody was confidently speaking in, and alignment
+    /// compares true transcript times against these adjusted ones. A stray cough or a missed word
+    /// in that window would then be labelled with full confidence instead of honestly falling
+    /// outside every speaker.
     private static func enforceContinuity(
         _ updates: [SortformerSpeakerUpdate]
     ) -> [SortformerSpeakerUpdate] {
@@ -104,10 +111,13 @@ enum SortformerTimeline {
                 continue
             }
 
+            let gap = update.startTime - last.endTime
             var start = update.startTime
-            if start < last.endTime {
+            if gap < 0 {
                 start = last.endTime
-            } else if start - last.endTime > AppConstants.Diarization.timelineMaxGap {
+            } else if gap > AppConstants.Diarization.timelineMaxGap,
+                      gap <= AppConstants.Diarization.maxClosableGap
+            {
                 start = last.endTime + AppConstants.Diarization.timelineMaxGap
             }
             guard update.endTime > start else { continue }
@@ -119,8 +129,12 @@ enum SortformerTimeline {
                 endTime: update.endTime
             )
 
-            // Clamping can bring two same-speaker segments flush together.
-            if last.speakerIndex == adjusted.speakerIndex {
+            // Clamping can bring two same-speaker segments flush together. Only merge when they
+            // genuinely are: a silence left open above must not be swallowed by joining the speaker
+            // to themselves across it.
+            if last.speakerIndex == adjusted.speakerIndex,
+               adjusted.startTime - last.endTime <= AppConstants.Diarization.timelineMaxGap
+            {
                 fixed[fixed.count - 1] = SortformerSpeakerUpdate(
                     speakerIndex: last.speakerIndex,
                     speakerName: last.speakerName,

--- a/Logue/Engine/SortformerTimeline.swift
+++ b/Logue/Engine/SortformerTimeline.swift
@@ -1,0 +1,142 @@
+import Foundation
+
+/// Cleans up raw Sortformer speaker output before it becomes persisted speaker data.
+///
+/// Sortformer emits a fragmented timeline: sub-second slivers, the same speaker split across
+/// consecutive segments, brief alternations where one speaker's turn is interrupted and resumed,
+/// and segments that overlap their neighbours. Feeding that straight into transcript alignment
+/// produces speaker labels that flip mid-sentence.
+///
+/// Every step here is speaker-count agnostic. Nothing collapses the timeline towards a target
+/// number of speakers, because a three- or four-person meeting is as valid as a two-person one.
+enum SortformerTimeline {
+    /// Filters fragments, merges same-speaker runs, collapses rapid alternations, and closes up
+    /// overlaps and gaps. Returns segments ordered by start time.
+    static func normalize(_ updates: [SortformerSpeakerUpdate]) -> [SortformerSpeakerUpdate] {
+        guard !updates.isEmpty else { return [] }
+
+        let ordered = updates
+            .filter { $0.endTime - $0.startTime >= AppConstants.Diarization.minSpeakerSegmentDuration }
+            .sorted { $0.startTime < $1.startTime }
+
+        let merged = mergeAdjacentSameSpeaker(ordered)
+        let collapsed = collapseRapidAlternations(merged)
+        return enforceContinuity(mergeAdjacentSameSpeaker(collapsed))
+    }
+
+    // MARK: - Merging
+
+    /// Joins consecutive segments attributed to the same speaker when the silence between them is
+    /// shorter than `sameSpeakerMergeGap` — one continuous turn Sortformer reported in pieces.
+    private static func mergeAdjacentSameSpeaker(
+        _ updates: [SortformerSpeakerUpdate]
+    ) -> [SortformerSpeakerUpdate] {
+        updates.reduce(into: [SortformerSpeakerUpdate]()) { merged, update in
+            guard let last = merged.last,
+                  last.speakerIndex == update.speakerIndex,
+                  update.startTime - last.endTime <= AppConstants.Diarization.sameSpeakerMergeGap
+            else {
+                merged.append(update)
+                return
+            }
+            merged[merged.count - 1] = SortformerSpeakerUpdate(
+                speakerIndex: last.speakerIndex,
+                speakerName: last.speakerName,
+                startTime: last.startTime,
+                endTime: max(last.endTime, update.endTime)
+            )
+        }
+    }
+
+    // MARK: - Alternation collapsing
+
+    /// Rewrites an A-B-A run that completes inside `alternationWindowSeconds` as a single segment
+    /// belonging to whichever speaker holds more of it. Three turns in under a second is the model
+    /// wavering, not two people talking.
+    private static func collapseRapidAlternations(
+        _ updates: [SortformerSpeakerUpdate]
+    ) -> [SortformerSpeakerUpdate] {
+        guard updates.count >= 3 else { return updates }
+
+        var collapsed = updates
+        var index = 0
+        while index + 2 < collapsed.count {
+            let first = collapsed[index]
+            let middle = collapsed[index + 1]
+            let last = collapsed[index + 2]
+
+            let spansWindow = last.endTime - first.startTime <= AppConstants.Diarization.alternationWindowSeconds
+            guard first.speakerIndex == last.speakerIndex,
+                  first.speakerIndex != middle.speakerIndex,
+                  spansWindow
+            else {
+                index += 1
+                continue
+            }
+
+            let flankDuration = duration(of: first) + duration(of: last)
+            let dominant = flankDuration >= duration(of: middle) ? first : middle
+            collapsed.replaceSubrange(index ... index + 2, with: [SortformerSpeakerUpdate(
+                speakerIndex: dominant.speakerIndex,
+                speakerName: dominant.speakerName,
+                startTime: first.startTime,
+                endTime: last.endTime
+            )])
+            // Step back so a longer alternating run collapses from the inside out.
+            index = max(0, index - 1)
+        }
+        return collapsed
+    }
+
+    // MARK: - Continuity
+
+    /// Removes overlaps and oversized gaps so the timeline reads as one continuous conversation.
+    /// A segment entirely swallowed by its predecessor is dropped rather than inverted.
+    private static func enforceContinuity(
+        _ updates: [SortformerSpeakerUpdate]
+    ) -> [SortformerSpeakerUpdate] {
+        var fixed: [SortformerSpeakerUpdate] = []
+        fixed.reserveCapacity(updates.count)
+
+        for update in updates {
+            guard let last = fixed.last else {
+                fixed.append(update)
+                continue
+            }
+
+            var start = update.startTime
+            if start < last.endTime {
+                start = last.endTime
+            } else if start - last.endTime > AppConstants.Diarization.timelineMaxGap {
+                start = last.endTime + AppConstants.Diarization.timelineMaxGap
+            }
+            guard update.endTime > start else { continue }
+
+            let adjusted = SortformerSpeakerUpdate(
+                speakerIndex: update.speakerIndex,
+                speakerName: update.speakerName,
+                startTime: start,
+                endTime: update.endTime
+            )
+
+            // Clamping can bring two same-speaker segments flush together.
+            if last.speakerIndex == adjusted.speakerIndex {
+                fixed[fixed.count - 1] = SortformerSpeakerUpdate(
+                    speakerIndex: last.speakerIndex,
+                    speakerName: last.speakerName,
+                    startTime: last.startTime,
+                    endTime: adjusted.endTime
+                )
+            } else {
+                fixed.append(adjusted)
+            }
+        }
+        return fixed
+    }
+
+    // MARK: - Helpers
+
+    private static func duration(of update: SortformerSpeakerUpdate) -> TimeInterval {
+        max(0, update.endTime - update.startTime)
+    }
+}

--- a/Logue/Engine/SpeakerAlignment.swift
+++ b/Logue/Engine/SpeakerAlignment.swift
@@ -37,6 +37,15 @@ enum SpeakerAlignment {
             speakerNamesByID: speakerNamesByID
         )
 
+        // Split parts arrive already labelled and with fresh IDs, so they are exactly the segments
+        // carrying a label that were not protected on the way in. Smoothing must leave them alone:
+        // a part between `minSplitPartDuration` and `maxSmoothedIslandDuration` flanked by the same
+        // speaker looks like flapping, and relabelling it would discard a boundary taken from the
+        // speaker timeline in favour of a guess made from its neighbours.
+        let splitPartIDs = Set(
+            output.filter { $0.speakerLabel != nil && !protectedIDs.contains($0.id) }.map(\.id)
+        )
+
         var previousLabel: String?
         for index in output.indices {
             guard output[index].speakerLabel == nil else {
@@ -54,7 +63,7 @@ enum SpeakerAlignment {
             previousLabel = label
         }
 
-        return smoothIslands(output, protectedIDs: protectedIDs)
+        return smoothIslands(output, protectedIDs: protectedIDs.union(splitPartIDs))
     }
 
     // MARK: - Overlap voting
@@ -96,13 +105,13 @@ enum SpeakerAlignment {
             chunkStart = chunkEnd
         }
 
-        let ranked = votes.sorted { $0.value > $1.value }
+        let ranked = rank(votes)
         guard let best = ranked.first else { return nil }
-        let runnerUp = ranked.dropFirst().first?.value ?? 0
-        if isTooCloseToCall(best: best.value, runnerUp: runnerUp), let previousLabel {
+        let runnerUp = ranked.dropFirst().first?.overlap ?? 0
+        if isTooCloseToCall(best: best.overlap, runnerUp: runnerUp), let previousLabel {
             return previousLabel
         }
-        return best.key
+        return best.name
     }
 
     /// Greatest-overlap speaker for one interval, falling back to the nearest speaker within
@@ -114,9 +123,7 @@ enum SpeakerAlignment {
         speakerNamesByID: [String: String],
         previousLabel: String?
     ) -> String? {
-        var bestName: String?
-        var bestOverlap: TimeInterval = 0
-        var runnerUpOverlap: TimeInterval = 0
+        var overlapByName: [String: TimeInterval] = [:]
         var nearestName: String?
         var nearestDistance = TimeInterval.greatestFiniteMagnitude
 
@@ -126,13 +133,13 @@ enum SpeakerAlignment {
             }
             guard let name = speakerNamesByID[speakerSegment.speakerId] else { continue }
 
+            // Totalled per speaker, not per speaker segment. A speaker interrupted and resumed holds
+            // two segments of this interval, and ranking segments would make them their own
+            // runner-up — reading as an ambiguous interval when it is the opposite, and handing the
+            // segment to `previousLabel`. That is the interjection case this type exists to fix.
             let overlap = min(end, speakerSegment.endTime) - max(start, speakerSegment.startTime)
-            if overlap > bestOverlap {
-                runnerUpOverlap = bestOverlap
-                bestOverlap = overlap
-                bestName = name
-            } else if overlap > runnerUpOverlap {
-                runnerUpOverlap = overlap
+            if overlap > 0 {
+                overlapByName[name, default: 0] += overlap
             }
 
             let distance = distanceBetween(start: start, end: end, speakerSegment: speakerSegment)
@@ -142,13 +149,25 @@ enum SpeakerAlignment {
             }
         }
 
-        guard bestOverlap > 0 else {
+        let ranked = rank(overlapByName)
+        guard let best = ranked.first else {
             return nearestDistance <= AppConstants.Diarization.labelFallbackTolerance ? nearestName : nil
         }
-        if isTooCloseToCall(best: bestOverlap, runnerUp: runnerUpOverlap), let previousLabel {
+        let runnerUp = ranked.dropFirst().first?.overlap ?? 0
+        if isTooCloseToCall(best: best.overlap, runnerUp: runnerUp), let previousLabel {
             return previousLabel
         }
-        return bestName
+        return best.name
+    }
+
+    /// Speakers ordered by how much of the interval they hold, name breaking exact ties so the same
+    /// input always produces the same label — dictionary iteration order does not.
+    private static func rank(
+        _ overlapByName: [String: TimeInterval]
+    ) -> [(name: String, overlap: TimeInterval)] {
+        overlapByName
+            .map { (name: $0.key, overlap: $0.value) }
+            .sorted { $0.overlap == $1.overlap ? $0.name < $1.name : $0.overlap > $1.overlap }
     }
 
     /// A runner-up this close to the winner means the interval genuinely spans both speakers, so
@@ -288,7 +307,8 @@ enum SpeakerAlignment {
     ///
     /// Bounded to islands shorter than `maxSmoothedIslandDuration`: a two-second turn is somebody
     /// speaking, and overriding it would delete a real contribution. Only brief islands are treated
-    /// as diarization flapping. Protected segments are never rewritten.
+    /// as diarization flapping. Protected segments — pre-labelled ones and the parts of a segment
+    /// split at a speaker boundary — are never rewritten.
     private static func smoothIslands(
         _ segments: [TranscriptSegment],
         protectedIDs: Set<UUID>

--- a/Logue/Engine/SpeakerAlignment.swift
+++ b/Logue/Engine/SpeakerAlignment.swift
@@ -1,0 +1,313 @@
+import Foundation
+
+/// Attributes transcript segments to speakers by time overlap.
+///
+/// Replaces midpoint-nearest matching, which asks only "which speaker segment is closest to the
+/// middle of this transcript segment?" — a question whose answer is wrong whenever a brief
+/// interjection happens to land mid-sentence, and whose 3.5s search window will happily borrow a
+/// speaker who was not talking at all.
+///
+/// Segments that already carry a label are left completely alone: not split, not relabelled, not
+/// smoothed. That protects the "You" attribution given to local mic audio in online meetings, and
+/// any speaker the user has corrected by hand.
+enum SpeakerAlignment {
+    /// Splits transcript segments at speaker boundaries, labels the unlabelled ones by overlap
+    /// vote, then smooths brief single-segment islands.
+    ///
+    /// Never returns fewer segments than it was given — a transcript segment may be subdivided but
+    /// is never dropped.
+    static func align(
+        segments: [TranscriptSegment],
+        speakerSegments: [SpeakerSegment],
+        speakerNamesByID: [String: String]
+    ) -> [TranscriptSegment] {
+        guard !segments.isEmpty, !speakerSegments.isEmpty else { return segments }
+
+        let sortedSpeakers = speakerSegments
+            .filter { $0.endTime > $0.startTime && speakerNamesByID[$0.speakerId] != nil }
+            .sorted { $0.startTime < $1.startTime }
+        guard !sortedSpeakers.isEmpty else { return segments }
+
+        let protectedIDs = Set(segments.filter { $0.speakerLabel != nil }.map(\.id))
+
+        var output = split(
+            segments: segments,
+            protectedIDs: protectedIDs,
+            speakerSegments: sortedSpeakers,
+            speakerNamesByID: speakerNamesByID
+        )
+
+        var previousLabel: String?
+        for index in output.indices {
+            guard output[index].speakerLabel == nil else {
+                previousLabel = output[index].speakerLabel
+                continue
+            }
+            let label = vote(
+                from: output[index].startTime,
+                to: output[index].endTime,
+                speakerSegments: sortedSpeakers,
+                speakerNamesByID: speakerNamesByID,
+                previousLabel: previousLabel
+            )
+            output[index].speakerLabel = label
+            previousLabel = label
+        }
+
+        return smoothIslands(output, protectedIDs: protectedIDs)
+    }
+
+    // MARK: - Overlap voting
+
+    /// Picks the speaker holding the most of `[start, end]`.
+    ///
+    /// Segments longer than `chunkThresholdSeconds` are subdivided and each slice votes weighted by
+    /// its duration, so a long segment straddling a speaker change is decided by how much of it each
+    /// speaker actually holds rather than by whatever sits at its midpoint.
+    private static func vote(
+        from start: TimeInterval,
+        to end: TimeInterval,
+        speakerSegments: [SpeakerSegment],
+        speakerNamesByID: [String: String],
+        previousLabel: String?
+    ) -> String? {
+        guard end - start > AppConstants.Diarization.chunkThresholdSeconds else {
+            return winner(
+                from: start, to: end,
+                speakerSegments: speakerSegments,
+                speakerNamesByID: speakerNamesByID,
+                previousLabel: previousLabel
+            )
+        }
+
+        var votes: [String: TimeInterval] = [:]
+        var chunkStart = start
+        while chunkStart < end {
+            let chunkEnd = min(chunkStart + AppConstants.Diarization.chunkDurationSeconds, end)
+            // Chunks vote without continuity bias; the aggregate below applies it once.
+            if let chunkWinner = winner(
+                from: chunkStart, to: chunkEnd,
+                speakerSegments: speakerSegments,
+                speakerNamesByID: speakerNamesByID,
+                previousLabel: nil
+            ) {
+                votes[chunkWinner, default: 0] += chunkEnd - chunkStart
+            }
+            chunkStart = chunkEnd
+        }
+
+        let ranked = votes.sorted { $0.value > $1.value }
+        guard let best = ranked.first else { return nil }
+        let runnerUp = ranked.dropFirst().first?.value ?? 0
+        if isTooCloseToCall(best: best.value, runnerUp: runnerUp), let previousLabel {
+            return previousLabel
+        }
+        return best.key
+    }
+
+    /// Greatest-overlap speaker for one interval, falling back to the nearest speaker within
+    /// `labelFallbackTolerance` when nothing overlaps at all.
+    private static func winner(
+        from start: TimeInterval,
+        to end: TimeInterval,
+        speakerSegments: [SpeakerSegment],
+        speakerNamesByID: [String: String],
+        previousLabel: String?
+    ) -> String? {
+        var bestName: String?
+        var bestOverlap: TimeInterval = 0
+        var runnerUpOverlap: TimeInterval = 0
+        var nearestName: String?
+        var nearestDistance = TimeInterval.greatestFiniteMagnitude
+
+        for speakerSegment in speakerSegments {
+            if speakerSegment.startTime > end + AppConstants.Diarization.labelFallbackTolerance {
+                break
+            }
+            guard let name = speakerNamesByID[speakerSegment.speakerId] else { continue }
+
+            let overlap = min(end, speakerSegment.endTime) - max(start, speakerSegment.startTime)
+            if overlap > bestOverlap {
+                runnerUpOverlap = bestOverlap
+                bestOverlap = overlap
+                bestName = name
+            } else if overlap > runnerUpOverlap {
+                runnerUpOverlap = overlap
+            }
+
+            let distance = distanceBetween(start: start, end: end, speakerSegment: speakerSegment)
+            if distance < nearestDistance {
+                nearestDistance = distance
+                nearestName = name
+            }
+        }
+
+        guard bestOverlap > 0 else {
+            return nearestDistance <= AppConstants.Diarization.labelFallbackTolerance ? nearestName : nil
+        }
+        if isTooCloseToCall(best: bestOverlap, runnerUp: runnerUpOverlap), let previousLabel {
+            return previousLabel
+        }
+        return bestName
+    }
+
+    /// A runner-up this close to the winner means the interval genuinely spans both speakers, so
+    /// picking the marginal winner is a coin flip. Continuity is the better guess.
+    private static func isTooCloseToCall(best: TimeInterval, runnerUp: TimeInterval) -> Bool {
+        runnerUp > 0 && runnerUp >= best * AppConstants.Diarization.ambiguityOverlapRatio
+    }
+
+    private static func distanceBetween(
+        start: TimeInterval,
+        end: TimeInterval,
+        speakerSegment: SpeakerSegment
+    ) -> TimeInterval {
+        if end < speakerSegment.startTime {
+            return speakerSegment.startTime - end
+        }
+        if start > speakerSegment.endTime {
+            return start - speakerSegment.endTime
+        }
+        return 0
+    }
+
+    // MARK: - Splitting at speaker boundaries
+
+    private static func split(
+        segments: [TranscriptSegment],
+        protectedIDs: Set<UUID>,
+        speakerSegments: [SpeakerSegment],
+        speakerNamesByID: [String: String]
+    ) -> [TranscriptSegment] {
+        segments.flatMap { segment -> [TranscriptSegment] in
+            guard !protectedIDs.contains(segment.id) else { return [segment] }
+            return splitParts(
+                of: segment,
+                speakerSegments: speakerSegments,
+                speakerNamesByID: speakerNamesByID
+            ) ?? [segment]
+        }
+    }
+
+    /// Divides one transcript segment at the boundaries between the speakers it spans.
+    ///
+    /// Returns `nil` — meaning "leave this segment whole" — whenever a faithful split is not
+    /// possible: only one speaker involved, too many speakers, parts that would be too short, or
+    /// fewer words than parts. Splitting must never invent, duplicate, or discard text, so when in
+    /// doubt the original segment is kept.
+    private static func splitParts(
+        of segment: TranscriptSegment,
+        speakerSegments: [SpeakerSegment],
+        speakerNamesByID: [String: String]
+    ) -> [TranscriptSegment]? {
+        let ranges = speakerRanges(spanning: segment, speakerSegments: speakerSegments)
+        guard ranges.count > 1, ranges.count <= AppConstants.Diarization.maxSplitParts else { return nil }
+
+        // Butt each part against the next so the split covers the original span with no holes.
+        var bounds: [(start: TimeInterval, end: TimeInterval, speakerId: String)] = []
+        for (index, range) in ranges.enumerated() {
+            let start = index == 0 ? segment.startTime : bounds[index - 1].end
+            let end = index == ranges.count - 1 ? segment.endTime : range.end
+            guard end - start >= AppConstants.Diarization.minSplitPartDuration else { return nil }
+            bounds.append((start: start, end: end, speakerId: range.speakerId))
+        }
+
+        let words = segment.text.split(whereSeparator: \.isWhitespace).map(String.init)
+        guard let texts = distribute(words: words, across: bounds.map { $0.end - $0.start }) else { return nil }
+
+        return zip(bounds, texts).map { bound, text in
+            TranscriptSegment(
+                text: text,
+                startTime: bound.start,
+                endTime: bound.end,
+                speakerLabel: speakerNamesByID[bound.speakerId],
+                confidence: segment.confidence,
+                audioSource: segment.audioSource
+            )
+        }
+    }
+
+    /// Speaker ranges overlapping `segment` by a meaningful margin, clipped to its bounds and with
+    /// consecutive runs of the same speaker merged.
+    private static func speakerRanges(
+        spanning segment: TranscriptSegment,
+        speakerSegments: [SpeakerSegment]
+    ) -> [(start: TimeInterval, end: TimeInterval, speakerId: String)] {
+        var ranges: [(start: TimeInterval, end: TimeInterval, speakerId: String)] = []
+        for speakerSegment in speakerSegments {
+            if speakerSegment.startTime >= segment.endTime {
+                break
+            }
+            guard speakerSegment.endTime > segment.startTime else { continue }
+
+            let start = max(segment.startTime, speakerSegment.startTime)
+            let end = min(segment.endTime, speakerSegment.endTime)
+            guard end - start >= AppConstants.Diarization.minSplitOverlap else { continue }
+
+            if let last = ranges.last, last.speakerId == speakerSegment.speakerId {
+                ranges[ranges.count - 1].end = max(last.end, end)
+            } else {
+                ranges.append((start: start, end: end, speakerId: speakerSegment.speakerId))
+            }
+        }
+        return ranges
+    }
+
+    /// Allocates words across parts in proportion to their durations, guaranteeing every part at
+    /// least one word. Returns `nil` when there are fewer words than parts.
+    private static func distribute(words: [String], across durations: [TimeInterval]) -> [String]? {
+        guard words.count >= durations.count, durations.count > 1 else { return nil }
+        let total = durations.reduce(0, +)
+        guard total > 0 else { return nil }
+
+        var parts: [String] = []
+        parts.reserveCapacity(durations.count)
+        var cursor = 0
+        var elapsed: TimeInterval = 0
+
+        for (index, duration) in durations.enumerated() {
+            let partsRemaining = durations.count - index - 1
+            let end: Int
+            if partsRemaining == 0 {
+                end = words.count
+            } else {
+                elapsed += duration
+                let proportional = Int((Double(words.count) * elapsed / total).rounded())
+                end = min(max(proportional, cursor + 1), words.count - partsRemaining)
+            }
+            guard end > cursor else { return nil }
+            parts.append(words[cursor ..< end].joined(separator: " "))
+            cursor = end
+        }
+        return parts
+    }
+
+    // MARK: - Smoothing
+
+    /// Rewrites a lone segment flanked on both sides by the same other speaker.
+    ///
+    /// Bounded to islands shorter than `maxSmoothedIslandDuration`: a two-second turn is somebody
+    /// speaking, and overriding it would delete a real contribution. Only brief islands are treated
+    /// as diarization flapping. Protected segments are never rewritten.
+    private static func smoothIslands(
+        _ segments: [TranscriptSegment],
+        protectedIDs: Set<UUID>
+    ) -> [TranscriptSegment] {
+        guard segments.count >= 3 else { return segments }
+
+        var smoothed = segments
+        for index in 1 ..< smoothed.count - 1 {
+            guard !protectedIDs.contains(smoothed[index].id),
+                  let current = smoothed[index].speakerLabel,
+                  let previous = smoothed[index - 1].speakerLabel,
+                  let next = smoothed[index + 1].speakerLabel,
+                  current != previous,
+                  previous == next,
+                  smoothed[index].endTime - smoothed[index].startTime
+                  <= AppConstants.Diarization.maxSmoothedIslandDuration
+            else { continue }
+            smoothed[index].speakerLabel = previous
+        }
+        return smoothed
+    }
+}

--- a/Logue/Services/MeetingStore+Diarization.swift
+++ b/Logue/Services/MeetingStore+Diarization.swift
@@ -34,10 +34,14 @@ extension MeetingStore {
     /// relative to the session's own audio buffer, so they are shifted onto the meeting timeline and
     /// only segments from this session are replaced — otherwise resuming a recording would discard
     /// every earlier session's transcript.
+    ///
+    /// Required deliberately: a default of `0` would filter for segments starting below zero, find
+    /// none, and silently go back to replacing the whole array — the exact data loss this argument
+    /// exists to prevent, in the one scenario least likely to be exercised while developing.
     func replaceTranscript(
         for meetingID: UUID,
         with segments: [TranscriptSegment],
-        sessionStart: TimeInterval = 0
+        sessionStart: TimeInterval
     ) {
         guard let index = meetingIndex(for: meetingID) else { return }
 

--- a/Logue/Services/MeetingStore+Diarization.swift
+++ b/Logue/Services/MeetingStore+Diarization.swift
@@ -3,68 +3,53 @@ import Foundation
 // MARK: - Speaker Diarization
 
 extension MeetingStore {
+    /// Persists diarization output and attributes transcript segments to speakers.
+    ///
+    /// Labelling is delegated to `SpeakerAlignment`, which decides by time overlap and may split a
+    /// transcript segment that spans two speakers. Segments already carrying a label are left alone,
+    /// preserving "You" attribution and any correction the user made by hand.
     func updateSpeakerData(for meetingID: UUID, speakers: [Speaker], speakerSegments: [SpeakerSegment]) {
         guard let index = meetingIndex(for: meetingID) else { return }
         meetings[index].speakers = speakers
         meetings[index].speakerSegments = speakerSegments
         meetings[index].hasSpeakerData = !speakerSegments.isEmpty
 
-        // Only label transcript segments that don't already have a speaker label.
-        // This preserves labels from previous recording sessions and periodic diarization.
-        let speakerMap = Dictionary(uniqueKeysWithValues: speakers.map { ($0.id, $0.name) })
-        let sortedSpeakerSegs = speakerSegments.sorted { $0.startTime < $1.startTime }
-        // Pre-extract startTimes for binary search (O(n log n) vs O(n²))
-        let startTimes = sortedSpeakerSegs.map(\.startTime)
-
-        guard !sortedSpeakerSegs.isEmpty else { return }
-
-        for (segIdx, segment) in meetings[index].segments.enumerated() {
-            guard segment.speakerLabel == nil else { continue }
-
-            let midpoint = (segment.startTime + segment.endTime) / 2
-
-            // Binary search for the insertion point of midpoint in sorted speaker segments.
-            // lo ends up as the first index where startTime > midpoint.
-            var lo = 0, hi = startTimes.count
-            while lo < hi {
-                let mid = (lo + hi) / 2
-                if startTimes[mid] <= midpoint {
-                    lo = mid + 1
-                } else {
-                    hi = mid
-                }
-            }
-            var matchedName: String?
-            var bestDistance = Double.greatestFiniteMagnitude
-            let searchRange = max(0, lo - 2) ... min(sortedSpeakerSegs.count - 1, lo + 1)
-
-            for i in searchRange {
-                let ss = sortedSpeakerSegs[i]
-                if midpoint >= ss.startTime, midpoint <= ss.endTime {
-                    matchedName = speakerMap[ss.speakerId]
-                    break
-                }
-                let distance = min(abs(midpoint - ss.startTime), abs(midpoint - ss.endTime))
-                if distance < bestDistance, distance <= AppConstants.Diarization.speakerLabelTolerance {
-                    bestDistance = distance
-                    matchedName = speakerMap[ss.speakerId]
-                }
-            }
-
-            if let name = matchedName {
-                meetings[index].segments[segIdx].speakerLabel = name
-            }
-        }
+        meetings[index].segments = SpeakerAlignment.align(
+            segments: meetings[index].segments,
+            speakerSegments: speakerSegments,
+            speakerNamesByID: Dictionary(
+                speakers.map { ($0.id, $0.name) },
+                uniquingKeysWith: { first, _ in first }
+            )
+        )
 
         meetings[index].modifiedAt = Date()
         saveMeeting(id: meetingID)
     }
 
-    /// Replace all transcript segments with the output of batch ASR (Parakeet TDT).
-    /// Called after recording stops to upgrade streaming transcript quality.
-    func replaceTranscript(for meetingID: UUID, with segments: [TranscriptSegment]) {
+    /// Replace this recording session's transcript segments with the output of batch ASR
+    /// (Parakeet TDT). Called after recording stops to upgrade streaming transcript quality.
+    ///
+    /// `sessionStart` is the meeting timeline offset the session began at. Batch ASR timings are
+    /// relative to the session's own audio buffer, so they are shifted onto the meeting timeline and
+    /// only segments from this session are replaced — otherwise resuming a recording would discard
+    /// every earlier session's transcript.
+    func replaceTranscript(
+        for meetingID: UUID,
+        with segments: [TranscriptSegment],
+        sessionStart: TimeInterval = 0
+    ) {
         guard let index = meetingIndex(for: meetingID) else { return }
-        meetings[index].segments = segments.sorted { $0.startTime < $1.startTime }
+
+        let shifted = segments.map { segment in
+            var moved = segment
+            moved.startTime += sessionStart
+            moved.endTime += sessionStart
+            return moved
+        }
+        let earlierSessions = meetings[index].segments.filter { $0.startTime < sessionStart }
+
+        meetings[index].segments = (earlierSessions + shifted).sorted { $0.startTime < $1.startTime }
         meetings[index].modifiedAt = Date()
         saveMeeting(id: meetingID)
     }

--- a/Logue/Services/RecordingSessionManager+Diarization.swift
+++ b/Logue/Services/RecordingSessionManager+Diarization.swift
@@ -45,7 +45,7 @@ extension RecordingSessionManager {
     func processDiarization(
         for meetingID: UUID,
         diarizer: DiarizationManager,
-        sessionStart: TimeInterval = 0
+        sessionStart: TimeInterval
     ) async {
         isDiarizing = true
         diarizationStage = "Identifying speakers…"
@@ -291,7 +291,7 @@ extension RecordingSessionManager {
     func mergeDiarizationResult(
         _ result: DiarizationResult,
         into meeting: MeetingNote,
-        sessionStart: TimeInterval = 0
+        sessionStart: TimeInterval
     ) -> (speakers: [Speaker], speakerSegments: [SpeakerSegment]) {
         var speakers = meeting.speakers
         var speakerSegments = meeting.speakerSegments
@@ -327,7 +327,7 @@ extension RecordingSessionManager {
     func applySortformerUpdates(
         _ updates: [SortformerSpeakerUpdate],
         for meetingID: UUID,
-        sessionStart: TimeInterval = 0
+        sessionStart: TimeInterval
     ) {
         let store = MeetingStore.shared
         guard let meeting = store.meetings.first(where: { $0.id == meetingID }) else { return }

--- a/Logue/Services/RecordingSessionManager+Diarization.swift
+++ b/Logue/Services/RecordingSessionManager+Diarization.swift
@@ -5,17 +5,53 @@ import os.log
 /// Diarization-related methods extracted from RecordingSessionManager.
 /// Handles speaker detection, merging, alignment, and Sortformer streaming updates.
 extension RecordingSessionManager {
+    // MARK: - Model Initialization
+
+    /// Waits for diarization model initialization, capped at
+    /// `AppConstants.Delays.diarizationInitStopWait`.
+    ///
+    /// Without this wait, stopping while models are still downloading leaves Sortformer not
+    /// streaming, and diarization silently degrades to the less accurate batch path. The cap keeps a
+    /// slow first-run download from holding up post-recording AI indefinitely.
+    func awaitDiarizationInit(_ initTask: Task<Void, Never>) async {
+        let finished = await withTaskGroup(of: Bool.self) { group in
+            group.addTask {
+                await initTask.value
+                return true
+            }
+            group.addTask {
+                try? await Task.sleep(for: AppConstants.Delays.diarizationInitStopWait)
+                return false
+            }
+            let first = await group.next() ?? false
+            group.cancelAll()
+            return first
+        }
+
+        if !finished {
+            logger.warning("Diarization model init still running at stop — proceeding without waiting further")
+        }
+    }
+
     // MARK: - Post-Recording Diarization Pipeline
 
     /// Runs the full diarization pipeline after recording stops.
     /// Uses Sortformer's `processComplete()` for maximum accuracy — the model sees the entire conversation.
     /// Falls back to batch DiarizerManager if Sortformer is unavailable.
-    func processDiarization(for meetingID: UUID, diarizer: DiarizationManager) async {
+    ///
+    /// - Parameter sessionStart: Where this recording session begins on the meeting timeline. Both
+    ///   diarizers time their output from the start of the session's own audio buffer, so their
+    ///   timestamps need shifting by this much when a recording resumes into an existing meeting.
+    func processDiarization(
+        for meetingID: UUID,
+        diarizer: DiarizationManager,
+        sessionStart: TimeInterval = 0
+    ) async {
         isDiarizing = true
         diarizationStage = "Identifying speakers…"
 
         // Primary path: Sortformer processComplete on full audio buffer
-        if await processSortformerDiarization(for: meetingID, diarizer: diarizer) {
+        if await processSortformerDiarization(for: meetingID, diarizer: diarizer, sessionStart: sessionStart) {
             return
         }
 
@@ -38,7 +74,11 @@ extension RecordingSessionManager {
             return
         }
 
-        var (speakers, speakerSegments) = mergeDiarizationResult(result, into: meeting)
+        var (speakers, speakerSegments) = mergeDiarizationResult(
+            result,
+            into: meeting,
+            sessionStart: sessionStart
+        )
 
         diarizationStage = "Aligning transcript…"
 
@@ -66,7 +106,11 @@ extension RecordingSessionManager {
     /// Primary diarization path: runs Sortformer `processComplete` and Parakeet TDT ASR
     /// concurrently on the full audio buffer, then aligns the transcript with speaker segments.
     /// Returns `true` when it handled diarization (streaming was active); `false` to fall back to batch.
-    private func processSortformerDiarization(for meetingID: UUID, diarizer: DiarizationManager) async -> Bool {
+    private func processSortformerDiarization(
+        for meetingID: UUID,
+        diarizer: DiarizationManager,
+        sessionStart: TimeInterval
+    ) async -> Bool {
         guard diarizer.isStreamingActive else { return false }
         logger.info("Starting parallel Sortformer + batch ASR for meeting \(meetingID)...")
 
@@ -77,18 +121,26 @@ extension RecordingSessionManager {
         async let asrTask = diarizer.transcribeBuffer(audioBuffer)
         let (sortformerUpdates, batchSegments) = await (sortformerTask, asrTask)
 
-        if let updates = sortformerUpdates {
-            applySortformerUpdates(updates, for: meetingID, isFinalizing: true)
-            // Renumber all auto-named speakers sequentially (1, 2, 3…) after finalization.
-            // Live-streaming updates may have assigned non-sequential numbers from Sortformer's
-            // internal cluster indices (e.g. Speaker 2, Speaker 4 for a 2-speaker meeting).
-            renumberSpeakers(for: meetingID)
+        // Replace this session's streaming transcript with the accurate Parakeet TDT result before
+        // speakers are assigned, so alignment runs against the final text rather than the draft.
+        if let batchSegments {
+            MeetingStore.shared.replaceTranscript(
+                for: meetingID,
+                with: batchSegments,
+                sessionStart: sessionStart
+            )
+            logger.info("Streaming transcript replaced with batch ASR (\(batchSegments.count) segments)")
         }
 
-        // Replace streaming transcript with accurate Parakeet TDT result.
-        if let batchSegments {
-            MeetingStore.shared.replaceTranscript(for: meetingID, with: batchSegments)
-            logger.info("Streaming transcript replaced with batch ASR (\(batchSegments.count) segments)")
+        if let updates = sortformerUpdates {
+            // Raw Sortformer output is fragmented — sub-second slivers, split turns, and rapid
+            // alternations that would make speaker labels flip mid-sentence.
+            let normalized = SortformerTimeline.normalize(updates)
+            logger.info("Sortformer timeline: \(updates.count) raw segments → \(normalized.count) normalized")
+            applySortformerUpdates(normalized, for: meetingID, sessionStart: sessionStart)
+            // Renumber auto-named speakers sequentially (1, 2, 3…). Sortformer's internal cluster
+            // indices are not contiguous (e.g. Speaker 2, Speaker 4 for a 2-speaker meeting).
+            renumberSpeakers(for: meetingID)
         }
 
         diarizationStage = "Aligning transcript…"
@@ -235,9 +287,11 @@ extension RecordingSessionManager {
     // MARK: - Result Merging
 
     /// Merges diarization result segments into existing speaker data for a meeting.
+    /// Segment times are shifted by `sessionStart` onto the meeting timeline.
     func mergeDiarizationResult(
         _ result: DiarizationResult,
-        into meeting: MeetingNote
+        into meeting: MeetingNote,
+        sessionStart: TimeInterval = 0
     ) -> (speakers: [Speaker], speakerSegments: [SpeakerSegment]) {
         var speakers = meeting.speakers
         var speakerSegments = meeting.speakerSegments
@@ -257,8 +311,8 @@ extension RecordingSessionManager {
 
             speakerSegments.append(SpeakerSegment(
                 speakerId: segment.speakerId,
-                startTime: TimeInterval(segment.startTimeSeconds),
-                endTime: TimeInterval(segment.endTimeSeconds),
+                startTime: TimeInterval(segment.startTimeSeconds) + sessionStart,
+                endTime: TimeInterval(segment.endTimeSeconds) + sessionStart,
                 confidence: segment.qualityScore,
                 embedding: segment.embedding
             ))
@@ -266,33 +320,15 @@ extension RecordingSessionManager {
         return (speakers, speakerSegments)
     }
 
-    /// Apply diarization results to a meeting. Used for both periodic (live) and final (tail) updates.
-    /// - Parameters:
-    ///   - result: The diarization result containing speaker segments.
-    ///   - meetingID: The meeting to update.
-    ///   - isPeriodic: If true, checks `isPeriodicDiarizationStopped` and sets `hasPeriodicDiarizationResults`.
-    func applyDiarizationResult(_ result: DiarizationResult, for meetingID: UUID, isPeriodic: Bool = false) {
-        if isPeriodic {
-            guard !isPeriodicDiarizationStopped else { return }
-        }
-        let store = MeetingStore.shared
-        guard let meeting = store.meetings.first(where: { $0.id == meetingID }) else { return }
+    // MARK: - Sortformer Updates
 
-        let (speakers, speakerSegments) = mergeDiarizationResult(result, into: meeting)
-        store.updateSpeakerData(for: meetingID, speakers: speakers, speakerSegments: speakerSegments)
-
-        if isPeriodic {
-            hasPeriodicDiarizationResults = true
-        }
-        let label = isPeriodic ? "Periodic" : "Final tail"
-        logger.info("\(label) diarization applied: \(speakers.count) speakers, \(speakerSegments.count) total segments")
-    }
-
-    // MARK: - Sortformer Streaming Updates
-
-    /// Apply real-time Sortformer streaming speaker updates to the meeting.
-    func applySortformerUpdates(_ updates: [SortformerSpeakerUpdate], for meetingID: UUID, isFinalizing: Bool = false) {
-        guard isFinalizing || !isPeriodicDiarizationStopped else { return }
+    /// Applies Sortformer speaker segments to the meeting. Runs once, after recording stops —
+    /// segment times are shifted by `sessionStart` onto the meeting timeline.
+    func applySortformerUpdates(
+        _ updates: [SortformerSpeakerUpdate],
+        for meetingID: UUID,
+        sessionStart: TimeInterval = 0
+    ) {
         let store = MeetingStore.shared
         guard let meeting = store.meetings.first(where: { $0.id == meetingID }) else { return }
 
@@ -316,17 +352,20 @@ extension RecordingSessionManager {
                 speakers.append(speaker)
             }
 
+            let startTime = update.startTime + sessionStart
+            let endTime = update.endTime + sessionStart
+
             // Deduplicate: skip if overlapping with an existing segment for the same speaker
             let isDuplicate = speakerSegments.suffix(20).contains { existing in
                 existing.speakerId == speakerID
-                    && abs(existing.startTime - update.startTime) < AppConstants.Diarization.segmentDedupTolerance
+                    && abs(existing.startTime - startTime) < AppConstants.Diarization.segmentDedupTolerance
             }
             guard !isDuplicate else { continue }
 
             let speakerSeg = SpeakerSegment(
                 speakerId: speakerID,
-                startTime: update.startTime,
-                endTime: update.endTime,
+                startTime: startTime,
+                endTime: endTime,
                 confidence: 1.0
             )
             speakerSegments.append(speakerSeg)
@@ -337,8 +376,6 @@ extension RecordingSessionManager {
             speakers: speakers,
             speakerSegments: speakerSegments
         )
-
-        hasPeriodicDiarizationResults = true
     }
 
     // MARK: - Text Alignment

--- a/Logue/Services/RecordingSessionManager.swift
+++ b/Logue/Services/RecordingSessionManager.swift
@@ -88,8 +88,6 @@ final class RecordingSessionManager {
 
     var isCapturingSystemAudio = false
     var isMicActive = false
-    var isPeriodicDiarizationStopped = false
-    var hasPeriodicDiarizationResults = false
     private var postRecordingTask: Task<Void, Never>?
     private var diarizationInitTask: Task<Void, Never>?
 
@@ -280,13 +278,11 @@ final class RecordingSessionManager {
                 return
             }
 
-            self?.isPeriodicDiarizationStopped = false
-            self?.hasPeriodicDiarizationResults = false
             self?.speakerDetectionStatus = .active
 
-            // Audio accumulates during recording via processAudioBuffer().
-            // Full diarization runs after recording stops via processCompleteRecording()
-            // for maximum accuracy — the model sees the entire conversation context.
+            // Audio accumulates during recording via processAudioBuffer(). Speakers are identified
+            // only once recording stops, by processCompleteWith() over the whole buffer, so the
+            // model sees the entire conversation rather than a sliding window of it.
             self?.logger.info("Diarization models ready — audio accumulating for post-recording processing")
         }
 
@@ -425,14 +421,17 @@ final class RecordingSessionManager {
 
         MeetingStore.shared.updateDuration(finalElapsedTime, for: meetingID)
 
-        // Clear session state
+        // Clear session state. Both diarizers time their output from the start of this session's
+        // own audio buffer, so post-recording needs the offset the session began at.
         currentMeetingID = nil
+        let sessionStart = timeOffset
         timeOffset = 0
 
-        // Drop reference but do NOT cancel — if models are mid-download, let them finish
-        // and cache so the next recording session finds them immediately.
+        // Drop the reference but do NOT cancel — if models are mid-download, let them finish
+        // and cache so the next recording session finds them immediately. Captured so the
+        // post-recording pipeline can wait for initialization to land.
+        let capturedInitTask = diarizationInitTask
         diarizationInitTask = nil
-        isPeriodicDiarizationStopped = true
 
         // Launch diarization + post-recording AI as a non-blocking background pipeline
         let capturedDiarizer = diarizationManager
@@ -440,8 +439,14 @@ final class RecordingSessionManager {
         isDiarizing = capturedDiarizer != nil
 
         postRecordingTask = Task { [weak self] in
+            // If models are still initializing, Sortformer is not streaming yet and diarization
+            // would silently fall back to the less accurate batch path. Wait — but bounded, so a
+            // slow first-run download cannot hold up post-recording AI indefinitely.
+            if let capturedInitTask {
+                await self?.awaitDiarizationInit(capturedInitTask)
+            }
             if let diarizer = capturedDiarizer {
-                await self?.processDiarization(for: meetingID, diarizer: diarizer)
+                await self?.processDiarization(for: meetingID, diarizer: diarizer, sessionStart: sessionStart)
             }
             guard let self else { return }
             if mode == .onlineMeeting {

--- a/LogueTests/SortformerTimelineTests.swift
+++ b/LogueTests/SortformerTimelineTests.swift
@@ -93,6 +93,43 @@ struct SortformerTimelineTests {
         #expect(result[0].endTime <= result[1].startTime)
     }
 
+    @Test("A gap narrow enough to be model jitter is closed")
+    func closesJitterGap() throws {
+        let result = SortformerTimeline.normalize([
+            update(0, 0, 10),
+            update(1, 11, 20),
+        ])
+
+        try #require(result.count == 2)
+        #expect(result[1].startTime == 10 + AppConstants.Diarization.timelineMaxGap)
+    }
+
+    @Test("A long silence is left as silence rather than given to the next speaker")
+    func doesNotCloseLongSilence() throws {
+        // Closing this would start Speaker 2 at 10.5 and hand them 19.5s they were not speaking for.
+        // Alignment compares true transcript times against these, so anything transcribed in the
+        // silence would be labelled Speaker 2 with full confidence.
+        let result = SortformerTimeline.normalize([
+            update(0, 0, 10),
+            update(1, 30, 40),
+        ])
+
+        try #require(result.count == 2)
+        #expect(result[1].startTime == 30)
+    }
+
+    @Test("The same speaker either side of a long silence is not joined across it")
+    func doesNotMergeSameSpeakerAcrossLongSilence() throws {
+        let result = SortformerTimeline.normalize([
+            update(0, 0, 10),
+            update(0, 30, 40),
+        ])
+
+        try #require(result.count == 2)
+        #expect(result[0].endTime == 10)
+        #expect(result[1].startTime == 30)
+    }
+
     @Test("Output is ordered by start time")
     func outputIsSorted() {
         let result = SortformerTimeline.normalize([

--- a/LogueTests/SortformerTimelineTests.swift
+++ b/LogueTests/SortformerTimelineTests.swift
@@ -1,0 +1,167 @@
+import Foundation
+@testable import Logue
+import Testing
+
+@Suite("Sortformer timeline normalization")
+struct SortformerTimelineTests {
+    // MARK: - Helpers
+
+    private func update(_ index: Int, _ start: TimeInterval, _ end: TimeInterval) -> SortformerSpeakerUpdate {
+        SortformerSpeakerUpdate(
+            speakerIndex: index,
+            speakerName: "Speaker \(index + 1)",
+            startTime: start,
+            endTime: end
+        )
+    }
+
+    // MARK: - Fragment filtering
+
+    @Test("Fragments below the minimum duration are discarded")
+    func dropsShortFragments() {
+        let result = SortformerTimeline.normalize([
+            update(0, 0, 5),
+            update(1, 5, 5.2),
+            update(0, 5.2, 10),
+        ])
+
+        #expect(result.allSatisfy { $0.endTime - $0.startTime >= AppConstants.Diarization.minSpeakerSegmentDuration })
+        #expect(result.allSatisfy { $0.speakerIndex == 0 })
+    }
+
+    // MARK: - Merging
+
+    @Test("Adjacent segments from the same speaker are merged across a small gap")
+    func mergesAdjacentSameSpeaker() {
+        let result = SortformerTimeline.normalize([
+            update(0, 0, 3),
+            update(0, 3.1, 6),
+        ])
+
+        #expect(result.count == 1)
+        #expect(result[0].startTime == 0)
+        #expect(result[0].endTime == 6)
+    }
+
+    @Test("Segments from different speakers are not merged")
+    func doesNotMergeDifferentSpeakers() {
+        let result = SortformerTimeline.normalize([
+            update(0, 0, 3),
+            update(1, 3.1, 6),
+        ])
+
+        #expect(result.count == 2)
+        #expect(result.map(\.speakerIndex) == [0, 1])
+    }
+
+    // MARK: - Alternation collapsing
+
+    @Test("A rapid A-B-A alternation collapses to the dominant speaker")
+    func collapsesRapidAlternation() {
+        // Three turns inside 0.8s is diarization flapping, not conversation.
+        let result = SortformerTimeline.normalize([
+            update(0, 0, 5),
+            update(1, 5, 5.3),
+            update(0, 5.3, 5.6),
+            update(1, 5.6, 12),
+        ])
+
+        #expect(result.map(\.speakerIndex) == [0, 1])
+    }
+
+    @Test("A genuine slow alternation is preserved")
+    func preservesSlowAlternation() {
+        let result = SortformerTimeline.normalize([
+            update(0, 0, 5),
+            update(1, 5, 10),
+            update(0, 10, 15),
+        ])
+
+        #expect(result.map(\.speakerIndex) == [0, 1, 0])
+    }
+
+    // MARK: - Continuity
+
+    @Test("Overlapping segments have their start clamped forward")
+    func clampsOverlappingStarts() {
+        let result = SortformerTimeline.normalize([
+            update(0, 0, 6),
+            update(1, 4, 10),
+        ])
+
+        #expect(result.count == 2)
+        #expect(result[0].endTime <= result[1].startTime)
+    }
+
+    @Test("Output is ordered by start time")
+    func outputIsSorted() {
+        let result = SortformerTimeline.normalize([
+            update(1, 10, 15),
+            update(0, 0, 5),
+            update(2, 20, 25),
+        ])
+
+        #expect(result.map(\.startTime) == result.map(\.startTime).sorted())
+    }
+
+    @Test("A segment fully swallowed by the preceding one is dropped rather than inverted")
+    func dropsSwallowedSegment() {
+        let result = SortformerTimeline.normalize([
+            update(0, 0, 10),
+            update(1, 2, 4),
+        ])
+
+        #expect(result.allSatisfy { $0.endTime > $0.startTime })
+    }
+
+    // MARK: - Speaker count is never forced
+
+    @Test("A three-speaker timeline keeps all three speakers")
+    func threeSpeakersSurvive() {
+        // Guards against reintroducing a hardcoded two-speaker collapse.
+        let result = SortformerTimeline.normalize([
+            update(0, 0, 20),
+            update(1, 20, 40),
+            update(2, 40, 60),
+        ])
+
+        #expect(Set(result.map(\.speakerIndex)) == [0, 1, 2])
+    }
+
+    @Test("A quiet but real third speaker is not folded into the others")
+    func quietThirdSpeakerSurvives() {
+        let result = SortformerTimeline.normalize([
+            update(0, 0, 60),
+            update(1, 60, 120),
+            update(2, 120, 124),
+        ])
+
+        #expect(Set(result.map(\.speakerIndex)) == [0, 1, 2])
+    }
+
+    // MARK: - Degenerate input
+
+    @Test("Empty input yields empty output")
+    func emptyInput() {
+        #expect(SortformerTimeline.normalize([]).isEmpty)
+    }
+
+    @Test("A single segment passes through unchanged")
+    func singleSegment() {
+        let result = SortformerTimeline.normalize([update(0, 0, 10)])
+
+        #expect(result.count == 1)
+        #expect(result[0].startTime == 0)
+        #expect(result[0].endTime == 10)
+    }
+
+    @Test("Input consisting only of fragments yields nothing")
+    func allFragments() {
+        let result = SortformerTimeline.normalize([
+            update(0, 0, 0.1),
+            update(1, 0.1, 0.2),
+        ])
+
+        #expect(result.isEmpty)
+    }
+}

--- a/LogueTests/SpeakerAlignmentTests.swift
+++ b/LogueTests/SpeakerAlignmentTests.swift
@@ -1,0 +1,330 @@
+import Foundation
+@testable import Logue
+import Testing
+
+@Suite("Speaker alignment")
+struct SpeakerAlignmentTests {
+    // MARK: - Helpers
+
+    private func speakerSegment(_ id: String, _ start: TimeInterval, _ end: TimeInterval) -> SpeakerSegment {
+        SpeakerSegment(speakerId: id, startTime: start, endTime: end)
+    }
+
+    private func transcript(
+        _ text: String,
+        _ start: TimeInterval,
+        _ end: TimeInterval,
+        label: String? = nil
+    ) -> TranscriptSegment {
+        TranscriptSegment(text: text, startTime: start, endTime: end, speakerLabel: label)
+    }
+
+    private let names = ["a": "Alice", "b": "Bob", "c": "Cleo"]
+
+    // MARK: - Overlap voting
+
+    @Test("The majority-overlap speaker wins even when the segment midpoint lands on another")
+    func overlapBeatsMidpoint() {
+        // Alice holds 9.2s of this segment, Bob 0.8s — but the midpoint (5.0) falls inside Bob's
+        // brief interjection, which is exactly what midpoint-nearest matching gets wrong.
+        let result = SpeakerAlignment.align(
+            segments: [transcript("one", 0, 10)],
+            speakerSegments: [
+                speakerSegment("a", 0, 4.6),
+                speakerSegment("b", 4.6, 5.4),
+                speakerSegment("a", 5.4, 10),
+            ],
+            speakerNamesByID: names
+        )
+
+        #expect(result.map(\.speakerLabel) == ["Alice"])
+    }
+
+    @Test("A near-tie in overlap keeps the previous segment's speaker")
+    func ambiguousOverlapPrefersContinuity() {
+        let result = SpeakerAlignment.align(
+            segments: [transcript("one", 0, 1), transcript("two", 1, 2)],
+            speakerSegments: [
+                speakerSegment("a", 0, 1),
+                speakerSegment("a", 1, 1.45),
+                speakerSegment("b", 1.45, 2),
+            ],
+            speakerNamesByID: names
+        )
+
+        // Bob has marginally more overlap on the second segment (0.55 vs 0.45), but not enough
+        // to justify a switch — without the guard this would read Alice, Bob.
+        #expect(result.map(\.speakerLabel) == ["Alice", "Alice"])
+    }
+
+    @Test("A near-tie with no previous speaker takes the greater overlap")
+    func ambiguousOverlapWithoutPreviousTakesWinner() {
+        let result = SpeakerAlignment.align(
+            segments: [transcript("two", 1, 2)],
+            speakerSegments: [speakerSegment("a", 1, 1.45), speakerSegment("b", 1.45, 2)],
+            speakerNamesByID: names
+        )
+
+        #expect(result.map(\.speakerLabel) == ["Bob"])
+    }
+
+    @Test("A decisive overlap still switches speakers")
+    func decisiveOverlapSwitches() {
+        let result = SpeakerAlignment.align(
+            segments: [transcript("one", 0, 1), transcript("two", 1, 2)],
+            speakerSegments: [speakerSegment("a", 0, 1), speakerSegment("b", 1, 2)],
+            speakerNamesByID: names
+        )
+
+        #expect(result.map(\.speakerLabel) == ["Alice", "Bob"])
+    }
+
+    // MARK: - Splitting at speaker boundaries
+
+    @Test("A segment spanning two speakers is split at the boundary")
+    func splitsAtSpeakerBoundary() {
+        let result = SpeakerAlignment.align(
+            segments: [transcript("one two three four five six seven eight nine ten", 0, 10)],
+            speakerSegments: [speakerSegment("a", 0, 5), speakerSegment("b", 5, 10)],
+            speakerNamesByID: names
+        )
+
+        #expect(result.count == 2)
+        #expect(result.map(\.speakerLabel) == ["Alice", "Bob"])
+        #expect(result[0].startTime == 0)
+        #expect(result[0].endTime == 5)
+        #expect(result[1].startTime == 5)
+        #expect(result[1].endTime == 10)
+    }
+
+    @Test("Splitting distributes the text without losing or duplicating words")
+    func splitPreservesEveryWord() {
+        let original = "one two three four five six seven eight nine ten"
+        let result = SpeakerAlignment.align(
+            segments: [transcript(original, 0, 10)],
+            speakerSegments: [speakerSegment("a", 0, 5), speakerSegment("b", 5, 10)],
+            speakerNamesByID: names
+        )
+
+        let rejoined = result.map(\.text).joined(separator: " ")
+        #expect(rejoined == original)
+    }
+
+    @Test("A segment spanning three speakers splits into three parts")
+    func splitsIntoThreeParts() {
+        let result = SpeakerAlignment.align(
+            segments: [transcript("one two three four five six", 0, 9)],
+            speakerSegments: [
+                speakerSegment("a", 0, 3),
+                speakerSegment("b", 3, 6),
+                speakerSegment("c", 6, 9),
+            ],
+            speakerNamesByID: names
+        )
+
+        #expect(result.map(\.speakerLabel) == ["Alice", "Bob", "Cleo"])
+    }
+
+    @Test("A segment with fewer words than speaker ranges is left whole")
+    func tooFewWordsToSplit() {
+        // Splitting "hi" across two speakers would have to invent or drop text.
+        let result = SpeakerAlignment.align(
+            segments: [transcript("hi", 0, 10)],
+            speakerSegments: [speakerSegment("a", 0, 5), speakerSegment("b", 5, 10)],
+            speakerNamesByID: names
+        )
+
+        #expect(result.count == 1)
+        #expect(result[0].text == "hi")
+    }
+
+    @Test("A brushing overlap below the meaningful threshold does not trigger a split")
+    func negligibleOverlapDoesNotSplit() {
+        let result = SpeakerAlignment.align(
+            segments: [transcript("one two three four", 0, 5.05)],
+            speakerSegments: [speakerSegment("a", 0, 5), speakerSegment("b", 5, 10)],
+            speakerNamesByID: names
+        )
+
+        #expect(result.count == 1)
+        #expect(result[0].speakerLabel == "Alice")
+    }
+
+    // MARK: - No transcript loss
+
+    @Test("A segment shorter than the split minimum is never dropped")
+    func shortSegmentSurvives() {
+        let result = SpeakerAlignment.align(
+            segments: [transcript("Yes.", 0, 0.3)],
+            speakerSegments: [speakerSegment("a", 0, 0.3)],
+            speakerNamesByID: names
+        )
+
+        #expect(result.count == 1)
+        #expect(result[0].text == "Yes.")
+        #expect(result[0].speakerLabel == "Alice")
+    }
+
+    @Test("Alignment never reduces the number of transcript segments")
+    func neverLosesSegments() {
+        let segments = [
+            transcript("a", 0, 0.2),
+            transcript("b", 0.2, 0.5),
+            transcript("c", 0.5, 12),
+            transcript("d", 12, 12.1),
+        ]
+        let result = SpeakerAlignment.align(
+            segments: segments,
+            speakerSegments: [speakerSegment("a", 0, 6), speakerSegment("b", 6, 13)],
+            speakerNamesByID: names
+        )
+
+        #expect(result.count >= segments.count)
+    }
+
+    // MARK: - Existing labels are protected
+
+    @Test("An already-labelled segment is neither relabelled nor split")
+    func existingLabelIsPreserved() {
+        let result = SpeakerAlignment.align(
+            segments: [transcript("one two three four", 0, 10, label: "You")],
+            speakerSegments: [speakerSegment("a", 0, 5), speakerSegment("b", 5, 10)],
+            speakerNamesByID: names
+        )
+
+        #expect(result.count == 1)
+        #expect(result[0].speakerLabel == "You")
+    }
+
+    @Test("A protected label is not rewritten by smoothing")
+    func smoothingSkipsProtectedLabels() {
+        let result = SpeakerAlignment.align(
+            segments: [
+                transcript("one", 0, 1),
+                transcript("two", 1, 1.5, label: "You"),
+                transcript("three", 1.5, 2.5),
+            ],
+            speakerSegments: [
+                speakerSegment("a", 0, 1),
+                speakerSegment("a", 1, 1.5),
+                speakerSegment("a", 1.5, 2.5),
+            ],
+            speakerNamesByID: names
+        )
+
+        #expect(result.map(\.speakerLabel) == ["Alice", "You", "Alice"])
+    }
+
+    // MARK: - Island smoothing
+
+    @Test("A brief single-segment island adopts the speaker flanking it")
+    func smoothsBriefIsland() {
+        let result = SpeakerAlignment.align(
+            segments: [
+                transcript("one", 0, 1),
+                transcript("two", 1, 1.5),
+                transcript("three", 1.5, 2.5),
+            ],
+            speakerSegments: [
+                speakerSegment("a", 0, 1),
+                speakerSegment("b", 1, 1.5),
+                speakerSegment("a", 1.5, 2.5),
+            ],
+            speakerNamesByID: names
+        )
+
+        #expect(result.map(\.speakerLabel) == ["Alice", "Alice", "Alice"])
+    }
+
+    @Test("A substantial island keeps its own speaker")
+    func keepsSubstantialIsland() {
+        // 2 seconds of speech is a real turn, not diarization flapping.
+        let result = SpeakerAlignment.align(
+            segments: [
+                transcript("one", 0, 1),
+                transcript("two", 1, 3),
+                transcript("three", 3, 4),
+            ],
+            speakerSegments: [
+                speakerSegment("a", 0, 1),
+                speakerSegment("b", 1, 3),
+                speakerSegment("a", 3, 4),
+            ],
+            speakerNamesByID: names
+        )
+
+        #expect(result.map(\.speakerLabel) == ["Alice", "Bob", "Alice"])
+    }
+
+    // MARK: - Fallback window
+
+    @Test("A segment just past a speaker's end still borrows that speaker")
+    func fallbackWithinTolerance() {
+        let result = SpeakerAlignment.align(
+            segments: [transcript("one", 5.2, 6)],
+            speakerSegments: [speakerSegment("a", 0, 5)],
+            speakerNamesByID: names
+        )
+
+        #expect(result.map(\.speakerLabel) == ["Alice"])
+    }
+
+    @Test("A segment far from every speaker is left unlabelled")
+    func noFallbackBeyondTolerance() {
+        let result = SpeakerAlignment.align(
+            segments: [transcript("one", 10, 11)],
+            speakerSegments: [speakerSegment("a", 0, 5)],
+            speakerNamesByID: names
+        )
+
+        #expect(result.map(\.speakerLabel) == [nil])
+    }
+
+    // MARK: - Degenerate input
+
+    @Test("With no speaker segments the transcript is returned untouched")
+    func noSpeakerSegments() {
+        let segments = [transcript("one", 0, 1), transcript("two", 1, 2)]
+        let result = SpeakerAlignment.align(
+            segments: segments,
+            speakerSegments: [],
+            speakerNamesByID: names
+        )
+
+        #expect(result.map(\.text) == ["one", "two"])
+        #expect(result.map(\.speakerLabel) == [nil, nil])
+    }
+
+    @Test("An empty transcript yields an empty result")
+    func emptyTranscript() {
+        let result = SpeakerAlignment.align(
+            segments: [],
+            speakerSegments: [speakerSegment("a", 0, 5)],
+            speakerNamesByID: names
+        )
+
+        #expect(result.isEmpty)
+    }
+
+    @Test("A speaker id with no name mapping does not produce a label")
+    func unmappedSpeakerID() {
+        let result = SpeakerAlignment.align(
+            segments: [transcript("one", 0, 1)],
+            speakerSegments: [speakerSegment("ghost", 0, 1)],
+            speakerNamesByID: names
+        )
+
+        #expect(result.map(\.speakerLabel) == [nil])
+    }
+
+    @Test("A single speaker labels the whole transcript")
+    func singleSpeaker() {
+        let result = SpeakerAlignment.align(
+            segments: [transcript("one", 0, 1), transcript("two", 1, 2), transcript("three", 2, 3)],
+            speakerSegments: [speakerSegment("a", 0, 3)],
+            speakerNamesByID: names
+        )
+
+        #expect(result.allSatisfy { $0.speakerLabel == "Alice" })
+    }
+}

--- a/LogueTests/SpeakerAlignmentTests.swift
+++ b/LogueTests/SpeakerAlignmentTests.swift
@@ -68,6 +68,32 @@ struct SpeakerAlignmentTests {
         #expect(result.map(\.speakerLabel) == ["Bob"])
     }
 
+    @Test("One speaker on both sides of an interjection is not their own runner-up")
+    func interjectionDoesNotCreateFalseAmbiguity() {
+        // Alice holds 1.8s of the second segment across two turns (1.0 then 0.8), Bob 0.2s in
+        // between. Ranking speaker *segments* rather than speakers made Alice her own runner-up, so
+        // 0.8 against 1.0 read as too close to call and continuity handed the whole sentence to Bob
+        // — the interjection failure this type exists to fix, arriving by another route.
+        //
+        // The 0.2s middle is below `minSplitPartDuration`, so splitting correctly declines and the
+        // vote decides the segment on its own.
+        let result = SpeakerAlignment.align(
+            segments: [
+                transcript("hello there", 0, 1.0),
+                transcript("this is a longer sentence", 1.0, 3.0),
+            ],
+            speakerSegments: [
+                speakerSegment("b", 0, 1.0),
+                speakerSegment("a", 1.0, 2.0),
+                speakerSegment("b", 2.0, 2.2),
+                speakerSegment("a", 2.2, 3.1),
+            ],
+            speakerNamesByID: names
+        )
+
+        #expect(result.map(\.speakerLabel) == ["Bob", "Alice"])
+    }
+
     @Test("A decisive overlap still switches speakers")
     func decisiveOverlapSwitches() {
         let result = SpeakerAlignment.align(
@@ -254,6 +280,26 @@ struct SpeakerAlignmentTests {
         )
 
         #expect(result.map(\.speakerLabel) == ["Alice", "Bob", "Alice"])
+    }
+
+    @Test("Smoothing does not undo a split made at a speaker boundary")
+    func smoothingLeavesSplitPartsAlone() {
+        // The middle part is 0.6s — long enough to be created, short enough to look like flapping to
+        // smoothing, and flanked by the same speaker on both sides. The split boundary came from the
+        // speaker timeline and outranks a guess made from the neighbours.
+        let result = SpeakerAlignment.align(
+            segments: [transcript("one two three four five six", 0, 3.0)],
+            speakerSegments: [
+                speakerSegment("a", 0, 1.2),
+                speakerSegment("b", 1.2, 1.8),
+                speakerSegment("a", 1.8, 3.0),
+            ],
+            speakerNamesByID: names
+        )
+
+        #expect(result.count == 3)
+        #expect(result.map(\.speakerLabel) == ["Alice", "Bob", "Alice"])
+        #expect(result.map(\.text).joined(separator: " ") == "one two three four five six")
     }
 
     // MARK: - Fallback window

--- a/docs/specs/2026-07-28-diarization-alignment-recovery.md
+++ b/docs/specs/2026-07-28-diarization-alignment-recovery.md
@@ -1,0 +1,311 @@
+# Diarization Alignment and Timeline Recovery
+
+**Date:** 2026-07-28
+**Status:** Approved for implementation
+
+## Background
+
+Three pre-open-source pull requests worked on transcription and diarization quality. One merged
+before the repository was published; two were closed unmerged during branch cleanup three days
+before publication, and their work never reached this repository.
+
+The merged branch introduced batch Parakeet TDT ASR plus Silero VAD, which replaces the streaming
+transcript after recording stops. That work is present in `DiarizationManager+BatchASR.swift` and
+`MeetingStore+Diarization.replaceTranscript(for:with:)`.
+
+The two unmerged branches were parallel, not sequential — neither is a superset of the other:
+
+- One rewrote transcript-to-speaker alignment and normalized Sortformer's raw output.
+- One replaced Apple Speech with a FluidAudio streaming ASR engine for the live preview.
+
+Both branches were stale enough that their diffs revert later `main` changes — they strip `Sendable`
+from `Speaker`, `SpeakerSegment`, `ActionItem`, `DiarizationConfig`, and roughly ten other types, and
+one downgrades `project.pbxproj` `objectVersion` from 77 to 63. That is branch drift, not work to
+recover.
+
+A separate bug report (issue #31) describes the app crashing after a user renamed two speakers to the
+same name — the user was merging rows that the alignment problems below had split apart. That crash
+is unrelated to any of the three branches and is designed and delivered separately, in
+[2026-07-28-duplicate-speaker-name-crash.md](2026-07-28-duplicate-speaker-name-crash.md).
+
+## Scope Decisions
+
+**The streaming ASR engine is out of scope.** Batch Parakeet already overwrites the final transcript
+after recording stops, so a streaming engine changes only the throwaway live preview. The cost is a
+second ASR model download and roughly 600 lines of new heuristics — a pending volatile queue,
+volatile-stable promotion, synthetic timeline generation — sitting directly on the recording hot path.
+The benefit does not survive the batch pass that follows it.
+
+**Hardcoded two-speaker collapsing is out of scope.** Both unmerged branches assume a two-speaker
+world: one takes the top two speakers by total speech duration and remaps everyone else onto them;
+the other collapses any third speaker into the temporally nearest of two. On a genuine three- or
+four-person meeting these destroy correct output. The speaker-count-agnostic parts of that work
+(minimum-duration filtering, same-speaker merging, alternation collapsing) are in scope; the top-two
+remapping is not.
+
+**No identifying information carries over.** The private Apple `DEVELOPMENT_TEAM` identifier that
+appears in one branch's `project.pbxproj` is not ported — and is moot regardless, since this project
+generates `project.pbxproj` via XcodeGen. Branch names, personal names, PR numbers, and
+`Co-authored-by` trailers from the closed branches appear nowhere in code, comments, or commit
+messages. All commits are authored as `westerosweb`.
+
+## What the current code already does well
+
+Parts of the unmerged branches are already superseded here and must not be re-introduced:
+
+- `renumberSpeakers(for:)` in `RecordingSessionManager+Diarization.swift` already fixes
+  non-contiguous speaker numbering ("Speaker 1" and "Speaker 3" for a two-speaker meeting) and
+  additionally prunes speakers holding no transcript segments. It is strictly better than the
+  contiguous-remap function one branch proposed.
+- Live and periodic diarization are already inert: `DiarizationManager.startPeriodicProcessing` and
+  `RecordingSessionManager+Diarization.applyDiarizationResult` have no callers anywhere in the
+  codebase. The "switch from live to post-recording diarization" goal of one branch is already met,
+  so its approach of wrapping the periodic path in `if false { ... }` is unnecessary.
+- Sortformer diarization and batch Parakeet ASR already run concurrently over one buffer snapshot in
+  `processSortformerDiarization`.
+
+## Alignment rewrite
+
+`MeetingStore+Diarization.updateSpeakerData` currently assigns speaker labels by taking each
+transcript segment's midpoint and finding the nearest speaker segment within
+`AppConstants.Diarization.speakerLabelTolerance` (3.5 seconds). A midpoint carries no information
+about how much of the segment each speaker actually occupies, and a 3.5-second nearest-neighbour
+window will label a segment from a speaker who was not talking during it.
+
+A new pure type, `Logue/Engine/SpeakerAlignment.swift`, replaces that with:
+
+- **Overlap-duration voting.** The speaker with the greatest temporal overlap wins, rather than the
+  one nearest the midpoint.
+- **Chunked weighted majority.** Transcript segments longer than `chunkThresholdSeconds` are divided
+  into `chunkDurationSeconds` slices; each slice votes, weighted by its duration. A long segment
+  spanning a speaker change no longer collapses to a single label chosen by its midpoint.
+- **Continuity under ambiguity.** When the runner-up speaker holds at least `ambiguityOverlapRatio`
+  of the winner's overlap, the interval genuinely spans both speakers and picking the marginal
+  winner is a coin flip, so the previous segment's speaker is kept instead. This suppresses
+  single-segment speaker flapping.
+
+  The source branch had two separate guards here — this one plus a `continuityThreshold` requiring
+  a switch to beat the previous speaker's overlap by 5%. The second is unreachable: the previous
+  speaker's overlap can never exceed the runner-up's (the runner-up is by definition the largest
+  non-winner), so any case that would trip the continuity threshold trips the ambiguity check
+  first. Only one guard is implemented.
+- **Boundary splitting.** A transcript segment overlapping two or more speaker ranges by a meaningful
+  margin is split at the boundaries, with its text distributed across the parts in proportion to
+  their durations. Parts are butted against each other so the split covers the original span with no
+  holes. Splitting is abandoned — the segment kept whole — whenever a faithful split is impossible:
+  too many speakers, a part that would fall below `minSplitPartDuration`, or fewer words than parts.
+  Splitting must never invent, duplicate, or drop text.
+- **Island smoothing.** A single segment flanked on both sides by the same other speaker adopts that
+  speaker, bounded to islands shorter than `maxSmoothedIslandDuration`. The source branch smoothed
+  regardless of duration, which would erase a genuine short turn ("Yes", "I agree"); with timeline
+  normalization already collapsing rapid alternations upstream, a two-second island is far more
+  likely to be real speech than model flapping.
+- **Tight fallback.** When no speaker segment overlaps at all, the nearest-neighbour fallback window
+  is capped at 0.5 seconds rather than 3.5. `speakerLabelTolerance` keeps its current value and its
+  current role in `alignTranscriptionWithSpeakers`, which gathers text into speaker segments and is a
+  different operation.
+
+Several elements of the source branch are deliberately excluded.
+
+Two on style grounds: a file-scope `var alignmentRunCounterByMeetingID` dictionary (mutable global
+state, unsynchronized, serving only debug telemetry), and per-segment `Logger.info` calls, which
+would emit thousands of log lines per meeting. Summary-level logging is retained.
+
+Two because they are defects:
+
+- Its word-distribution routine reduces per-part word targets in a `while excess > 0` loop that only
+  decrements a target already greater than one, and resets its cursor when it runs off the end. When
+  every part needs one word but there are fewer words than parts, no target is reducible and the loop
+  never terminates. Splitting a short segment across two speakers would hang the post-recording
+  pipeline. The replacement allocates words by cumulative proportion and returns "do not split" when
+  there are fewer words than parts.
+- Its ordering clamp drops any segment shorter than 0.6 seconds, and it runs across the whole output
+  rather than only over generated split parts — so short original segments ("Yes.", "Okay.") are
+  silently deleted from the transcript. Ordering here never drops a segment: if a split would produce
+  an undersized part, the split is abandoned and the original kept.
+
+`MeetingStore+Diarization.updateSpeakerData` keeps its signature and its early-out when every
+transcript segment already carries a label; it delegates the algorithm to `SpeakerAlignment` and
+remains responsible only for reading, writing, and persisting.
+
+## Sortformer timeline normalization
+
+Raw Sortformer output currently flows into speaker data unmodified. The source branch's own benchmark
+note recorded three detected speakers for a two-speaker recording, with overlapping and fragmented
+segments. A new pure type, `Logue/Engine/SortformerTimeline.swift`, normalizes the timeline before it
+becomes `SpeakerSegment` data:
+
+- Discard segments shorter than `minSpeakerSegmentDuration`.
+- Merge adjacent segments from the same speaker separated by less than `sameSpeakerMergeGap`.
+- Collapse rapid A-B-A alternations within `alternationWindowSeconds` to the dominant speaker by
+  duration.
+- Enforce timeline continuity: clamp overlapping starts forward, and cap gaps so a normalized
+  timeline has no unexplained holes.
+
+Called from `processSortformerDiarization` before `applySortformerUpdates`. Speaker-count-agnostic
+throughout — no step assumes or enforces a speaker count.
+
+## Model preload — no change needed
+
+This item was planned and then dropped: the current code already does it, and does more.
+
+`DiarizationManager.prewarmGlobalCache()` runs from `RecordingSessionManager`'s initializer at app
+launch and warms the Sortformer, Parakeet ASR, and Silero VAD caches. The source branch's
+`preloadModels()` covered Sortformer only, so porting it would have been a regression in coverage and
+a duplicate of existing behaviour. No preload work is included.
+
+## Bounded wait for model initialization on stop
+
+`RecordingSessionManager.stopRecording` sets `diarizationInitTask = nil` without awaiting it. The
+decision not to *cancel* is correct and already documented in the code — cancelling would abort a
+model download mid-flight. But not awaiting means that if models are still initializing when
+recording stops, `diarizer.isStreamingActive` is `false` and `processDiarization` silently degrades
+to the batch fallback.
+
+`stopRecording` will await the captured init task with a bounded timeout before invoking
+`processDiarization`, so post-recording AI is never blocked indefinitely. The timeout is a named
+constant in `AppConstants.Delays`, not an inline literal.
+
+## Resumed-recording correctness
+
+This bug is not addressed by any of the three branches and was found while comparing them against
+current code.
+
+`RecordingSessionManager` sets `timeOffset` when recording resumes into an existing meeting, and
+tags streaming transcript segments with it. Diarization and batch-ASR output are not offset:
+
+- `applySortformerUpdates` and `mergeDiarizationResult` write Sortformer and batch-diarizer
+  timestamps unmodified, and those are session-relative, starting at zero.
+- `DiarizationManager.transcribeBuffer` returns batch-ASR segments derived from token timings over
+  the current session's buffer, also starting at zero.
+- `replaceTranscript(for:with:)` **assigns** `meetings[index].segments`, so on a resumed recording it
+  discards every segment from earlier sessions.
+
+The consequence is transcript loss on resume, plus speaker labels aligned against the wrong
+timebase. One unmerged branch introduced a `timeOffset` parameter along this call chain, but it
+predates the batch-ASR work and so does not cover the destructive replace.
+
+The fix threads the session's `timeOffset` — captured in `stopRecording` before it is reset to zero —
+through `processDiarization` into `applySortformerUpdates`, `mergeDiarizationResult`, and the
+batch-ASR result, and narrows `replaceTranscript` to the current session's time range so
+earlier-session segments survive. Delivered as its own commit within Part 2's pull request, since it
+touches the same signatures.
+
+## Dead code and stale documentation
+
+The following are unreachable and will be removed:
+
+- `DiarizationManager.startPeriodicProcessing(onUpdate:)`, `stopPeriodicProcessing()`,
+  `processIncrementalChunk()`, `processRemainingChunk()`, and the `periodicTask`,
+  `lastProcessedSampleIndex`, and `lastProcessedTime` state they carried
+- `RecordingSessionManager+Diarization.applyDiarizationResult(_:for:isPeriodic:)`
+- `RecordingSessionManager.isPeriodicDiarizationStopped` and `hasPeriodicDiarizationResults`, and the
+  `isFinalizing || !isPeriodicDiarizationStopped` guard in `applySortformerUpdates` that reads them.
+  With the guard gone, `applySortformerUpdates` no longer needs its `isFinalizing` parameter.
+- `AppConstants.Delays.batchDiarizationInitialDelay`, used only by the periodic loop
+
+Stale comments will be corrected, including the `RecordingSessionManager` comment describing
+post-recording diarization via `processCompleteRecording()` — superseded by `processCompleteWith(_:)`
+— and the `MeetingStore+Diarization` comment attributing existing labels to "periodic diarization",
+a path that no longer runs.
+
+`SpeakerDetectionStatus` keeps its current cases and its `.active` value during recording. That value
+is defensible — audio is being accumulated for speaker detection — and changing it is UI churn
+outside this work's purpose.
+
+## New constants
+
+Added to `AppConstants.Diarization`: `minSpeakerSegmentDuration`, `sameSpeakerMergeGap`,
+`alternationWindowSeconds`, `timelineMaxGap`, `chunkThresholdSeconds`, `chunkDurationSeconds`,
+`ambiguityOverlapRatio`, `labelFallbackTolerance`, `minSplitOverlap`, `minSplitPartDuration`,
+`maxSplitParts`, and `maxSmoothedIslandDuration`. The source branch hardcoded most of these inline.
+`continuityThreshold` is not added — see the unreachable second guard noted above. The model-init
+wait timeout, `diarizationInitStopWait`, goes in `AppConstants.Delays`, replacing the
+now-unused `batchDiarizationInitialDelay`.
+
+## Architecture
+
+Both new types are pure: value inputs, value outputs, no `MeetingStore`, no `RecordingSessionManager`,
+no `Logger` dependency injected through a store, no global mutable state.
+
+```text
+RecordingSessionManager+Diarization.processSortformerDiarization
+    │
+    ├── DiarizationManager.takeAudioBuffer()
+    ├── DiarizationManager.processCompleteWith(_:)   ─┐ concurrent
+    ├── DiarizationManager.transcribeBuffer(_:)      ─┘
+    │
+    ├── MeetingStore.replaceTranscript(for:with:sessionStart:)
+    │       └── final text is in place before any speaker is assigned
+    │
+    ├── SortformerTimeline.normalize(_:)              ← new, pure
+    ├── applySortformerUpdates(_:for:sessionStart:)
+    │       └── MeetingStore.updateSpeakerData(for:speakers:speakerSegments:)
+    │               └── SpeakerAlignment.align(...)   ← new, pure
+    │
+    └── renumberSpeakers(for:)
+```
+
+Batch ASR replaces the transcript *before* speakers are assigned, so alignment runs against the final
+text rather than the streaming draft it supersedes. The source branch ordered these the other way
+round, which meant labels were computed against text that was about to be discarded.
+
+Keeping the algorithms out of the extension files matters for size as well as clarity.
+`RecordingSessionManager+Diarization.swift` is 446 lines today; absorbing the timeline normalization
+inline would push it past the project's ~500-line extension guideline.
+`MeetingStore+Diarization.swift` is 71 lines and would stay under that ceiling at roughly 470, but it
+would stop being a persistence extension and become an alignment engine with a store attached — the
+concern the guideline exists to prevent.
+
+## Testing
+
+Swift Testing suites (`@Suite`, `@Test`, `#expect`) in `LogueTests/`. Both are pure logic — no
+model downloads, no inference, seconds to run, unlike the `LogueTests/LLMIntegration` suites.
+
+**`SpeakerAlignmentTests.swift`** (21 tests)
+
+- Overlap voting picks the majority-overlap speaker where midpoint matching picks the wrong one
+- A near-tie keeps the previous speaker; a near-tie with no previous speaker takes the winner; a
+  decisive overlap still switches
+- A segment spanning two, then three, speakers splits at the boundaries, and every word survives the
+  redistribution
+- Splitting is declined when there are fewer words than parts, and when the second speaker's overlap
+  is negligible
+- A segment shorter than the split minimum is never dropped, and alignment never returns fewer
+  segments than it received
+- An already-labelled segment is neither relabelled, split, nor smoothed
+- A brief island is smoothed; a two-second island keeps its own speaker
+- The 0.5s fallback labels a segment just past a speaker's end and declines one far from every speaker
+- Empty speaker segments, empty transcript, an unmapped speaker id, and a single speaker are handled
+
+**`SortformerTimelineTests.swift`** (13 tests)
+
+- Sub-threshold fragments are discarded, and input consisting only of fragments yields nothing
+- Adjacent same-speaker segments within the merge gap combine; different speakers do not
+- A-B-A alternation inside the window collapses to the duration-dominant speaker; a slow alternation
+  is preserved
+- Overlapping starts clamp forward, a fully swallowed segment is dropped rather than inverted, and
+  output is ordered by start time
+- A three-speaker timeline keeps all three speakers, including a quiet third speaker — the regression
+  guard against reintroducing two-speaker collapsing
+- Empty input returns empty; a single segment passes through unchanged
+
+The three guards that carry the most judgement — the ambiguity check, the island-duration bound, and
+splitting — were each verified by mutation: disabling the guard in the implementation must fail the
+specific test written for it. Tests that cannot fail prove nothing, and a suite that passes on the
+first implementation attempt deserves that check.
+
+## Verification
+
+1. `xcodegen generate` — both new files land under `Logue/`, which the target discovers by path
+2. `xcodebuild build -project Logue.xcodeproj -scheme Logue -destination 'platform=macOS'`
+3. The two new suites, plus the existing non-LLM suites, pass
+4. SwiftFormat and SwiftLint clean via the pre-commit hooks, with no new suppressions
+
+## Known Limitation
+
+Diarization accuracy cannot be measured from code review. The alignment and splitting changes are
+well-reasoned, and the fragmentation they target is documented in the source branch's own benchmark
+note — but "improves quality" is a claim that requires a real multi-speaker recording to confirm. The
+unit tests verify the algorithms behave as specified on constructed inputs; they do not establish an
+accuracy improvement on real audio. That verification is a manual step after implementation.


### PR DESCRIPTION
Recovers the transcription/diarization work that was in flight before the repo was published and
never landed here. Design doc ships in #32 (`docs/specs/2026-07-28-diarization-recovery-design.md`).

## Why speaker labels are wrong today

Labels are assigned by taking each transcript segment's **midpoint** and finding the nearest speaker
segment within **3.5 seconds**. A midpoint carries no information about how much of a segment each
speaker holds, so a brief interjection landing mid-sentence captures the whole sentence — and a 3.5s
nearest-neighbour window will label a segment from a speaker who was not talking during it at all.

Raw Sortformer output makes it worse: sub-second slivers, single turns split across segments, and
rapid alternations, all fed straight into that matcher. This is the fragmentation the earlier
benchmark work observed (three speakers reported for a two-speaker recording).

## What changed

**`SpeakerAlignment`** (new, pure) — overlap-duration voting; segments over 2s chunked with each
slice voting weighted by duration; a near-tie keeps the previous speaker instead of flipping on a
marginal difference; segments genuinely spanning two speakers split at the boundary with text
distributed proportionally; brief islands smoothed; fallback tightened from 3.5s to 0.5s and applied
only when nothing overlaps.

**`SortformerTimeline`** (new, pure) — filters fragments, merges same-speaker runs, collapses rapid
alternations, closes up overlaps and gaps, before any of it becomes speaker data.

Both live outside the store, so 34 unit tests cover them with no models and millisecond runtime.

## Deliberately not ported

The earlier branches both hardcode a two-speaker world — one remaps everyone outside the top two by
duration onto them, the other collapses any third speaker into the nearest of two. On a real
three- or four-person meeting that destroys correct output. Every step here is speaker-count
agnostic, and two tests exist purely to guard against reintroducing it.

Also skipped: replacing Apple Speech with a streaming FluidAudio engine. Batch Parakeet already
overwrites the final transcript after stop, so that change only affects the live preview, at the cost
of a second model download and ~600 lines of heuristics on the recording hot path.

Two defects in the source branch are documented in the design doc rather than ported: a
word-distribution loop that never terminates when there are fewer words than parts (would hang the
post-recording pipeline), and an ordering clamp that silently deletes any transcript segment under
0.6 seconds. Its `continuityThreshold` guard is unreachable — the previous speaker's overlap can
never exceed the runner-up's — so one guard is implemented, not two.

## Transcript loss on resumed recordings

Found while comparing the branches, fixed here. Both diarizers and batch ASR time their output from
the start of the session's own audio buffer, but `replaceTranscript` **assigned** over the whole
segment array. Recording again into an existing meeting therefore discarded everything transcribed
earlier and misaligned what remained. The session offset is threaded through and only that session's
segments are replaced.

## Reliability and cleanup

Stopping while models were still downloading left Sortformer not streaming, silently degrading to the
batch path. Stop now waits for initialization, capped by `diarizationInitStopWait` so a slow first
run cannot hold up post-recording AI.

Removes the live/periodic diarization path, which has had no callers for some time:
`startPeriodicProcessing`, `stopPeriodicProcessing`, `processIncrementalChunk`,
`processRemainingChunk`, `applyDiarizationResult`, their state, and the two flags gating them.
Comments describing live speaker updates and a `processCompleteRecording()` call site now match what
the pipeline actually does.

No preload work is included — `prewarmGlobalCache()` already warms Sortformer, ASR, and VAD at
launch, which is more than the source branch's Sortformer-only preload.

## Verification

- Build: succeeded
- Full non-LLM suite: **465 tests in 46 suites passed** (was 444 before the two new suites)
- SwiftFormat and SwiftLint: clean, no new suppressions — `awaitDiarizationInit` was placed in the
  diarization extension rather than suppressing a `file_length` violation
- The three guards carrying the most judgement (ambiguity check, island-duration bound, splitting)
  were each mutation-verified: disabling the guard fails the specific test written for it

## What still needs a human

Diarization accuracy cannot be measured from code review. The algorithms behave as specified on
constructed inputs, but **whether this measurably improves labelling on real audio needs a
multi-speaker recording** — worth checking before merge, ideally on the kind of meeting that produced
the original complaint.
