### PR TITLE
Wire up the editor affordances whose models were already written (#9, #10, #11, #12, #13, #14, #15)

### DIFF
--- a/Logue.xcodeproj/project.pbxproj
+++ b/Logue.xcodeproj/project.pbxproj
@@ -447,6 +447,7 @@
 		D9A6E157B7388F93053A45EB /* CommandCenterNewMeetingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7300054D056065027CC1FF3 /* CommandCenterNewMeetingView.swift */; };
 		D9AB840EBB96846249E397A7 /* MeetingAIChatPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5EAC4820F6E13CFDE208D0 /* MeetingAIChatPanelView.swift */; };
 		DA09144C59EB500FC57CC929 /* HapticFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22933096283C449A4669F1BF /* HapticFeedback.swift */; };
+		DB5F93E698ADB73400C9EFC4 /* QuickOpenCandidateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9048A84C6D32D4327622137 /* QuickOpenCandidateTests.swift */; };
 		DB7FBB80B66B893EFB636750 /* MeetingStore+WelcomeMeeting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C9C2F4FFD45E6CE518D8C39 /* MeetingStore+WelcomeMeeting.swift */; };
 		DD3720347A5EBD370B3A60EE /* StatusBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB25376AFA88E0F16400AA7 /* StatusBadge.swift */; };
 		DD5DA3825C26BBEF11ADF223 /* AgentChatEmptyState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91DA817000619561CE8DA7FB /* AgentChatEmptyState.swift */; };
@@ -875,6 +876,7 @@
 		A81080B89B0F0AC01017D6D7 /* ModelManager+HuggingFace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ModelManager+HuggingFace.swift"; sourceTree = "<group>"; };
 		A864D7C5937FF77CB9835242 /* DocumentListContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentListContentView.swift; sourceTree = "<group>"; };
 		A8ACC65E14034118E968BBE6 /* DocsHomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocsHomeView.swift; sourceTree = "<group>"; };
+		A9048A84C6D32D4327622137 /* QuickOpenCandidateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickOpenCandidateTests.swift; sourceTree = "<group>"; };
 		A92D6AC76A79B38344F240A3 /* DetectorResultBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetectorResultBody.swift; sourceTree = "<group>"; };
 		A930070B8B38F806BA54B436 /* BookmarkColorHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkColorHelper.swift; sourceTree = "<group>"; };
 		A9BBB9D94724076C53D2F8EC /* PromptRegistry+InlineRewrite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PromptRegistry+InlineRewrite.swift"; sourceTree = "<group>"; };
@@ -1156,6 +1158,7 @@
 				46D5AD1551B13733D986BC37 /* NavigationHistoryTests.swift */,
 				D417341CA0E1725E2C8FB9BA /* NeighborhoodTests.swift */,
 				EAAA4BF89D7A99D017BB1C8E /* PromptBuilderTests.swift */,
+				A9048A84C6D32D4327622137 /* QuickOpenCandidateTests.swift */,
 				B37427E70D5B05A2E6C5B253 /* QuickOpenTests.swift */,
 				556A511293280EF4427934FA /* RelationshipFieldTests.swift */,
 				EFE448FDFB9D86AB13035E23 /* ReleaseEntitlementsTests.swift */,
@@ -2166,6 +2169,7 @@
 				A73935430EF00561EE6074E9 /* NavigationHistoryTests.swift in Sources */,
 				6D5F5E356DF157A16246B26C /* NeighborhoodTests.swift in Sources */,
 				957DBF3D45C9A998D610B8B2 /* PromptBuilderTests.swift in Sources */,
+				DB5F93E698ADB73400C9EFC4 /* QuickOpenCandidateTests.swift in Sources */,
 				4371B1C1354F8BF50EFECCBB /* QuickOpenTests.swift in Sources */,
 				05EB2376928B177F338562E4 /* RelationshipFieldTests.swift in Sources */,
 				CADF664CE3E27718367FEA0F /* ReleaseEntitlementsTests.swift in Sources */,

--- a/Logue.xcodeproj/project.pbxproj
+++ b/Logue.xcodeproj/project.pbxproj
@@ -373,6 +373,7 @@
 		B0F79BB2896CD38F5076C649 /* BlockSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFE45DD206DEC983F8781BB2 /* BlockSerializer.swift */; };
 		B17505DC8364AC00D95F535E /* AgentChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B03398707EAC7A65A3C41D13 /* AgentChatView.swift */; };
 		B1CFB818BCC765AD35BA6339 /* EmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E12A64F34E4BB90D4A6AD325 /* EmptyStateView.swift */; };
+		B27F60023417DD2C91BC326C /* CalloutRoundTripEdgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AB2A7A4F24E2BC67AEE4319 /* CalloutRoundTripEdgeTests.swift */; };
 		B2D7739A8B5B43D1E1B182D7 /* PermissionsSettingsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A96015B635CF7C9D07F84DA /* PermissionsSettingsTab.swift */; };
 		B39E816EDE9D3B2D46B16297 /* PostRecordingPipeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = 739A71E158624FCF8E71C075 /* PostRecordingPipeline.swift */; };
 		B543DA0878AEDD4F6C24DC93 /* WritingScore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3505A705EE4C5C9F81001E29 /* WritingScore.swift */; };
@@ -688,6 +689,7 @@
 		4846B28779DCE95A2E8E9D23 /* ComingSoonPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComingSoonPanelView.swift; sourceTree = "<group>"; };
 		493337C75A0D4F073E22C76F /* BlockEditorDocument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockEditorDocument.swift; sourceTree = "<group>"; };
 		4A96015B635CF7C9D07F84DA /* PermissionsSettingsTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionsSettingsTab.swift; sourceTree = "<group>"; };
+		4AB2A7A4F24E2BC67AEE4319 /* CalloutRoundTripEdgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalloutRoundTripEdgeTests.swift; sourceTree = "<group>"; };
 		4B27EF7809E2AAC8C8F7E6DC /* DocumentRelationshipTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentRelationshipTests.swift; sourceTree = "<group>"; };
 		4B2F874FCD0AF25F7B37D3FC /* MalformedToolCall.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalformedToolCall.swift; sourceTree = "<group>"; };
 		4B4D41D14C5F7B6352AC692F /* CanvasPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasPaneView.swift; sourceTree = "<group>"; };
@@ -1127,6 +1129,7 @@
 				7A450984B8338837BFDFF868 /* BlockTypeSlashMenuTests.swift */,
 				221BC5AEDD75B485C3384F37 /* BulkActionInboxTests.swift */,
 				46DB0259534855A640246B2A /* CalloutBlockTests.swift */,
+				4AB2A7A4F24E2BC67AEE4319 /* CalloutRoundTripEdgeTests.swift */,
 				83C272112D79CC98FD132288 /* ContentNavigatorTests.swift */,
 				263E3C59B8D03346E04E7C92 /* DeepLinkRoutingTests.swift */,
 				EB27F11A2333C941E28C916E /* DeepLinkTests.swift */,
@@ -2133,6 +2136,7 @@
 				F990F4EC5E8A9FEBA4C9FD3F /* BlockTypeSlashMenuTests.swift in Sources */,
 				4F1D0B3B8CE3D50CCD09720C /* BulkActionInboxTests.swift in Sources */,
 				2ED027BF90138612DDE85A2C /* CalloutBlockTests.swift in Sources */,
+				B27F60023417DD2C91BC326C /* CalloutRoundTripEdgeTests.swift in Sources */,
 				2EBF59EE30602911A0C7236E /* ContentNavigatorTests.swift in Sources */,
 				8837715694AEB1053618212A /* DeepLinkRoutingTests.swift in Sources */,
 				52B089BBC06F1A4DC8CFA5CE /* DeepLinkTests.swift in Sources */,

--- a/Logue.xcodeproj/project.pbxproj
+++ b/Logue.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		01E3484C686F805348FC1842 /* VocabularyEnhancementPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3FB4C4D5FE2C19460E3DFED /* VocabularyEnhancementPanelView.swift */; };
 		02437AA08BF113B6E0957131 /* PulsingDot.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A491C56C1501F3D06F7734 /* PulsingDot.swift */; };
 		0252F36658727AF28041B0E5 /* BlockTextView+WikiLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A6129C7861CC0ACE7F78CA9 /* BlockTextView+WikiLink.swift */; };
+		02761D820E1A047DCF30B4AD /* CalloutKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = F97E5373C0EEEA49FDB78D3B /* CalloutKind.swift */; };
 		03C16AA3E0D4260F0D389809 /* CommandPaletteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3089A12B33B90CC09610C11 /* CommandPaletteView.swift */; };
 		0449935D6F3DDF8994CDB6AE /* DailyDigestCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABDDA0045C55C8B7299F678E /* DailyDigestCard.swift */; };
 		04582C96B6B8D35D02D71C39 /* MultiBlockKeyHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 133717C9C61937FC843612D1 /* MultiBlockKeyHandler.swift */; };
@@ -115,6 +116,7 @@
 		2E38E8631137FF77CB24BD2C /* WritingMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE1C21D4C5160CF9D5FEB10 /* WritingMode.swift */; };
 		2E44F9F45806D57C7D99BC21 /* SkeletonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 946A6E172B8989687D211113 /* SkeletonView.swift */; };
 		2EBF59EE30602911A0C7236E /* ContentNavigatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83C272112D79CC98FD132288 /* ContentNavigatorTests.swift */; };
+		2ED027BF90138612DDE85A2C /* CalloutBlockTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46DB0259534855A640246B2A /* CalloutBlockTests.swift */; };
 		2F188F551FC6C5738BDB23B2 /* QuickOpen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D732A7B7C4D529BBD960BDC9 /* QuickOpen.swift */; };
 		2FD721F2491FFD83810DB23C /* DiarizationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6518F90C57E0A10C7DBF1328 /* DiarizationManager.swift */; };
 		3078B745D4379CB1523EA5D2 /* IconToolbarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FF6C4FACAA2A06BB2C5306A /* IconToolbarView.swift */; };
@@ -122,6 +124,7 @@
 		30A943560FB26E73460267FC /* ModelManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D510ED6451CBD5DB1C3227EA /* ModelManager.swift */; };
 		31A87049A3EB3E57EF4D888D /* ZIPArchiveReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9791CDD317958805125F6D78 /* ZIPArchiveReader.swift */; };
 		31F088EDA786AF95FA1D2067 /* SourcesPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B203FDECC75AFF647507580 /* SourcesPanelView.swift */; };
+		32250FA08C8D190532365E94 /* CodeBlockLanguageMemory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6253F68F7BEF5952530CDA76 /* CodeBlockLanguageMemory.swift */; };
 		323E15A51D95328EFA95C6CB /* TableBlockView+Drawing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 661DE2C2CA1ADD02979BC042 /* TableBlockView+Drawing.swift */; };
 		32B43BE16C729F35B4FF8F9E /* DocumentStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 309F1230B70C14F8E80EDC10 /* DocumentStorage.swift */; };
 		33038EADE390EBB10FDF2642 /* PromptBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB78AC5932FC825A08DD0EBB /* PromptBuilder.swift */; };
@@ -330,6 +333,7 @@
 		99FCB8FEB17A1DA884E6892C /* CommandCenterController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8D8F63B0BEBD964C1409AA5 /* CommandCenterController.swift */; };
 		9AA3E154D17149A8C490B914 /* MarkdownFrontmatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E3C7891AC5CF6FA2648B7EB /* MarkdownFrontmatter.swift */; };
 		9C2E27B8A6B79A81F9495399 /* SpaceFolderLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62A5299B26C4D742EB7BABD3 /* SpaceFolderLayoutTests.swift */; };
+		9CA475E2C0878AB09EE8082F /* DocumentIconPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC17E4D853587B8D1F0BED80 /* DocumentIconPicker.swift */; };
 		9F4F117462111A847F62D542 /* EditTemplateSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43D628E66EC44675B3D52230 /* EditTemplateSheet.swift */; };
 		9FA6157D1340BFC0915DB143 /* AgentChatView+Messages.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA41BE45973601CD371C00BB /* AgentChatView+Messages.swift */; };
 		9FC5E9AC4D7755C95151D036 /* InsightCardShell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0F94FBB07034AA79CECEDED /* InsightCardShell.swift */; };
@@ -359,6 +363,7 @@
 		AB5ECDB7A635C2DB974F908D /* SeedDataBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9478E4D1E64E36CDE232568E /* SeedDataBannerView.swift */; };
 		ABEB7317A02B279F22E9AB8E /* SpaceContentTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08FACCA64C397DACFD78CE8C /* SpaceContentTypes.swift */; };
 		ACBD67F76F286A34F1A0E4CA /* DocumentWidthMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = A62566632EE8FA6DAD6713DB /* DocumentWidthMode.swift */; };
+		ACF6D6515BF5CB9F03B85496 /* QuickOpenPaletteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CABE8A04DD20F09B12BEDB15 /* QuickOpenPaletteView.swift */; };
 		AD07D0DCE8536510D087A05C /* TroubleshootingActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15DD5F0F004960A0D0B66E8B /* TroubleshootingActions.swift */; };
 		AE7BCB76D77404A8B71D119E /* PIIModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B9978579DD7A8D5743C9DB6 /* PIIModels.swift */; };
 		AF35E4BCA1244DFE4B983329 /* UndoToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFBC89D908FFD586D1C38ABF /* UndoToastView.swift */; };
@@ -676,6 +681,7 @@
 		46B853F7D5C62F407E23AD41 /* OverviewRightColumnCards.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverviewRightColumnCards.swift; sourceTree = "<group>"; };
 		46D5AD1551B13733D986BC37 /* NavigationHistoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationHistoryTests.swift; sourceTree = "<group>"; };
 		46D6419EB91D515BAD26FEF7 /* ScheduledTaskManager+WeeklyReview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ScheduledTaskManager+WeeklyReview.swift"; sourceTree = "<group>"; };
+		46DB0259534855A640246B2A /* CalloutBlockTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalloutBlockTests.swift; sourceTree = "<group>"; };
 		47D61456AC8A03F3A37D8ABD /* OverviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverviewView.swift; sourceTree = "<group>"; };
 		47D6D28A5F055B59944316D6 /* HomeAttentionCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeAttentionCard.swift; sourceTree = "<group>"; };
 		4846B28779DCE95A2E8E9D23 /* ComingSoonPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComingSoonPanelView.swift; sourceTree = "<group>"; };
@@ -715,6 +721,7 @@
 		61150569A2C3758E03DC0666 /* BlockRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockRowView.swift; sourceTree = "<group>"; };
 		61E35F43E33DAC50D32ED6B1 /* DocumentStorage+Rescan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DocumentStorage+Rescan.swift"; sourceTree = "<group>"; };
 		6217AE8765C37EAAE87C7F54 /* katex.min.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = katex.min.js; sourceTree = "<group>"; };
+		6253F68F7BEF5952530CDA76 /* CodeBlockLanguageMemory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeBlockLanguageMemory.swift; sourceTree = "<group>"; };
 		62A5299B26C4D742EB7BABD3 /* SpaceFolderLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceFolderLayoutTests.swift; sourceTree = "<group>"; };
 		6392D9C30DCF6BDFC18DCF63 /* WikiLinkStylingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WikiLinkStylingTests.swift; sourceTree = "<group>"; };
 		63AC1DBC374C162B470E69D4 /* RecentContentPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentContentPane.swift; sourceTree = "<group>"; };
@@ -935,6 +942,7 @@
 		C8D8F63B0BEBD964C1409AA5 /* CommandCenterController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandCenterController.swift; sourceTree = "<group>"; };
 		C8F833920208ECD78C193568 /* LogueLogoLight.svg */ = {isa = PBXFileReference; path = LogueLogoLight.svg; sourceTree = "<group>"; };
 		CA29CBB4724CFEE0030E5FE3 /* AgentDictationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentDictationService.swift; sourceTree = "<group>"; };
+		CABE8A04DD20F09B12BEDB15 /* QuickOpenPaletteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickOpenPaletteView.swift; sourceTree = "<group>"; };
 		CAFFBC9452CA163A47F3FCEA /* Logue.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Logue.entitlements; sourceTree = "<group>"; };
 		CB8AA1433C5115832D5A7647 /* TemplateTools.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateTools.swift; sourceTree = "<group>"; };
 		CC3CE09FD46E14F97E07C0BF /* UnifiedSidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedSidebarView.swift; sourceTree = "<group>"; };
@@ -1034,6 +1042,7 @@
 		F86FEEACED36C11C79D2FA9A /* RichTextEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RichTextEditor.swift; sourceTree = "<group>"; };
 		F9017DE8546F2B3F48A6C3EB /* Neighborhood.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Neighborhood.swift; sourceTree = "<group>"; };
 		F95595374A2F4D02321B7CA2 /* DocumentReplaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentReplaceTests.swift; sourceTree = "<group>"; };
+		F97E5373C0EEEA49FDB78D3B /* CalloutKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalloutKind.swift; sourceTree = "<group>"; };
 		F9ABFE8CDB709383F2CCC4A8 /* MLXToolDefinitions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MLXToolDefinitions.swift; sourceTree = "<group>"; };
 		F9D05F3B9F242D1B1198B528 /* MeetingLLMTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingLLMTests.swift; sourceTree = "<group>"; };
 		F9DD3273B7AB955D3C6E3BC1 /* DeckPDFExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeckPDFExporter.swift; sourceTree = "<group>"; };
@@ -1042,6 +1051,7 @@
 		FB35376739D17A4539998C09 /* TemplateGalleryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateGalleryView.swift; sourceTree = "<group>"; };
 		FB395EE9C9C26DE9E0F65678 /* SemanticIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SemanticIndex.swift; sourceTree = "<group>"; };
 		FBCD9FE533E01D4D082FF3EC /* WritingNSTextView+ListContinuation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WritingNSTextView+ListContinuation.swift"; sourceTree = "<group>"; };
+		FC17E4D853587B8D1F0BED80 /* DocumentIconPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentIconPicker.swift; sourceTree = "<group>"; };
 		FCEBD05BEF5831C92DDDE40E /* SuggestionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionParser.swift; sourceTree = "<group>"; };
 		FD9DB88569857E33E72CCFAE /* OverviewRecentActivityCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverviewRecentActivityCard.swift; sourceTree = "<group>"; };
 		FDFC48D1348543B9A74105F1 /* SpaceStore+MarkdownFolder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SpaceStore+MarkdownFolder.swift"; sourceTree = "<group>"; };
@@ -1114,6 +1124,7 @@
 				88C42C0A1E60F8FC22AC2EF3 /* BlockPasteTests.swift */,
 				7A450984B8338837BFDFF868 /* BlockTypeSlashMenuTests.swift */,
 				221BC5AEDD75B485C3384F37 /* BulkActionInboxTests.swift */,
+				46DB0259534855A640246B2A /* CalloutBlockTests.swift */,
 				83C272112D79CC98FD132288 /* ContentNavigatorTests.swift */,
 				263E3C59B8D03346E04E7C92 /* DeepLinkRoutingTests.swift */,
 				EB27F11A2333C941E28C916E /* DeepLinkTests.swift */,
@@ -1284,6 +1295,7 @@
 				3C1F2914E4AE0CEBC75367EC /* Block.swift */,
 				493337C75A0D4F073E22C76F /* BlockEditorDocument.swift */,
 				BFE45DD206DEC983F8781BB2 /* BlockSerializer.swift */,
+				F97E5373C0EEEA49FDB78D3B /* CalloutKind.swift */,
 				D7D771D4ECF4472264165F1C /* DocumentSearchState.swift */,
 				7CB8F29FAA5817D348722762 /* MultiBlockSelectionState.swift */,
 			);
@@ -1539,6 +1551,7 @@
 			children = (
 				D3089A12B33B90CC09610C11 /* CommandPaletteView.swift */,
 				D732A7B7C4D529BBD960BDC9 /* QuickOpen.swift */,
+				CABE8A04DD20F09B12BEDB15 /* QuickOpenPaletteView.swift */,
 			);
 			path = CommandPalette;
 			sourceTree = "<group>";
@@ -1912,7 +1925,9 @@
 				A391B8A86402BB8B109FC089 /* BlockEditor */,
 				98CFCFB27017B8D799B8178B /* Components */,
 				86F393DC727834A59AB47A62 /* AIChatPanelView.swift */,
+				6253F68F7BEF5952530CDA76 /* CodeBlockLanguageMemory.swift */,
 				A92D6AC76A79B38344F240A3 /* DetectorResultBody.swift */,
+				FC17E4D853587B8D1F0BED80 /* DocumentIconPicker.swift */,
 				C3F51D3C49EB4A8530380A86 /* DocumentWorkspaceView.swift */,
 				ECB1EE6AF1D9283E7F15E6C3 /* DocumentWorkspaceView+Toolbar.swift */,
 				C262104A21E62547CE677D5B /* EditorLayoutMode.swift */,
@@ -2114,6 +2129,7 @@
 				6E66E9B993B63623F605E552 /* BlockPasteTests.swift in Sources */,
 				F990F4EC5E8A9FEBA4C9FD3F /* BlockTypeSlashMenuTests.swift in Sources */,
 				4F1D0B3B8CE3D50CCD09720C /* BulkActionInboxTests.swift in Sources */,
+				2ED027BF90138612DDE85A2C /* CalloutBlockTests.swift in Sources */,
 				2EBF59EE30602911A0C7236E /* ContentNavigatorTests.swift in Sources */,
 				8837715694AEB1053618212A /* DeepLinkRoutingTests.swift in Sources */,
 				52B089BBC06F1A4DC8CFA5CE /* DeepLinkTests.swift in Sources */,
@@ -2239,6 +2255,7 @@
 				246528648EF53A7AEA379A83 /* CalendarManager.swift in Sources */,
 				05E99FAA405A57C40016FFA5 /* CalendarTools.swift in Sources */,
 				486082E3815CD2D7A4249A82 /* CalendarWriteTools.swift in Sources */,
+				02761D820E1A047DCF30B4AD /* CalloutKind.swift in Sources */,
 				24C4E391A8A690C60D26E51A /* CanvasController.swift in Sources */,
 				E37BD26415388D727ACC60A6 /* CanvasPaneView.swift in Sources */,
 				457B5F17B248B73950E85F0C /* CanvasSnapshot.swift in Sources */,
@@ -2251,6 +2268,7 @@
 				92B35DA71181DA35404DA59D /* ChatBubble.swift in Sources */,
 				98CDA216810CB2AC9592889C /* ChatHomeEmptyState.swift in Sources */,
 				ED7BBA11866E8887D849AD84 /* ChatInputField.swift in Sources */,
+				32250FA08C8D190532365E94 /* CodeBlockLanguageMemory.swift in Sources */,
 				064963B61C0242F39204C049 /* CodeSyntaxHighlighter.swift in Sources */,
 				1CF5D6AE20C1BDE279762B9F /* ComingSoonPanelView.swift in Sources */,
 				E5DF85C2C0803078D80C350C /* CommandCenterChatView.swift in Sources */,
@@ -2284,6 +2302,7 @@
 				A1D7482C98EE0833CBA17214 /* DocumentCardView.swift in Sources */,
 				F6B3634D89D31E335DE866BC /* DocumentFilename.swift in Sources */,
 				5FCA28149B189B61283A387C /* DocumentIcon.swift in Sources */,
+				9CA475E2C0878AB09EE8082F /* DocumentIconPicker.swift in Sources */,
 				6EF0995F3E06CB5ED24FD625 /* DocumentListContentView.swift in Sources */,
 				166F6924A97D2ECE1AE75F3E /* DocumentListPane+Organise.swift in Sources */,
 				A4AEBA0FBDA0E9CE695009FD /* DocumentListPane.swift in Sources */,
@@ -2482,6 +2501,7 @@
 				02437AA08BF113B6E0957131 /* PulsingDot.swift in Sources */,
 				6BFD579894DD38D9476BB78C /* QuickComposeView.swift in Sources */,
 				2F188F551FC6C5738BDB23B2 /* QuickOpen.swift in Sources */,
+				ACF6D6515BF5CB9F03B85496 /* QuickOpenPaletteView.swift in Sources */,
 				22EACBCCB7BD304F9AE40B4E /* QuickPromptChip.swift in Sources */,
 				FB2DCEFD67348622524BEB81 /* RecentContentPane.swift in Sources */,
 				0932B4BDD1E386DF7D71C86C /* RecordingSessionManager+Diarization.swift in Sources */,

--- a/Logue/App/AppConstants.swift
+++ b/Logue/App/AppConstants.swift
@@ -29,6 +29,12 @@ enum AppConstants {
         static let autoSortCheckedItems = "autoSortCheckedItems"
         /// Editor zoom multiplier applied on top of the base editor font size.
         static let editorZoomScale = "editorZoomScale"
+        /// Width mode newly created documents start at. Per-document values still win.
+        static let defaultDocumentWidthMode = "defaultDocumentWidthMode"
+        /// Which panes the main window shows — see `EditorLayoutMode`.
+        static let editorLayoutMode = "editorLayoutMode"
+        /// Language last chosen in a code block, used as the default for the next one.
+        static let lastCodeBlockLanguage = "lastCodeBlockLanguage"
         /// How documents are stored: `encrypted` (default) or `markdown`.
         static let documentStorageMode = "documentStorageMode"
         static let unwritableDocuments = "unwritableDocuments"

--- a/Logue/App/LogueApp.swift
+++ b/Logue/App/LogueApp.swift
@@ -20,10 +20,10 @@ extension Notification.Name {
 struct LogueApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
 
-    /// Editor zoom multiplier, shared with the editor through AppStorage so both
-    /// scenes stay in sync without a separate observable.
-    @AppStorage(AppConstants.UserDefaultsKeys.editorZoomScale) private var zoomScale: Double =
-        AppConstants.Editor.defaultZoom
+    /// Which panes the main window shows. Shared with `MainWindowView` through the same
+    /// AppStorage key, which is also what persists the choice across launches.
+    @AppStorage(AppConstants.UserDefaultsKeys.editorLayoutMode) private var layoutModeRaw =
+        EditorLayoutMode.allPanels.rawValue
 
     init() {
         // Must run before any store singleton resolves its Application Support
@@ -86,12 +86,33 @@ struct LogueApp: App {
             }
 
             CommandGroup(after: .toolbar) {
-                Button("Zoom In") { applyZoom { $0.zoomIn() } }
+                // Only `⌘+` is bound here, and a key equivalent of `+` matches nothing but
+                // `⌘+` itself — measured, not assumed. On any layout where `+` needs Shift
+                // that is a chord the user may never reach, so `⌘=` — the unshifted key in
+                // the same physical position — is bound in `MainWindowView` instead. Not as
+                // a second menu item, because SwiftUI allows one shortcut per button and a
+                // second button would list "Zoom In" twice in the View menu.
+                Button("Zoom In") { EditorZoom.mutatePersisted { $0.zoomIn() } }
                     .keyboardShortcut("+", modifiers: .command)
-                Button("Zoom Out") { applyZoom { $0.zoomOut() } }
+                Button("Zoom Out") { EditorZoom.mutatePersisted { $0.zoomOut() } }
                     .keyboardShortcut("-", modifiers: .command)
-                Button("Actual Size") { applyZoom { $0.reset() } }
+                Button("Actual Size") { EditorZoom.mutatePersisted { $0.reset() } }
                     .keyboardShortcut("0", modifiers: .command)
+
+                Divider()
+
+                // ⌘1 / ⌘2 / ⌘3. Each entry resolves its mode through
+                // `EditorLayoutMode(shortcutNumber:)` rather than restating the pairing here,
+                // so the menu cannot disagree with the model about which key means which layout.
+                ForEach(1 ... EditorLayoutMode.allCases.count, id: \.self) { number in
+                    if let mode = EditorLayoutMode(shortcutNumber: number),
+                       let key = "\(number)".first
+                    {
+                        Button(mode.label) { layoutModeRaw = mode.rawValue }
+                            .keyboardShortcut(KeyEquivalent(key), modifiers: .command)
+                    }
+                }
+
                 Divider()
             }
 
@@ -128,14 +149,6 @@ struct LogueApp: App {
         Settings {
             SettingsRootView()
         }
-    }
-
-    /// Applies a zoom mutation through `EditorZoom` so clamping lives in one place.
-    private func applyZoom(_ mutate: (inout EditorZoom) -> Void) {
-        var zoom = EditorZoom()
-        zoom.scale = zoomScale
-        mutate(&zoom)
-        zoomScale = zoom.scale
     }
 }
 

--- a/Logue/App/LogueApp.swift
+++ b/Logue/App/LogueApp.swift
@@ -9,6 +9,11 @@ extension Notification.Name {
     static let openResourceUsageWindow = Notification.Name("openResourceUsageWindow")
     static let openReportBugWindow = Notification.Name("openReportBugWindow")
 
+    /// `Cmd+P` — open quick-open. A menu item rather than only an in-window key handler,
+    /// because a main-menu key equivalent fires whatever holds focus inside the window,
+    /// including the editor's text view.
+    static let openQuickOpenPalette = Notification.Name("openQuickOpenPalette")
+
     /// Phase A: chat-first shortcuts.
     /// `Cmd+L` — start a new chat (and switch sidebar to Ask Logue).
     static let chatNewConversation = Notification.Name("chatNewConversation")
@@ -62,6 +67,13 @@ struct LogueApp: App {
                     NotificationCenter.default.post(name: .chatFocusInput, object: nil)
                 }
                 .keyboardShortcut("l", modifiers: [.command, .shift])
+            }
+
+            CommandGroup(after: .newItem) {
+                Button("Quick Open…") {
+                    NotificationCenter.default.post(name: .openQuickOpenPalette, object: nil)
+                }
+                .keyboardShortcut("p", modifiers: .command)
             }
 
             CommandGroup(after: .importExport) {

--- a/Logue/Engine/CodeSyntaxHighlighter.swift
+++ b/Logue/Engine/CodeSyntaxHighlighter.swift
@@ -131,6 +131,56 @@ enum CodeSyntaxHighlighter {
         "template|namespace|using|new|delete|try|catch|throw|this",
     ].joined(separator: "|")
 
+    // MARK: - Supported Languages
+
+    /// A language the highlighter knows, as offered to the user in the code block picker.
+    ///
+    /// `id` is the fence identifier written to markdown, so it has to be one of the
+    /// identifiers `rules(for:)` matches on below — anything else silently falls through to
+    /// the Swift-like default. Aliases (`py`, `js`, `golang`) are deliberately absent: they
+    /// highlight identically to their canonical spelling, and offering both in a menu would
+    /// only make the list longer.
+    struct Language: Identifiable, Hashable, Sendable {
+        let id: String
+        let displayName: String
+    }
+
+    /// The languages the picker offers, in the order it shows them.
+    static let supportedLanguages: [Language] = [
+        Language(id: "swift", displayName: "Swift"),
+        Language(id: "python", displayName: "Python"),
+        Language(id: "javascript", displayName: "JavaScript"),
+        Language(id: "typescript", displayName: "TypeScript"),
+        Language(id: "jsx", displayName: "JSX"),
+        Language(id: "tsx", displayName: "TSX"),
+        Language(id: "go", displayName: "Go"),
+        Language(id: "rust", displayName: "Rust"),
+        Language(id: "c", displayName: "C"),
+        Language(id: "cpp", displayName: "C++"),
+        Language(id: "objc", displayName: "Objective-C"),
+        Language(id: "java", displayName: "Java"),
+        Language(id: "csharp", displayName: "C#"),
+        Language(id: "sql", displayName: "SQL"),
+        Language(id: "bash", displayName: "Shell"),
+        Language(id: "json", displayName: "JSON"),
+        Language(id: "html", displayName: "HTML"),
+        Language(id: "xml", displayName: "XML"),
+        Language(id: "css", displayName: "CSS"),
+        Language(id: "scss", displayName: "SCSS"),
+    ]
+
+    /// How a fence identifier should be labelled in the UI.
+    ///
+    /// Falls back to the identifier itself so a language typed by hand, or one that arrived
+    /// in imported markdown, still reads as what the file actually says rather than as
+    /// nothing at all.
+    static func displayName(forLanguage language: String) -> String? {
+        let trimmed = language.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        let match = supportedLanguages.first { $0.id.caseInsensitiveCompare(trimmed) == .orderedSame }
+        return match?.displayName ?? trimmed
+    }
+
     // MARK: - Rules by Language
 
     private static func rules(for language: String) -> [TokenRule] {

--- a/Logue/Models/DocumentStore+Creation.swift
+++ b/Logue/Models/DocumentStore+Creation.swift
@@ -58,6 +58,13 @@ extension DocumentStore {
         doc.tags = item.tags.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
             .filter { !$0.isEmpty }
         doc.spaceID = spaceID
+        // Stamped only when the app-wide default is not `normal`, because `widthMode` already
+        // reads an absent value as `normal`. Writing it regardless would put a redundant
+        // `width:` line in the frontmatter of every new file in markdown storage mode.
+        let defaultWidth = DocumentWidthMode.appDefault
+        if defaultWidth != .normal {
+            doc.widthMode = defaultWidth
+        }
         if !item.properties.isEmpty {
             doc.properties = item.properties
         }

--- a/Logue/Models/DocumentWidthMode.swift
+++ b/Logue/Models/DocumentWidthMode.swift
@@ -34,4 +34,17 @@ enum DocumentWidthMode: String, Codable, CaseIterable, Sendable {
         case .wide: "rectangle"
         }
     }
+
+    /// The app-wide default a newly created document starts at, from Settings → General.
+    ///
+    /// Read straight from `UserDefaults` rather than through `@AppStorage` because the
+    /// caller is `DocumentStore`, not a view. An unset or unrecognised value reads as
+    /// `normal`, which is also what an unset per-document value means.
+    static var appDefault: DocumentWidthMode {
+        guard let raw = UserDefaults.standard.string(
+            forKey: AppConstants.UserDefaultsKeys.defaultDocumentWidthMode
+        )
+        else { return .normal }
+        return DocumentWidthMode(rawValue: raw) ?? .normal
+    }
 }

--- a/Logue/Views/CommandPalette/QuickOpen.swift
+++ b/Logue/Views/CommandPalette/QuickOpen.swift
@@ -14,6 +14,37 @@ struct QuickOpenItem: Identifiable, Equatable, Sendable {
     let kind: Kind
 }
 
+// MARK: - Candidates
+
+extension QuickOpenItem {
+    /// Everything quick-open can jump to, most recently modified first.
+    ///
+    /// A function over plain arrays rather than something reading the stores, so the three rules
+    /// that matter here are testable without a `@MainActor` store: trashed items are excluded,
+    /// an untitled item still gets a name to match against, and the order is recency. That last
+    /// one is not cosmetic — `QuickOpenMatcher` is stable within a rank, so the order it is
+    /// handed is exactly what breaks ties between equally good matches.
+    static func candidates(documents: [WritingDocument], meetings: [MeetingNote]) -> [QuickOpenItem] {
+        let documentEntries = documents.lazy.filter { !$0.isTrashed }.map {
+            (modifiedAt: $0.modifiedAt, item: QuickOpenItem(
+                id: $0.id,
+                title: $0.title.isEmpty ? AppConstants.defaultDocumentTitle : $0.title,
+                kind: .document
+            ))
+        }
+        let meetingEntries = meetings.lazy.filter { !$0.isTrashed }.map {
+            (modifiedAt: $0.modifiedAt, item: QuickOpenItem(
+                id: $0.id,
+                title: $0.title.isEmpty ? AppConstants.defaultMeetingTitle : $0.title,
+                kind: .meeting
+            ))
+        }
+        return (Array(documentEntries) + Array(meetingEntries))
+            .sorted { $0.modifiedAt > $1.modifiedAt }
+            .map(\.item)
+    }
+}
+
 // MARK: - Matcher
 
 /// Ranks quick-open candidates by title.

--- a/Logue/Views/CommandPalette/QuickOpenPaletteView.swift
+++ b/Logue/Views/CommandPalette/QuickOpenPaletteView.swift
@@ -1,0 +1,274 @@
+import SwiftUI
+
+/// Jump straight to a document or meeting by name — `Cmd+P` / `Cmd+O`.
+///
+/// A separate surface from `CommandPaletteView` rather than a mode inside it, because the two
+/// answer different questions and are shaped differently for it. The command palette groups
+/// results by category and runs a debounced full-text search over bodies and transcripts;
+/// quick-open is a single flat list, ranked by title only, filtered synchronously on every
+/// keystroke. Sharing one view would have meant a mode flag threaded through the grouping,
+/// the debounce and the keyboard handling alike.
+///
+/// All ranking is `QuickOpenMatcher`'s — there is no second matching implementation here.
+struct QuickOpenPaletteView: View {
+    @Binding var isPresented: Bool
+
+    @Environment(DocumentStore.self) private var documentStore
+    @Environment(MeetingStore.self) private var meetingStore
+
+    @State private var query = ""
+    @State private var selectedIndex = 0
+    @FocusState private var isSearchFocused: Bool
+
+    /// Documents and meetings, most recently modified first.
+    ///
+    /// The order matters: `QuickOpenMatcher` is stable within a rank, so the caller's ordering
+    /// is what breaks ties — recency, here. Trashed items are excluded by `activeDocuments`
+    /// and `activeMeetings`.
+    private var candidates: [QuickOpenItem] {
+        let documents = documentStore.activeDocuments.map {
+            (modifiedAt: $0.modifiedAt, item: QuickOpenItem(
+                id: $0.id,
+                title: $0.title.isEmpty ? AppConstants.defaultDocumentTitle : $0.title,
+                kind: .document
+            ))
+        }
+        let meetings = meetingStore.activeMeetings.map {
+            (modifiedAt: $0.modifiedAt, item: QuickOpenItem(
+                id: $0.id,
+                title: $0.title.isEmpty ? AppConstants.defaultMeetingTitle : $0.title,
+                kind: .meeting
+            ))
+        }
+        return (documents + meetings)
+            .sorted { $0.modifiedAt > $1.modifiedAt }
+            .map(\.item)
+    }
+
+    private var results: [QuickOpenItem] {
+        QuickOpenMatcher.match(query: query, in: candidates)
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            searchField
+
+            Divider()
+
+            if results.isEmpty {
+                emptyState
+            } else {
+                resultList
+            }
+
+            Divider()
+            HStack(spacing: 16) {
+                footerHint(icon: "arrow.up.arrow.down", text: "Navigate")
+                footerHint(icon: "return", text: "Open")
+                footerHint(icon: "escape", text: "Close")
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 8)
+        }
+        .frame(width: 520)
+        .background(
+            .regularMaterial,
+            in: RoundedRectangle(cornerRadius: AppThemeConstants.radiusXLarge, style: .continuous)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: AppThemeConstants.radiusXLarge, style: .continuous)
+                .strokeBorder(.separator, lineWidth: 0.5)
+        )
+        .shadow(
+            color: .black.opacity(AppThemeConstants.panelShadowOpacity),
+            radius: AppThemeConstants.panelShadowRadius,
+            x: 0,
+            y: AppThemeConstants.panelShadowY
+        )
+        .onAppear {
+            isSearchFocused = true
+            selectedIndex = 0
+        }
+        .onChange(of: query) {
+            selectedIndex = 0
+        }
+        .onKeyPress(.upArrow) {
+            if selectedIndex > 0 {
+                selectedIndex -= 1
+            }
+            return .handled
+        }
+        .onKeyPress(.downArrow) {
+            if selectedIndex < results.count - 1 {
+                selectedIndex += 1
+            }
+            return .handled
+        }
+        .onKeyPress(.escape) {
+            isPresented = false
+            return .handled
+        }
+        .onKeyPress(.return) {
+            openSelected()
+            return .handled
+        }
+    }
+
+    // MARK: - Subviews
+
+    private var searchField: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "arrow.right.doc.on.clipboard")
+                .font(.system(size: 15, weight: .medium))
+                .foregroundStyle(.secondary)
+
+            TextField("Go to document or meeting…", text: $query)
+                .textFieldStyle(.plain)
+                .font(.system(size: 16))
+                .focused($isSearchFocused)
+                .accessibilityLabel("Quick open search")
+                .accessibilityHint("Type part of a document or meeting title")
+                .onSubmit { openSelected() }
+
+            if !query.isEmpty {
+                Button {
+                    query = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.tertiary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Clear search")
+                .accessibilityHint("Clears the quick open search text")
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "magnifyingglass")
+                .font(.title2)
+                .foregroundStyle(.tertiary)
+            Text(candidates.isEmpty ? "Nothing to open yet" : "No matches for \"\(query)\"")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, minHeight: 120)
+    }
+
+    private var resultList: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    ForEach(Array(results.enumerated()), id: \.element.id) { index, item in
+                        QuickOpenRow(item: item, isSelected: index == selectedIndex) {
+                            open(item)
+                        }
+                        .id(item.id)
+                    }
+                }
+                .padding(.vertical, 4)
+            }
+            .frame(maxHeight: 340)
+            .onChange(of: selectedIndex) { _, newIndex in
+                // Bounds-checked because the result set shrinks as the query grows, and the
+                // index can be stale for a frame after a keystroke.
+                guard newIndex >= 0, newIndex < results.count else { return }
+                proxy.scrollTo(results[newIndex].id)
+            }
+        }
+    }
+
+    private func footerHint(icon: String, text: String) -> some View {
+        HStack(spacing: 4) {
+            Image(systemName: icon)
+                .font(.caption2)
+            Text(text)
+                .font(.caption2)
+        }
+        .foregroundStyle(.tertiary)
+    }
+
+    // MARK: - Opening
+
+    private func openSelected() {
+        guard selectedIndex >= 0, selectedIndex < results.count else { return }
+        open(results[selectedIndex])
+    }
+
+    /// Selecting an item opens it: `MainWindowView` observes both stores' selection and
+    /// switches to the editor or the meeting workspace, so setting the ID is the whole action.
+    private func open(_ item: QuickOpenItem) {
+        isPresented = false
+        switch item.kind {
+        case .document:
+            meetingStore.selectedMeetingID = nil
+            documentStore.selectedDocumentID = item.id
+        case .meeting:
+            documentStore.selectedDocumentID = nil
+            meetingStore.selectedMeetingID = item.id
+        }
+    }
+}
+
+// MARK: - Row
+
+private struct QuickOpenRow: View {
+    let item: QuickOpenItem
+    let isSelected: Bool
+    let action: () -> Void
+    @State private var isHovered = false
+
+    private var kindLabel: String {
+        switch item.kind {
+        case .document: "Document"
+        case .meeting: "Meeting"
+        }
+    }
+
+    private var kindIcon: String {
+        switch item.kind {
+        case .document: "doc.text"
+        case .meeting: "waveform"
+        }
+    }
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 10) {
+                Image(systemName: kindIcon)
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundStyle(isSelected ? .primary : .secondary)
+                    .frame(width: 24, height: 24)
+
+                Text(item.title)
+                    .font(.system(size: 14))
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+
+                Spacer()
+
+                Text(kindLabel)
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 6)
+            .background(
+                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                    .fill(isSelected
+                        ? AppThemeConstants.accent.opacity(AppThemeConstants.opacityMedium)
+                        : (isHovered ? Color.primary.opacity(AppThemeConstants.opacityLight) : Color.clear))
+                    .padding(.horizontal, 8)
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovered = $0 }
+        .accessibilityLabel("\(item.title), \(kindLabel)")
+        .accessibilityHint("Opens this \(kindLabel.lowercased())")
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+}

--- a/Logue/Views/CommandPalette/QuickOpenPaletteView.swift
+++ b/Logue/Views/CommandPalette/QuickOpenPaletteView.swift
@@ -22,27 +22,10 @@ struct QuickOpenPaletteView: View {
 
     /// Documents and meetings, most recently modified first.
     ///
-    /// The order matters: `QuickOpenMatcher` is stable within a rank, so the caller's ordering
-    /// is what breaks ties — recency, here. Trashed items are excluded by `activeDocuments`
-    /// and `activeMeetings`.
+    /// The raw arrays go in rather than `activeDocuments` / `activeMeetings`, so that excluding
+    /// trashed items is `QuickOpenItem.candidates`' job and therefore a tested one.
     private var candidates: [QuickOpenItem] {
-        let documents = documentStore.activeDocuments.map {
-            (modifiedAt: $0.modifiedAt, item: QuickOpenItem(
-                id: $0.id,
-                title: $0.title.isEmpty ? AppConstants.defaultDocumentTitle : $0.title,
-                kind: .document
-            ))
-        }
-        let meetings = meetingStore.activeMeetings.map {
-            (modifiedAt: $0.modifiedAt, item: QuickOpenItem(
-                id: $0.id,
-                title: $0.title.isEmpty ? AppConstants.defaultMeetingTitle : $0.title,
-                kind: .meeting
-            ))
-        }
-        return (documents + meetings)
-            .sorted { $0.modifiedAt > $1.modifiedAt }
-            .map(\.item)
+        QuickOpenItem.candidates(documents: documentStore.documents, meetings: meetingStore.meetings)
     }
 
     private var results: [QuickOpenItem] {

--- a/Logue/Views/Content/DocumentListContentView.swift
+++ b/Logue/Views/Content/DocumentListContentView.swift
@@ -298,9 +298,7 @@ struct DocumentListContentView: View {
         } content: { _ in
             VStack(alignment: .leading, spacing: 8) {
                 HStack {
-                    Image(systemName: "doc.text")
-                        .font(.title3)
-                        .foregroundStyle(.secondary)
+                    DocumentIconLabel(icon: doc.icon)
                     Spacer()
                     if doc.isPinned {
                         Image(systemName: "pin.fill")
@@ -383,9 +381,7 @@ struct DocumentListContentView: View {
             accessibilityHint: "Opens document",
             content: { _ in
                 HStack(spacing: 12) {
-                    Image(systemName: "doc.text")
-                        .font(.title3)
-                        .foregroundStyle(.secondary)
+                    DocumentIconLabel(icon: doc.icon)
                         .frame(width: 28)
 
                     VStack(alignment: .leading, spacing: 3) {

--- a/Logue/Views/Editor/BlockEditor/Model/Block.swift
+++ b/Logue/Views/Editor/BlockEditor/Model/Block.swift
@@ -48,6 +48,12 @@ enum Block: Identifiable {
     case mermaid(id: BlockID, source: String)
     /// A display-math block, stored as LaTeX between `$$` fences.
     case math(id: BlockID, latex: String)
+    /// A GitHub-style alert: `> [!NOTE] optional title` followed by quoted body lines.
+    ///
+    /// `title` is the optional text after the marker, empty when there is none — the
+    /// distinction is kept rather than defaulted so serialization can reproduce the original
+    /// markdown exactly either way.
+    case callout(id: BlockID, kind: CalloutKind, title: String, body: String)
 
     var id: BlockID {
         switch self {
@@ -61,7 +67,8 @@ enum Block: Identifiable {
              let .table(id, _),
              let .divider(id),
              let .mermaid(id, _),
-             let .math(id, _):
+             let .math(id, _),
+             let .callout(id, _, _, _):
             id
         }
     }
@@ -76,6 +83,8 @@ enum Block: Identifiable {
                 text
             case let .codeBlock(_, _, code):
                 code
+            case let .callout(_, _, _, body):
+                body
             default:
                 nil
             }
@@ -91,6 +100,8 @@ enum Block: Identifiable {
                 self = .blockQuote(id: id, text: newValue)
             case let .codeBlock(id, language, _):
                 self = .codeBlock(id: id, language: language, code: newValue)
+            case let .callout(id, kind, title, _):
+                self = .callout(id: id, kind: kind, title: title, body: newValue)
             default:
                 break
             }
@@ -98,9 +109,12 @@ enum Block: Identifiable {
     }
 
     /// Whether this block type contains editable text directly (not via list items).
+    ///
+    /// A callout counts: its body is edited in place like a quote's. That also puts it in the
+    /// "Turn into" menu, which is what lets a callout be demoted back to a plain quote.
     var isTextBlock: Bool {
         switch self {
-        case .paragraph, .heading, .blockQuote, .codeBlock:
+        case .paragraph, .heading, .blockQuote, .codeBlock, .callout:
             true
         default:
             false
@@ -133,6 +147,8 @@ enum Block: Identifiable {
             source.isEmpty ? [] : [source]
         case let .math(_, latex):
             latex.isEmpty ? [] : [latex]
+        case let .callout(_, _, title, body):
+            [title, body].filter { !$0.isEmpty }
         default:
             []
         }
@@ -163,6 +179,9 @@ enum Block: Identifiable {
             source.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         case let .math(_, latex):
             latex.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        case let .callout(_, _, title, body):
+            title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                && body.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         }
     }
 }
@@ -194,6 +213,8 @@ extension Block: Equatable {
             lid == rid && ls == rs
         case let (.math(lid, ll), .math(rid, rl)):
             lid == rid && ll == rl
+        case let (.callout(lid, lk, lt, lb), .callout(rid, rk, rt, rb)):
+            lid == rid && lk == rk && lt == rt && lb == rb
         default:
             false
         }
@@ -245,6 +266,12 @@ extension Block {
 
     static func emptyMath() -> Block {
         .math(id: UUID(), latex: "")
+    }
+
+    /// A new callout with no title, so the row shows the kind's default heading and the
+    /// serialized markdown is the bare `> [!NOTE]` form.
+    static func emptyCallout(kind: CalloutKind = .note) -> Block {
+        .callout(id: UUID(), kind: kind, title: "", body: "")
     }
 
     /// The first list item ID for list-type blocks, nil for others.

--- a/Logue/Views/Editor/BlockEditor/Model/BlockSerializer.swift
+++ b/Logue/Views/Editor/BlockEditor/Model/BlockSerializer.swift
@@ -22,7 +22,17 @@ enum BlockSerializer {
             case let .math(latex):
                 blocks.append(.math(id: UUID(), latex: latex))
             case let .markdown(text):
-                blocks += parseMarkdownSegment(text)
+                // Callouts get pulled out for the same reason as math fences: cmark reads one
+                // as a block quote and folds its line breaks into spaces, so a multi-line
+                // callout body could not be written back the way it arrived.
+                for calloutSegment in calloutSegments(in: text) {
+                    switch calloutSegment {
+                    case let .callout(kind, title, body):
+                        blocks.append(.callout(id: UUID(), kind: kind, title: title, body: body))
+                    case let .markdown(plain):
+                        blocks += parseMarkdownSegment(plain)
+                    }
+                }
             }
         }
 
@@ -97,6 +107,91 @@ enum BlockSerializer {
         }
 
         return segments
+    }
+
+    // MARK: - Callout Splitting
+
+    private enum CalloutSegment {
+        case markdown(String)
+        case callout(kind: CalloutKind, title: String, body: String)
+    }
+
+    /// Splits `markdown` into alternating plain-markdown runs and callout blocks.
+    ///
+    /// A callout is a block quote whose first line is `> [!TYPE]`, optionally followed by a
+    /// title on the same line. It runs until the first line that is not part of the quote.
+    /// Anything that is not one of the five recognised types — `> [!BANANA]`, or a plain
+    /// `> quote` — is left in the markdown run untouched, so cmark parses it as the block
+    /// quote it is.
+    private static func calloutSegments(in markdown: String) -> [CalloutSegment] {
+        guard markdown.contains("[!") else { return [.markdown(markdown)] }
+
+        let lines = markdown.components(separatedBy: "\n")
+        var segments: [CalloutSegment] = []
+        var pending: [String] = []
+        var index = 0
+
+        while index < lines.count {
+            guard let header = calloutHeader(in: lines[index]) else {
+                pending.append(lines[index])
+                index += 1
+                continue
+            }
+
+            // Body lines are the quote lines that follow, stopping at the first line that is
+            // not quoted — a blank line ends the quote in CommonMark, and a non-quote line
+            // starts a new block.
+            var bodyLines: [String] = []
+            var cursor = index + 1
+            while cursor < lines.count, let content = quotedContent(of: lines[cursor]) {
+                bodyLines.append(content)
+                cursor += 1
+            }
+
+            if !pending.isEmpty {
+                segments.append(.markdown(pending.joined(separator: "\n")))
+                pending = []
+            }
+            segments.append(.callout(
+                kind: header.kind,
+                title: header.title,
+                body: bodyLines.joined(separator: "\n")
+            ))
+            index = cursor
+        }
+
+        if !pending.isEmpty {
+            segments.append(.markdown(pending.joined(separator: "\n")))
+        }
+
+        return segments
+    }
+
+    /// Reads `> [!TYPE] optional title`, or `nil` when the line is not a callout header.
+    private static func calloutHeader(in line: String) -> (kind: CalloutKind, title: String)? {
+        guard let content = quotedContent(of: line) else { return nil }
+        let trimmed = content.trimmingCharacters(in: .whitespaces)
+        guard trimmed.hasPrefix("[!"), let closing = trimmed.firstIndex(of: "]") else { return nil }
+
+        let marker = String(trimmed[trimmed.index(trimmed.startIndex, offsetBy: 2) ..< closing])
+        guard let kind = CalloutKind(marker: marker) else { return nil }
+
+        let title = trimmed[trimmed.index(after: closing)...].trimmingCharacters(in: .whitespaces)
+        return (kind, title)
+    }
+
+    /// The content of a quote line with its `>` marker removed, or `nil` if it is not one.
+    ///
+    /// Exactly one following space is dropped, because that space is the marker's separator
+    /// rather than the author's indentation — dropping all leading whitespace would flatten a
+    /// deliberately indented body line and break the round-trip.
+    private static func quotedContent(of line: String) -> String? {
+        guard let markerRange = line.range(of: ">"),
+              line[line.startIndex ..< markerRange.lowerBound].allSatisfy(\.isWhitespace)
+        else { return nil }
+
+        let rest = line[markerRange.upperBound...]
+        return rest.hasPrefix(" ") ? String(rest.dropFirst()) : String(rest)
     }
 
     // MARK: - Serialize (Blocks → Markdown)
@@ -404,9 +499,26 @@ enum BlockSerializer {
         case let .mermaid(_, source):
             return "```\(Self.mermaidLanguage)\n\(source)\n```"
 
+        case let .callout(_, kind, title, body):
+            return serializeCallout(kind: kind, title: title, body: body)
+
         case let .math(_, latex):
             return "\(mathFence)\n\(latex)\n\(mathFence)"
         }
+    }
+
+    /// Writes a callout back as `> [!TYPE] title` plus quoted body lines.
+    ///
+    /// An empty body line serializes as a bare `>` rather than `"> "`, which is what it was
+    /// read from — a trailing space there is the one thing that would stop the round-trip
+    /// being byte-exact.
+    private static func serializeCallout(kind: CalloutKind, title: String, body: String) -> String {
+        var lines = ["> [!\(kind.rawValue)]" + (title.isEmpty ? "" : " \(title)")]
+        // A callout with no body is a single header line, not a header plus an empty quote.
+        if !body.isEmpty {
+            lines += body.components(separatedBy: "\n").map { $0.isEmpty ? ">" : "> \($0)" }
+        }
+        return lines.joined(separator: "\n")
     }
 
     static let mermaidLanguage = "mermaid"

--- a/Logue/Views/Editor/BlockEditor/Model/BlockSerializer.swift
+++ b/Logue/Views/Editor/BlockEditor/Model/BlockSerializer.swift
@@ -123,6 +123,23 @@ enum BlockSerializer {
     /// Anything that is not one of the five recognised types — `> [!BANANA]`, or a plain
     /// `> quote` — is left in the markdown run untouched, so cmark parses it as the block
     /// quote it is.
+    ///
+    /// **A recognised callout round-trips byte-exactly. One shape does not, and it matters in
+    /// markdown storage mode, where the file is the document and opening it rewrites it.** An
+    /// unquoted line immediately after a callout gains a blank line before it:
+    ///
+    ///     in   > [!NOTE]\n> Body\nRegular paragraph
+    ///     out  > [!NOTE]\n> Body\n\nRegular paragraph
+    ///
+    /// That is CommonMark lazy continuation: the unquoted line is part of the quote, and ending
+    /// the callout at the last `>` separates it instead of absorbing it. The separation is
+    /// deliberate — the alternative is what cmark did before this existed, which was to fold the
+    /// whole thing into `> [!NOTE] Body Regular paragraph` and lose the paragraph entirely — but
+    /// the rewrite is real, so it is written down rather than left to be discovered.
+    ///
+    /// An unrecognised type folds its line breaks (`> [!BANANA]\n> Body` becomes
+    /// `> [!BANANA] Body`) because it degrades to a block quote, and block quotes have always
+    /// done that. `CalloutRoundTripEdgeTests` pins both down.
     private static func calloutSegments(in markdown: String) -> [CalloutSegment] {
         guard markdown.contains("[!") else { return [.markdown(markdown)] }
 
@@ -510,8 +527,8 @@ enum BlockSerializer {
     /// Writes a callout back as `> [!TYPE] title` plus quoted body lines.
     ///
     /// An empty body line serializes as a bare `>` rather than `"> "`, which is what it was
-    /// read from — a trailing space there is the one thing that would stop the round-trip
-    /// being byte-exact.
+    /// read from — a trailing space there would be enough on its own to stop a callout coming
+    /// back byte-for-byte. For the two shapes that still do not, see `calloutSegments`.
     private static func serializeCallout(kind: CalloutKind, title: String, body: String) -> String {
         var lines = ["> [!\(kind.rawValue)]" + (title.isEmpty ? "" : " \(title)")]
         // A callout with no body is a single header line, not a header plus an empty quote.

--- a/Logue/Views/Editor/BlockEditor/Model/CalloutKind.swift
+++ b/Logue/Views/Editor/BlockEditor/Model/CalloutKind.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+
+/// The five GitHub alert types a callout block can be.
+///
+/// Deliberately closed. An unrecognised marker such as `> [!BANANA]` is not a callout at
+/// all — the serializer leaves it to be parsed as an ordinary block quote, which is what
+/// GitHub does with it too, and which keeps the round-trip honest: a type we cannot name is
+/// a type we cannot write back.
+enum CalloutKind: String, CaseIterable, Codable, Sendable {
+    case note = "NOTE"
+    case tip = "TIP"
+    case important = "IMPORTANT"
+    case warning = "WARNING"
+    case caution = "CAUTION"
+
+    /// Parses the marker text between the brackets, e.g. `NOTE` from `> [!NOTE]`.
+    ///
+    /// Case-insensitive on the way in because editors and people write `[!note]` too, but
+    /// `rawValue` — always upper case — is what gets written back, so a document normalises
+    /// to the spelling GitHub renders.
+    init?(marker: String) {
+        let upper = marker.trimmingCharacters(in: .whitespaces).uppercased()
+        guard let match = CalloutKind(rawValue: upper) else { return nil }
+        self = match
+    }
+
+    /// Title shown when the callout has no title of its own. Matches GitHub's rendering.
+    var defaultTitle: String {
+        rawValue.capitalized
+    }
+
+    var symbolName: String {
+        switch self {
+        case .note: "info.circle.fill"
+        case .tip: "lightbulb.fill"
+        case .important: "exclamationmark.bubble.fill"
+        case .warning: "exclamationmark.triangle.fill"
+        case .caution: "exclamationmark.octagon.fill"
+        }
+    }
+
+    /// Accent used for the icon, the title and the leading rule. Follows GitHub's alert
+    /// palette; system colours rather than fixed values so both appearances stay legible.
+    var accent: Color {
+        switch self {
+        case .note: .blue
+        case .tip: .green
+        case .important: .purple
+        case .warning: .orange
+        case .caution: .red
+        }
+    }
+}

--- a/Logue/Views/Editor/BlockEditor/Model/DocumentSearchState.swift
+++ b/Logue/Views/Editor/BlockEditor/Model/DocumentSearchState.swift
@@ -178,6 +178,12 @@ final class DocumentSearchState {
             case let .math(id, latex):
                 results += findMatches(in: latex, blockID: id, itemID: nil, options: searchOptions)
 
+            case let .callout(id, _, title, body):
+                // Title as well as body: the title is authored text, and find-in-document
+                // that skipped it would look broken to whoever wrote it.
+                results += findMatches(in: title, blockID: id, itemID: nil, options: searchOptions)
+                results += findMatches(in: body, blockID: id, itemID: nil, options: searchOptions)
+
             case .table, .divider:
                 break
             }

--- a/Logue/Views/Editor/BlockEditor/Views/BlockRowView+Actions.swift
+++ b/Logue/Views/Editor/BlockEditor/Views/BlockRowView+Actions.swift
@@ -198,6 +198,7 @@ extension BlockRowView {
                 Button("Heading 2") { turnInto(.heading2) }
                 Button("Heading 3") { turnInto(.heading3) }
                 Button("Quote") { turnInto(.quote) }
+                Button("Callout") { turnInto(.callout) }
                 Button("Code Block") { turnInto(.codeBlock) }
             }
             Divider()
@@ -237,8 +238,16 @@ extension BlockRowView {
             newBlock = .heading(id: block.id, level: 3, text: text)
         case .quote:
             newBlock = .blockQuote(id: block.id, text: text)
+        case .callout:
+            // Keeps the kind and title when the block already is a callout, so "Turn into >
+            // Callout" on a warning does not silently demote it to a note.
+            if case let .callout(_, kind, title, _) = block {
+                newBlock = .callout(id: block.id, kind: kind, title: title, body: text)
+            } else {
+                newBlock = .callout(id: block.id, kind: .note, title: "", body: text)
+            }
         case .codeBlock:
-            newBlock = .codeBlock(id: block.id, language: "", code: text)
+            newBlock = .codeBlock(id: block.id, language: CodeBlockLanguageMemory.suggestedLanguage, code: text)
         default:
             return
         }
@@ -275,6 +284,8 @@ extension BlockRowView {
             return .mermaid(id: newID, source: source)
         case let .math(_, latex):
             return .math(id: newID, latex: latex)
+        case let .callout(_, kind, title, body):
+            return .callout(id: newID, kind: kind, title: title, body: body)
         }
     }
 

--- a/Logue/Views/Editor/BlockEditor/Views/BlockRowView.swift
+++ b/Logue/Views/Editor/BlockEditor/Views/BlockRowView.swift
@@ -99,6 +99,9 @@ struct BlockRowView: View {
         case let .blockQuote(id, text):
             blockQuoteView(id: id, text: text)
 
+        case let .callout(id, kind, title, body):
+            calloutView(id: id, kind: kind, title: title, body: body)
+
         case let .codeBlock(id, language, code):
             codeBlockView(id: id, language: language, code: code)
 
@@ -447,15 +450,136 @@ struct BlockRowView: View {
         }
     }
 
+    // MARK: - Callout
+
+    /// A GitHub-style alert: kind icon and heading, with the body editable underneath.
+    ///
+    /// The body uses the same `editableTextView` as a quote, so typing, splitting and the
+    /// backspace-at-start behaviour are the ones the rest of the editor already has. Only the
+    /// chrome around it — icon, colour, heading, tinted background — is new.
+    private func calloutView(id: BlockID, kind: CalloutKind, title: String, body: String) -> some View {
+        HStack(spacing: 0) {
+            RoundedRectangle(cornerRadius: 6)
+                .fill(kind.accent.opacity(AppThemeConstants.opacityStrong))
+                .frame(width: blockquoteBarWidth)
+
+            VStack(alignment: .leading, spacing: 4) {
+                calloutHeader(id: id, kind: kind, title: title)
+
+                editableTextView(
+                    id: id,
+                    text: textBinding(for: id),
+                    font: .systemFont(ofSize: fontSize),
+                    isFocused: isFocused,
+                    searchHighlights: blockSearchHighlights(),
+                    onEnter: { offset in
+                        // An empty callout collapses to a paragraph on Return, matching what a
+                        // quote does — otherwise the only way out is the context menu.
+                        if body.isEmpty {
+                            document.replaceBlock(id: id, with: .paragraph(id: id, text: ""))
+                        } else {
+                            splitBlock(id: id, at: offset)
+                        }
+                    },
+                    onBackspaceAtStart: {
+                        if body.isEmpty {
+                            document.replaceBlock(id: id, with: .paragraph(id: id, text: ""))
+                        } else {
+                            mergeWithPrevious(id: id)
+                        }
+                    }
+                )
+            }
+            .padding(.leading, fontSize * 0.75)
+            .padding(.trailing, fontSize * 0.5)
+            .padding(.vertical, fontSize * 0.5)
+        }
+        .background(kind.accent.opacity(AppThemeConstants.opacityLight))
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+
+    /// The icon, kind picker and optional title line.
+    private func calloutHeader(id: BlockID, kind: CalloutKind, title: String) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: kind.symbolName)
+                .font(.system(size: fontSize * 0.85))
+                .foregroundStyle(kind.accent)
+
+            Menu {
+                ForEach(CalloutKind.allCases, id: \.self) { candidate in
+                    Button {
+                        document.replaceBlock(
+                            id: id,
+                            with: .callout(id: id, kind: candidate, title: title, body: calloutBody(of: id))
+                        )
+                    } label: {
+                        Label(candidate.defaultTitle, systemImage: candidate.symbolName)
+                    }
+                }
+            } label: {
+                Text(title.isEmpty ? kind.defaultTitle : title)
+                    .font(.system(size: fontSize * 0.9, weight: .semibold))
+                    .foregroundStyle(kind.accent)
+            }
+            .menuStyle(.borderlessButton)
+            .fixedSize()
+            .help("Callout type")
+
+            Spacer()
+
+            if isFocused {
+                // Only offered while the block is focused: an always-visible field would put a
+                // text box in every callout in the document.
+                TextField("Optional title", text: calloutTitleBinding(for: id))
+                    .textFieldStyle(.plain)
+                    .font(.system(size: fontSize * 0.8))
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: 160)
+            }
+        }
+    }
+
+    /// The current body text, read back from the document so a kind change cannot write a
+    /// stale copy of it over what the user has since typed.
+    private func calloutBody(of id: BlockID) -> String {
+        if case let .callout(_, _, _, body) = document.block(for: id) {
+            return body
+        }
+        return ""
+    }
+
+    private func calloutTitleBinding(for id: BlockID) -> Binding<String> {
+        Binding(
+            get: {
+                if case let .callout(_, _, title, _) = document.block(for: id) {
+                    return title
+                }
+                return ""
+            },
+            set: { newTitle in
+                if case let .callout(_, kind, _, body) = document.block(for: id) {
+                    // Newlines would break the single-line `> [!NOTE] title` form on the way
+                    // back out, so they are stripped rather than allowed to corrupt the fence.
+                    let cleaned = newTitle.replacingOccurrences(of: "\n", with: " ")
+                    document.replaceBlock(id: id, with: .callout(id: id, kind: kind, title: cleaned, body: body))
+                }
+            }
+        )
+    }
+
     // MARK: - Code Block
 
     private func codeBlockHeader(id: BlockID, code: String) -> some View {
         HStack {
+            languageMenu(for: id)
+            // The free-text field stays alongside the menu so a language the highlighter
+            // does not know — one that arrived in imported markdown, or a new one — can
+            // still be written into the fence by hand.
             TextField("language", text: languageBinding(for: id))
                 .textFieldStyle(.plain)
                 .font(.caption.monospaced())
                 .foregroundStyle(.secondary)
-                .frame(maxWidth: 120)
+                .frame(maxWidth: 100)
             Spacer()
             Button {
                 NSPasteboard.general.clearContents()
@@ -471,6 +595,33 @@ struct BlockRowView: View {
         .padding(.horizontal, 12)
         .padding(.top, 8)
         .padding(.bottom, 4)
+    }
+
+    /// Picks the fence language from the set the highlighter actually supports.
+    ///
+    /// `CodeSyntaxHighlighter.supportedLanguages` is the source of the list, so the menu
+    /// cannot drift from what highlighting is available for. The chosen language is also
+    /// remembered, and becomes the default for the next code block inserted.
+    private func languageMenu(for id: BlockID) -> some View {
+        let binding = languageBinding(for: id)
+        let current = CodeSyntaxHighlighter.displayName(forLanguage: binding.wrappedValue)
+
+        return Menu {
+            Button("Plain Text") { binding.wrappedValue = "" }
+            Divider()
+            ForEach(CodeSyntaxHighlighter.supportedLanguages) { language in
+                Button(language.displayName) {
+                    binding.wrappedValue = language.id
+                    CodeBlockLanguageMemory.remember(language.id)
+                }
+            }
+        } label: {
+            Text(current ?? "Plain Text")
+                .font(.caption)
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize()
+        .help("Syntax highlighting language")
     }
 
     @ViewBuilder

--- a/Logue/Views/Editor/CodeBlockLanguageMemory.swift
+++ b/Logue/Views/Editor/CodeBlockLanguageMemory.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// Remembers the language last chosen in a code block, so the next one starts there.
+///
+/// Someone writing a document full of Swift snippets should pick "Swift" once, not once per
+/// block. Stored in `UserDefaults` rather than held in memory so the preference survives a
+/// relaunch, and read through a plain accessor rather than `@AppStorage` because the callers
+/// are `BlockType.makeBlock` and the block row's menu, neither of which is a view with state.
+enum CodeBlockLanguageMemory {
+    /// The language a newly inserted code block should start with.
+    ///
+    /// Empty when nothing has been chosen yet, which is the same as "plain text" — a new block
+    /// then behaves exactly as it did before this existed. A remembered value that is no longer
+    /// one the highlighter supports is discarded rather than written into a fence.
+    static var suggestedLanguage: String {
+        guard let stored = UserDefaults.standard.string(
+            forKey: AppConstants.UserDefaultsKeys.lastCodeBlockLanguage
+        )
+        else { return "" }
+        let isSupported = CodeSyntaxHighlighter.supportedLanguages.contains {
+            $0.id.caseInsensitiveCompare(stored) == .orderedSame
+        }
+        return isSupported ? stored : ""
+    }
+
+    /// Records a language the user picked from the code block menu.
+    ///
+    /// Only called for menu choices, not for text typed into the language field: a half-typed
+    /// identifier would otherwise become the default for every subsequent block.
+    static func remember(_ language: String) {
+        let trimmed = language.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        UserDefaults.standard.set(trimmed, forKey: AppConstants.UserDefaultsKeys.lastCodeBlockLanguage)
+    }
+}

--- a/Logue/Views/Editor/DocumentIconPicker.swift
+++ b/Logue/Views/Editor/DocumentIconPicker.swift
@@ -1,0 +1,195 @@
+import SwiftUI
+
+/// Shows a document's icon where a list or card would otherwise show the document symbol.
+///
+/// The emoji takes the place of the symbol rather than sitting next to it, so a document
+/// without an icon renders exactly as it did before icons existed — same glyph, same slot,
+/// no placeholder and nothing that shifts when one is set.
+struct DocumentIconLabel: View {
+    let icon: String?
+    /// The symbol drawn when there is no icon. Sites differ (`doc.text`, `doc.text.fill`),
+    /// so the caller names the one it was already using.
+    var fallbackSymbol: String = "doc.text"
+    var font: Font = .title3
+    /// Applied to the fallback symbol only — tinting an emoji does nothing useful.
+    var fallbackStyle: Color?
+
+    var body: some View {
+        if let icon {
+            Text(icon)
+                .font(font)
+        } else if let fallbackStyle {
+            Image(systemName: fallbackSymbol)
+                .font(font)
+                .foregroundStyle(fallbackStyle)
+        } else {
+            Image(systemName: fallbackSymbol)
+                .font(font)
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+
+/// A popover grid for picking a single-emoji icon for a document.
+///
+/// Separate from `SpaceIconPicker`, which offers SF Symbol *names*: a document icon is a
+/// single grapheme (see `DocumentIcon`), so a symbol name could never be a valid value for
+/// one. Every path out of here — grid or typed field — goes through `DocumentIcon.sanitised`,
+/// so nothing that would be rejected downstream can be assigned in the first place.
+struct DocumentIconPicker: View {
+    let currentIcon: String?
+    /// Called with the sanitised icon, or `nil` to clear it.
+    let onSelect: (String?) -> Void
+
+    @State private var customIcon = ""
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+
+            Divider()
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 12) {
+                    ForEach(Self.emojiGroups, id: \.0) { group, emoji in
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text(group)
+                                .font(.caption2.weight(.semibold))
+                                .foregroundStyle(.secondary)
+                                .padding(.horizontal, 12)
+
+                            LazyVGrid(
+                                columns: Array(repeating: GridItem(.fixed(32), spacing: 4), count: 8),
+                                spacing: 4
+                            ) {
+                                ForEach(emoji, id: \.self) { icon in
+                                    emojiButton(icon)
+                                }
+                            }
+                            .padding(.horizontal, 12)
+                        }
+                    }
+                }
+                .padding(.vertical, 8)
+            }
+        }
+        .frame(width: 300, height: 340)
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        VStack(spacing: 8) {
+            HStack(spacing: 6) {
+                // A typed field as well as the grid, because the grid is a shortlist and any
+                // single grapheme is a legal icon. `sanitised` is what decides, not this field.
+                TextField("Type any emoji…", text: $customIcon)
+                    .textFieldStyle(.plain)
+                    .font(.callout)
+                    .onSubmit { commitCustomIcon() }
+                    .accessibilityLabel("Custom document icon")
+                    .accessibilityHint("Type a single emoji and press Return")
+
+                if !customIcon.isEmpty {
+                    Button("Use") { commitCustomIcon() }
+                        .controlSize(.small)
+                        .disabled(DocumentIcon.sanitised(customIcon) == nil)
+                }
+            }
+            .padding(8)
+            .background(
+                Color.primary.opacity(AppThemeConstants.opacityLight),
+                in: RoundedRectangle(cornerRadius: 6)
+            )
+
+            Button {
+                onSelect(nil)
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "slash.circle")
+                        .frame(width: 20)
+                    Text("No icon")
+                        .font(.caption)
+                    Spacer()
+                    if currentIcon == nil {
+                        Image(systemName: "checkmark")
+                            .font(.caption2.bold())
+                            .foregroundStyle(AppThemeConstants.brandPrimary)
+                    }
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("No document icon")
+            .accessibilityHint("Removes the document's icon")
+            .accessibilityAddTraits(currentIcon == nil ? .isSelected : [])
+        }
+        .padding(.horizontal, 12)
+        .padding(.top, 12)
+        .padding(.bottom, 8)
+    }
+
+    private func emojiButton(_ icon: String) -> some View {
+        Button {
+            onSelect(DocumentIcon.sanitised(icon))
+        } label: {
+            Text(icon)
+                .font(.system(size: 18))
+                .frame(width: 32, height: 32)
+                .background(
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(currentIcon == icon
+                            ? AppThemeConstants.brandPrimary.opacity(AppThemeConstants.opacityMedium)
+                            : Color.clear)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6)
+                        .strokeBorder(
+                            currentIcon == icon ? AppThemeConstants.brandPrimary : Color.clear,
+                            lineWidth: 1.5
+                        )
+                )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(icon)
+        .accessibilityHint("Sets the document icon")
+        .accessibilityAddTraits(currentIcon == icon ? .isSelected : [])
+    }
+
+    /// Applies the typed icon, ignoring anything `DocumentIcon` rejects.
+    ///
+    /// Silently declining is deliberate: the "Use" button is already disabled for input that
+    /// would not survive validation, so reaching here with something invalid means a Return
+    /// key on an empty or multi-character field, where an error would be noise.
+    private func commitCustomIcon() {
+        guard let sanitised = DocumentIcon.sanitised(customIcon) else { return }
+        customIcon = ""
+        onSelect(sanitised)
+    }
+
+    // MARK: - Emoji Library
+
+    /// A shortlist for the grid. Not exhaustive by design — the typed field covers the rest.
+    static let emojiGroups: [(String, [String])] = [
+        ("General", [
+            "📄", "📝", "📋", "📌", "📎", "🔖", "🗂", "📁",
+            "⭐️", "❤️", "🔥", "✅", "❌", "⚠️", "❓", "💡",
+        ]),
+        ("Work", [
+            "💼", "📊", "📈", "📉", "🗓", "⏰", "🎯", "🏆",
+            "🤝", "💰", "🧾", "🏢", "✉️", "📞", "🖇", "🗒",
+        ]),
+        ("Product & Design", [
+            "🎨", "🖌", "✏️", "📐", "🧩", "🪄", "🖼", "🎬",
+            "🚀", "🛠", "🔧", "🧪", "🔬", "📦", "🧭", "🗺",
+        ]),
+        ("Engineering", [
+            "💻", "🖥", "⌨️", "🐛", "🔒", "🔑", "☁️", "🗄",
+            "⚙️", "🧱", "🔌", "📡", "🤖", "🧠", "♻️", "🔍",
+        ]),
+        ("People & Places", [
+            "👤", "👥", "🗣", "🎓", "🏠", "🌍", "✈️", "🚗",
+            "☕️", "🍽", "🌱", "🌤", "🌙", "🎉", "🎁", "🎵",
+        ]),
+    ]
+}

--- a/Logue/Views/Editor/DocumentWorkspaceView+Toolbar.swift
+++ b/Logue/Views/Editor/DocumentWorkspaceView+Toolbar.swift
@@ -89,6 +89,11 @@ extension DocumentWorkspaceView {
             Label("Rename", systemImage: "pencil")
         }
         Button {
+            showIconPicker = true
+        } label: {
+            Label(doc.icon == nil ? "Add Icon" : "Change Icon", systemImage: "face.smiling")
+        }
+        Button {
             showTagPopover = true
         } label: {
             Label("Add Tag", systemImage: "tag")
@@ -98,6 +103,17 @@ extension DocumentWorkspaceView {
         } label: {
             Label("Save as Template", systemImage: "doc.on.doc")
         }
+        exportMenu(doc: doc)
+        Divider()
+        Button(role: .destructive) {
+            store.deleteDocument(id: doc.id)
+        } label: {
+            Label("Delete Document", systemImage: "trash")
+        }
+    }
+
+    /// Split out of `moreMenuItems` only to keep that function within the body-length limit.
+    private func exportMenu(doc: WritingDocument) -> some View {
         Menu("Export") {
             Button {
                 PDFExportService.export(document: doc)
@@ -110,12 +126,6 @@ extension DocumentWorkspaceView {
                 Label("Export as Markdown", systemImage: "doc.plaintext")
             }
         }
-        Divider()
-        Button(role: .destructive) {
-            store.deleteDocument(id: doc.id)
-        } label: {
-            Label("Delete Document", systemImage: "trash")
-        }
     }
 
     func moreOptionsMenu(doc: WritingDocument) -> some View {
@@ -127,6 +137,15 @@ extension DocumentWorkspaceView {
         .help("More options")
         .popover(isPresented: $showTagPopover, arrowEdge: .bottom) {
             tagPopoverContent(doc: doc)
+        }
+        .popover(isPresented: $showIconPicker, arrowEdge: .bottom) {
+            DocumentIconPicker(currentIcon: doc.icon) { icon in
+                var updated = doc
+                // Already sanitised by the picker; `icon` is never raw input here.
+                updated.icon = icon
+                store.updateDocument(updated)
+                showIconPicker = false
+            }
         }
         .alert("Rename Document", isPresented: $showRenameAlert) {
             TextField("Title", text: $renameText)

--- a/Logue/Views/Editor/DocumentWorkspaceView.swift
+++ b/Logue/Views/Editor/DocumentWorkspaceView.swift
@@ -42,13 +42,23 @@ struct DocumentWorkspaceView: View {
         AppConstants.Editor.defaultZoom
     @State private var aiChatPendingMessage: String?
     // Extension-visible: +Toolbar
-    @State var isSidebarCollapsed = false
+    /// Starts from the persisted pane layout, then follows ⌘1 / ⌘2 / ⌘3 — but the toolbar's
+    /// own toggle still writes here directly, so a manual show/hide keeps working and simply
+    /// wins until the next time the layout shortcut is used.
+    @State var isSidebarCollapsed = !EditorLayoutMode.stored.showsInspector
+
+    /// Observed rather than read once, so the ⌘1 / ⌘2 / ⌘3 items in the View menu reach the
+    /// inspector while a document is already open.
+    @AppStorage(AppConstants.UserDefaultsKeys.editorLayoutMode) private var layoutModeRaw =
+        EditorLayoutMode.allPanels.rawValue
     @State private var scrollToSuggestion: Suggestion?
     /// Scrolls to and selects arbitrary text in the editor (used by vocab enhancement, etc.)
     @State private var scrollToText: String?
     @State private var toolPanelWidths: [String: CGFloat] = [:]
     // Extension-visible: +Toolbar
     @State var showTagPopover = false
+    // Extension-visible: +Toolbar
+    @State var showIconPicker = false
     @State private var newTagText = ""
     // Extension-visible: +Toolbar
     @State var showRenameAlert = false
@@ -138,6 +148,14 @@ struct DocumentWorkspaceView: View {
             .onChange(of: isSidebarCollapsed) { _, collapsed in
                 if !collapsed, activeTool == nil {
                     activeTool = .proofreader
+                }
+            }
+            .onChange(of: layoutModeRaw) { _, raw in
+                // Reads `showsInspector` rather than testing for a particular mode, so what
+                // each layout means stays a question only `EditorLayoutMode` answers.
+                let mode = EditorLayoutMode(rawValue: raw) ?? .allPanels
+                withAnimation(.spring(duration: 0.25, bounce: 0.1)) {
+                    isSidebarCollapsed = !mode.showsInspector
                 }
             }
             .onReceive(NotificationCenter.default.publisher(for: .logueAskAI)) { note in

--- a/Logue/Views/Editor/EditorLayoutMode.swift
+++ b/Logue/Views/Editor/EditorLayoutMode.swift
@@ -31,6 +31,20 @@ enum EditorLayoutMode: String, CaseIterable, Codable, Sendable {
         }
     }
 
+    /// The mode a split-view visibility report should store, or `nil` to leave the mode alone.
+    ///
+    /// Only a collapse is inferred, and that asymmetry is the whole point. SwiftUI echoes the
+    /// new visibility back through its `columnVisibility` binding immediately after a menu item
+    /// sets a mode, and the echo arrives while the binding still reads the previous mode —
+    /// `@AppStorage` caches, so a setter cannot see the write it is echoing. A rule that tried
+    /// to name the mode for a *re-appearing* list therefore read the old mode's
+    /// `showsInspector`, which is `false` in editor-only, and turned every ⌘3 pressed from
+    /// editor-only into editor-and-list. Nothing needs that direction inferred: every path that
+    /// shows the list again already names the mode it wants.
+    static func modeAfterVisibilityReport(listIsVisible: Bool) -> EditorLayoutMode? {
+        listIsVisible ? nil : .editorOnly
+    }
+
     /// The persisted layout, read straight from `UserDefaults`.
     ///
     /// Exists so a `@State` property can be initialised from the stored mode — a property

--- a/Logue/Views/Editor/EditorLayoutMode.swift
+++ b/Logue/Views/Editor/EditorLayoutMode.swift
@@ -41,6 +41,13 @@ enum EditorLayoutMode: String, CaseIterable, Codable, Sendable {
     /// `showsInspector`, which is `false` in editor-only, and turned every ⌘3 pressed from
     /// editor-only into editor-and-list. Nothing needs that direction inferred: every path that
     /// shows the list again already names the mode it wants.
+    ///
+    /// A consequence worth stating, because it is chosen rather than accidental: dragging the
+    /// sidebar shut while in `allPanels` lands on `editorOnly`, which hides the inspector too.
+    /// There is no editor-plus-inspector mode to land on — the three modes are a progression, so
+    /// "no list" can only mean the narrowest one. Someone dragging the divider for more room may
+    /// not expect to lose the inspector, and the honest fix for that is a fourth case rather than
+    /// a special case here. ⌘3 brings both back in one keystroke.
     static func modeAfterVisibilityReport(listIsVisible: Bool) -> EditorLayoutMode? {
         listIsVisible ? nil : .editorOnly
     }

--- a/Logue/Views/Editor/EditorLayoutMode.swift
+++ b/Logue/Views/Editor/EditorLayoutMode.swift
@@ -30,4 +30,17 @@ enum EditorLayoutMode: String, CaseIterable, Codable, Sendable {
         case .allPanels: "All Panels"
         }
     }
+
+    /// The persisted layout, read straight from `UserDefaults`.
+    ///
+    /// Exists so a `@State` property can be initialised from the stored mode — a property
+    /// initialiser cannot read another wrapper's value. Views that need to *react* to the
+    /// mode changing observe the `@AppStorage` key instead.
+    static var stored: EditorLayoutMode {
+        guard let raw = UserDefaults.standard.string(
+            forKey: AppConstants.UserDefaultsKeys.editorLayoutMode
+        )
+        else { return .allPanels }
+        return EditorLayoutMode(rawValue: raw) ?? .allPanels
+    }
 }

--- a/Logue/Views/Editor/EditorZoom.swift
+++ b/Logue/Views/Editor/EditorZoom.swift
@@ -43,3 +43,21 @@ struct EditorZoom: Equatable {
         min(max(value, AppConstants.Editor.minZoom), AppConstants.Editor.maxZoom)
     }
 }
+
+extension EditorZoom {
+    /// Reads the persisted scale, applies `mutate`, and writes the clamped result back.
+    ///
+    /// Two places drive zoom — the View menu items and the main window's own key handling for
+    /// the `⌘=` alias — and the clamping has to stay in one place, so they meet at the stored
+    /// value rather than at a binding one of them owns. Writing through `UserDefaults` is what
+    /// makes that work: the `@AppStorage` properties reading this key update from it.
+    static func mutatePersisted(_ mutate: (inout EditorZoom) -> Void) {
+        let key = AppConstants.UserDefaultsKeys.editorZoomScale
+        var zoom = EditorZoom()
+        if let stored = UserDefaults.standard.object(forKey: key) as? Double {
+            zoom.scale = CGFloat(stored)
+        }
+        mutate(&zoom)
+        UserDefaults.standard.set(Double(zoom.scale), forKey: key)
+    }
+}

--- a/Logue/Views/Editor/RichTextEditorHelpers.swift
+++ b/Logue/Views/Editor/RichTextEditorHelpers.swift
@@ -19,12 +19,13 @@ enum BlockType: String, CaseIterable {
     case heading1, heading2, heading3
     case bulletList, numberedList, todoList
     case quote, divider, codeBlock, table
-    case mermaid, math
+    case mermaid, math, callout
 
     var displayName: String {
         switch self {
         case .mermaid: "Diagram"
         case .math: "Equation"
+        case .callout: "Callout"
         case .text: "Text"
         case .heading1: "Heading 1"
         case .heading2: "Heading 2"
@@ -43,6 +44,7 @@ enum BlockType: String, CaseIterable {
         switch self {
         case .mermaid: "flowchart"
         case .math: "function"
+        case .callout: "exclamationmark.bubble"
         case .text: "text.alignleft"
         case .heading1: "textformat.size.larger"
         case .heading2: "textformat.size"
@@ -61,6 +63,7 @@ enum BlockType: String, CaseIterable {
         switch self {
         case .mermaid: "Mermaid diagram, stored as markdown"
         case .math: "LaTeX equation block"
+        case .callout: "Note, tip, or warning block"
         case .text: "Plain text paragraph"
         case .heading1: "Large section heading"
         case .heading2: "Medium section heading"
@@ -85,7 +88,7 @@ enum BlockType: String, CaseIterable {
         switch self {
         case .text, .heading1, .heading2, .heading3: .text
         case .bulletList, .numberedList, .todoList: .lists
-        case .quote, .divider, .codeBlock, .table, .mermaid, .math: .advanced
+        case .quote, .divider, .codeBlock, .table, .mermaid, .math, .callout: .advanced
         }
     }
 
@@ -114,8 +117,14 @@ enum BlockType: String, CaseIterable {
             return .checkboxList(id: id, items: [CheckboxItem(text: text)])
         case .quote:
             return .blockQuote(id: id, text: text)
+        case .callout:
+            // Any existing text becomes the body, not the title: converting a paragraph should
+            // keep what was written where it reads the same, and the title is decoration.
+            return .callout(id: id, kind: .note, title: "", body: text)
         case .codeBlock:
-            return .codeBlock(id: id, language: "", code: text)
+            // Starts at the language last picked from a code block's menu, so a document
+            // full of snippets in one language does not need choosing block by block.
+            return .codeBlock(id: id, language: CodeBlockLanguageMemory.suggestedLanguage, code: text)
         case .divider:
             return .divider(id: id)
         case .table:
@@ -145,6 +154,7 @@ enum BlockType: String, CaseIterable {
         case .numberedList: "1. "
         case .todoList: "- [ ] "
         case .quote: "> "
+        case .callout: "> [!NOTE]\n> "
         case .divider: "---"
         case .codeBlock: "```"
         case .table: ""

--- a/Logue/Views/Home/DocumentCardView.swift
+++ b/Logue/Views/Home/DocumentCardView.swift
@@ -57,9 +57,12 @@ struct DocumentCardView: View {
             // Footer
             VStack(alignment: .leading, spacing: 4) {
                 HStack(spacing: 6) {
-                    Image(systemName: "doc.text.fill")
-                        .font(.caption2)
-                        .foregroundColor(AppThemeConstants.accent)
+                    DocumentIconLabel(
+                        icon: document.icon,
+                        fallbackSymbol: "doc.text.fill",
+                        font: .caption2,
+                        fallbackStyle: AppThemeConstants.accent
+                    )
                     Text(document.title)
                         .font(.subheadline.weight(.medium))
                         .lineLimit(1)

--- a/Logue/Views/KeyboardShortcutsView.swift
+++ b/Logue/Views/KeyboardShortcutsView.swift
@@ -9,6 +9,14 @@ struct KeyboardShortcutsView: View {
             ("Ask Logue", shortcutManager.commandCenterShortcut.displayString),
             ("New Document", "⌘N"),
             ("New Meeting", "⇧⌘N"),
+            ("Command Palette", "⌘K"),
+            ("Quick Open", "⌘P"),
+            ("Zoom In", "⌘+ or ⌘="),
+            ("Zoom Out", "⌘-"),
+            ("Actual Size", "⌘0"),
+            (EditorLayoutMode.editorOnly.label, "⌘1"),
+            (EditorLayoutMode.editorAndList.label, "⌘2"),
+            (EditorLayoutMode.allPanels.label, "⌘3"),
             ("Export Meeting", "⌘E"),
             ("Settings", "⌘,"),
             ("Close Window", "⌘W"),
@@ -17,15 +25,17 @@ struct KeyboardShortcutsView: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            ForEach(shortcuts, id: \.label) { item in
-                ShortcutListRow(label: item.label, shortcut: item.shortcut)
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                ForEach(shortcuts, id: \.label) { item in
+                    ShortcutListRow(label: item.label, shortcut: item.shortcut)
+                }
             }
-
-            Spacer()
+            .padding(AppThemeConstants.paddingXXLarge)
         }
-        .padding(AppThemeConstants.paddingXXLarge)
-        .frame(width: 380, height: 320)
+        // Scrolls rather than growing the window: the list is long enough now that a fixed
+        // height would clip the last rows on a short display.
+        .frame(width: 400, height: 420)
     }
 }
 

--- a/Logue/Views/MainWindowView.swift
+++ b/Logue/Views/MainWindowView.swift
@@ -84,23 +84,18 @@ struct MainWindowView: View {
 
     /// Bridge between `EditorLayoutMode` and the split view's own column visibility.
     ///
-    /// The write-back only ever records a *collapse*, and never tries to work out which mode a
-    /// re-appearing sidebar should mean. That is deliberate, and it was a bug first: SwiftUI
-    /// echoes the new visibility straight back through this binding after the menu sets a mode,
-    /// and the echo arrives with `layoutMode` still reading the value it had a moment ago —
-    /// `@AppStorage` caches, so the setter cannot see its own write. Reconstructing the mode
-    /// from that stale read turned every ⌘3 pressed from editor-only into editor-and-list,
-    /// because the old mode showed no inspector. Only the collapse direction is safe to infer,
-    /// and it is the only one that has to be: every path that shows the list again names the
-    /// mode it wants.
+    /// What a report back from the split view means is decided by
+    /// `EditorLayoutMode.modeAfterVisibilityReport(listIsVisible:)` rather than here, because
+    /// that rule is subtle enough to be worth a test — see its doc comment for the bug that
+    /// made it so.
     private var columnVisibility: Binding<NavigationSplitViewVisibility> {
         Binding(
             get: { layoutMode.showsList ? .all : .detailOnly },
             set: { newValue in
-                // Idempotent when the mode is already editor-only, which is what the echo of
-                // our own `.detailOnly` looks like.
-                guard newValue == .detailOnly else { return }
-                layoutModeRaw = EditorLayoutMode.editorOnly.rawValue
+                let listIsVisible = newValue != .detailOnly
+                guard let next = EditorLayoutMode.modeAfterVisibilityReport(listIsVisible: listIsVisible)
+                else { return }
+                layoutModeRaw = next.rawValue
             }
         )
     }
@@ -134,6 +129,9 @@ struct MainWindowView: View {
         .onReceive(NotificationCenter.default.publisher(for: .chatFocusInput)) { _ in
             sidebarSelection = .agentChat
             isEditing = false
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .openQuickOpenPalette)) { _ in
+            toggleQuickOpen()
         }
         // When sidebar selection changes, handle navigation
         .onChange(of: sidebarSelection) { _, newValue in
@@ -255,22 +253,16 @@ struct MainWindowView: View {
                 .transition(.opacity)
             }
         }
-        // Quick Open (Cmd+P / Cmd+O)
-        .overlay {
-            if showQuickOpen {
-                ZStack {
-                    Color.black.opacity(0.2)
-                        .ignoresSafeArea()
-                        .onTapGesture { showQuickOpen = false }
-
-                    VStack {
-                        QuickOpenPaletteView(isPresented: $showQuickOpen)
-                            .padding(.top, 80)
-                        Spacer()
-                    }
-                }
-                .transition(.opacity)
-            }
+        // Quick Open (⌘P / ⌘O).
+        //
+        // A sheet rather than an `.overlay` like the command palette above, because an overlay
+        // on this `NavigationSplitView` does not draw: clicking the menu item posted the
+        // notification and flipped the state, and nothing appeared. The same is true of the
+        // ⌘K palette, which is why it does not open either — a separate problem, left alone
+        // here. The issue for this work named a sheet as an acceptable shape, and a sheet is
+        // also the modality quick-open wants: it takes focus, and Esc dismisses it.
+        .sheet(isPresented: $showQuickOpen) {
+            QuickOpenPaletteView(isPresented: $showQuickOpen)
         }
         .onKeyPress(keys: [KeyEquivalent("k")], phases: .down) { keyPress in
             guard keyPress.modifiers.contains(.command) else { return .ignored }
@@ -286,12 +278,13 @@ struct MainWindowView: View {
             EditorZoom.mutatePersisted { $0.zoomIn() }
             return .handled
         }
-        .onKeyPress(keys: [KeyEquivalent("p"), KeyEquivalent("o")], phases: .down) { keyPress in
-            // Plain ⌘P / ⌘O only. Without the shift check, ⇧⌘P would open quick-open too,
-            // and the two palettes must not both be up at once.
+        // ⌘O, the secondary binding. ⌘P arrives as a notification from the File menu instead,
+        // so it fires even when the editor's text view holds focus — a main-menu key equivalent
+        // is handled before the key event reaches any view.
+        .onKeyPress(keys: [KeyEquivalent("o")], phases: .down) { keyPress in
+            // Plain ⌘O only: without the check, ⇧⌘O would open quick-open too.
             guard keyPress.modifiers == .command else { return .ignored }
-            showCommandPalette = false
-            showQuickOpen.toggle()
+            toggleQuickOpen()
             return .handled
         }
         .onKeyPress(keys: [KeyEquivalent("f")], phases: .down) { keyPress in
@@ -303,6 +296,13 @@ struct MainWindowView: View {
             focusState.toggle()
             return .handled
         }
+    }
+
+    /// Shows or dismisses quick-open, closing the command palette first so the two are never
+    /// stacked on top of each other.
+    private func toggleQuickOpen() {
+        showCommandPalette = false
+        showQuickOpen.toggle()
     }
 
     // MARK: - Content Area

--- a/Logue/Views/MainWindowView.swift
+++ b/Logue/Views/MainWindowView.swift
@@ -273,6 +273,11 @@ struct MainWindowView: View {
         // needs Shift is a chord the menu never matches — so the unshifted key in the same
         // physical position is handled here instead. It cannot be a second menu item: see
         // the comment on the zoom group in `LogueApp`.
+        //
+        // The exact `==` is load-bearing, not a stylistic difference from the `.contains` used
+        // for ⌘K below. On a US layout ⌘⇧= *is* ⌘+, which the View menu already binds; with
+        // `.contains(.command)` that one chord would fire the menu item and this handler both,
+        // and zoom would jump two steps.
         .onKeyPress(keys: [KeyEquivalent("=")], phases: .down) { keyPress in
             guard keyPress.modifiers == .command else { return .ignored }
             EditorZoom.mutatePersisted { $0.zoomIn() }

--- a/Logue/Views/MainWindowView.swift
+++ b/Logue/Views/MainWindowView.swift
@@ -64,12 +64,49 @@ struct MainWindowView: View {
     @State private var lastSeenStoreVersion: Int = 0
 
     @State private var showCommandPalette = false
+    @State private var showQuickOpen = false
+
+    /// Which panes are shown, driven by ⌘1 / ⌘2 / ⌘3 and persisted across launches.
+    ///
+    /// Stored as the raw string so `@AppStorage` can hold it directly; `layoutMode` below is
+    /// the typed view of it, and every layout decision reads `showsList` / `showsInspector`
+    /// from `EditorLayoutMode` rather than re-deriving what each mode means.
+    @AppStorage(AppConstants.UserDefaultsKeys.editorLayoutMode) private var layoutModeRaw =
+        EditorLayoutMode.allPanels.rawValue
+
+    private var layoutMode: EditorLayoutMode {
+        EditorLayoutMode(rawValue: layoutModeRaw) ?? .allPanels
+    }
+
     // Extension-visible: +Navigation
     /// Remembers the sidebar context when entering editing mode (since sidebarSelection is nilled out).
     @State var editingSourceSelection: SidebarItem?
 
+    /// Bridge between `EditorLayoutMode` and the split view's own column visibility.
+    ///
+    /// The write-back only ever records a *collapse*, and never tries to work out which mode a
+    /// re-appearing sidebar should mean. That is deliberate, and it was a bug first: SwiftUI
+    /// echoes the new visibility straight back through this binding after the menu sets a mode,
+    /// and the echo arrives with `layoutMode` still reading the value it had a moment ago —
+    /// `@AppStorage` caches, so the setter cannot see its own write. Reconstructing the mode
+    /// from that stale read turned every ⌘3 pressed from editor-only into editor-and-list,
+    /// because the old mode showed no inspector. Only the collapse direction is safe to infer,
+    /// and it is the only one that has to be: every path that shows the list again names the
+    /// mode it wants.
+    private var columnVisibility: Binding<NavigationSplitViewVisibility> {
+        Binding(
+            get: { layoutMode.showsList ? .all : .detailOnly },
+            set: { newValue in
+                // Idempotent when the mode is already editor-only, which is what the echo of
+                // our own `.detailOnly` looks like.
+                guard newValue == .detailOnly else { return }
+                layoutModeRaw = EditorLayoutMode.editorOnly.rawValue
+            }
+        )
+    }
+
     var body: some View {
-        NavigationSplitView {
+        NavigationSplitView(columnVisibility: columnVisibility) {
             CategorySidebarView(selection: $sidebarSelection)
                 .navigationSplitViewColumnWidth(min: 200, ideal: 240, max: 300)
         } detail: {
@@ -218,9 +255,43 @@ struct MainWindowView: View {
                 .transition(.opacity)
             }
         }
+        // Quick Open (Cmd+P / Cmd+O)
+        .overlay {
+            if showQuickOpen {
+                ZStack {
+                    Color.black.opacity(0.2)
+                        .ignoresSafeArea()
+                        .onTapGesture { showQuickOpen = false }
+
+                    VStack {
+                        QuickOpenPaletteView(isPresented: $showQuickOpen)
+                            .padding(.top, 80)
+                        Spacer()
+                    }
+                }
+                .transition(.opacity)
+            }
+        }
         .onKeyPress(keys: [KeyEquivalent("k")], phases: .down) { keyPress in
             guard keyPress.modifiers.contains(.command) else { return .ignored }
             showCommandPalette.toggle()
+            return .handled
+        }
+        // ⌘= is the alias for Zoom In. The View menu binds ⌘+, which on any layout where `+`
+        // needs Shift is a chord the menu never matches — so the unshifted key in the same
+        // physical position is handled here instead. It cannot be a second menu item: see
+        // the comment on the zoom group in `LogueApp`.
+        .onKeyPress(keys: [KeyEquivalent("=")], phases: .down) { keyPress in
+            guard keyPress.modifiers == .command else { return .ignored }
+            EditorZoom.mutatePersisted { $0.zoomIn() }
+            return .handled
+        }
+        .onKeyPress(keys: [KeyEquivalent("p"), KeyEquivalent("o")], phases: .down) { keyPress in
+            // Plain ⌘P / ⌘O only. Without the shift check, ⇧⌘P would open quick-open too,
+            // and the two palettes must not both be up at once.
+            guard keyPress.modifiers == .command else { return .ignored }
+            showCommandPalette = false
+            showQuickOpen.toggle()
             return .handled
         }
         .onKeyPress(keys: [KeyEquivalent("f")], phases: .down) { keyPress in

--- a/Logue/Views/Settings/Tabs/GeneralSettingsTab.swift
+++ b/Logue/Views/Settings/Tabs/GeneralSettingsTab.swift
@@ -29,6 +29,8 @@ struct GeneralSettingsTab: View {
     @State private var launchAtLogin = SMAppService.mainApp.status == .enabled
     @AppStorage("appearanceMode") private var appearanceMode: AppearanceMode = .system
     @AppStorage("editorFontSize") private var editorFontSize: Double = 15
+    @AppStorage(AppConstants.UserDefaultsKeys.defaultDocumentWidthMode) private var defaultDocumentWidthRaw =
+        DocumentWidthMode.normal.rawValue
     @AppStorage(AppConstants.UserDefaultsKeys.autoSortCheckedItems) private var autoSortCheckedItems = false
     @AppStorage(AppConstants.UserDefaultsKeys.groupByDate) private var groupByDate = true
     @AppStorage(AppConstants.UserDefaultsKeys.hasClearedSeedData) private var hasClearedSeedData = false
@@ -110,6 +112,18 @@ struct GeneralSettingsTab: View {
                 } maximumValueLabel: {
                     Text("24").font(.caption)
                 }
+
+                Picker("Default Document Width", selection: Binding(
+                    get: { DocumentWidthMode(rawValue: defaultDocumentWidthRaw) ?? .normal },
+                    set: { defaultDocumentWidthRaw = $0.rawValue }
+                )) {
+                    ForEach(DocumentWidthMode.allCases, id: \.self) { mode in
+                        Text(mode.label).tag(mode)
+                    }
+                }
+                Text("Applies to documents you create from now on. Existing documents keep their own width.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
 
                 Toggle(isOn: $autoSortCheckedItems) {
                     VStack(alignment: .leading, spacing: 2) {

--- a/LogueTests/CalloutBlockTests.swift
+++ b/LogueTests/CalloutBlockTests.swift
@@ -6,6 +6,11 @@ import Testing
 /// document in plain-storage mode — a lossy serialize rewrites the user's file on the next
 /// save. The unrecognised-type cases matter for the same reason: anything we cannot name has
 /// to survive as the block quote it already was.
+///
+/// "Exactly" holds for a recognised callout on its own. Two shapes do not come back
+/// byte-for-byte — an unquoted line straight after a callout, and an unrecognised type's line
+/// breaks — and both are pinned in `CalloutRoundTripEdgeTests` rather than left implied by the
+/// absence of a test here.
 @Suite("CalloutBlocks")
 struct CalloutBlockTests {
     // MARK: - Parse

--- a/LogueTests/CalloutBlockTests.swift
+++ b/LogueTests/CalloutBlockTests.swift
@@ -1,0 +1,280 @@
+import Foundation
+@testable import Logue
+import Testing
+
+/// Callouts must round-trip through markdown exactly, because the markdown file is the
+/// document in plain-storage mode — a lossy serialize rewrites the user's file on the next
+/// save. The unrecognised-type cases matter for the same reason: anything we cannot name has
+/// to survive as the block quote it already was.
+@Suite("CalloutBlocks")
+struct CalloutBlockTests {
+    // MARK: - Parse
+
+    @Test("Each recognised alert type parses into a callout of that kind", arguments: CalloutKind.allCases)
+    func everyKindParses(kind: CalloutKind) {
+        let blocks = BlockSerializer.parse(markdown: "> [!\(kind.rawValue)]\n> Body text.")
+
+        #expect(blocks.count == 1)
+        guard case let .callout(_, parsedKind, title, body) = blocks[0] else {
+            Issue.record("Expected a callout, got \(blocks[0])")
+            return
+        }
+        #expect(parsedKind == kind)
+        #expect(title.isEmpty)
+        #expect(body == "Body text.")
+    }
+
+    @Test("A title after the type is captured")
+    func titleIsCaptured() {
+        let blocks = BlockSerializer.parse(markdown: "> [!NOTE] Local-first\n> Stays readable outside the app.")
+
+        guard case let .callout(_, kind, title, body) = blocks[0] else {
+            Issue.record("Expected a callout, got \(blocks[0])")
+            return
+        }
+        #expect(kind == .note)
+        #expect(title == "Local-first")
+        #expect(body == "Stays readable outside the app.")
+    }
+
+    @Test("A lower-case marker still parses")
+    func lowerCaseMarker() {
+        guard case let .callout(_, kind, _, _) = BlockSerializer.parse(markdown: "> [!tip]\n> Try this.")[0] else {
+            Issue.record("Expected a callout for a lower-case marker")
+            return
+        }
+        #expect(kind == .tip)
+    }
+
+    @Test("A multi-line body keeps its line breaks")
+    func multiLineBody() {
+        let blocks = BlockSerializer.parse(markdown: "> [!WARNING]\n> First line.\n> Second line.")
+
+        guard case let .callout(_, _, _, body) = blocks[0] else {
+            Issue.record("Expected a callout, got \(blocks[0])")
+            return
+        }
+        #expect(body == "First line.\nSecond line.")
+    }
+
+    @Test("A callout with no body is just its header")
+    func headerOnlyCallout() {
+        let blocks = BlockSerializer.parse(markdown: "> [!CAUTION] Careful")
+
+        guard case let .callout(_, kind, title, body) = blocks[0] else {
+            Issue.record("Expected a callout, got \(blocks[0])")
+            return
+        }
+        #expect(kind == .caution)
+        #expect(title == "Careful")
+        #expect(body.isEmpty)
+    }
+
+    // MARK: - Degrading gracefully
+
+    @Test("An unrecognised type stays a block quote")
+    func unknownTypeIsABlockQuote() {
+        let blocks = BlockSerializer.parse(markdown: "> [!BANANA]\n> Still a quote.")
+
+        #expect(blocks.count == 1)
+        guard case let .blockQuote(_, text) = blocks[0] else {
+            Issue.record("Expected a block quote, got \(blocks[0])")
+            return
+        }
+        // The marker text is not dropped — it is part of the quote, as GitHub renders it.
+        #expect(text.contains("[!BANANA]"))
+        #expect(text.contains("Still a quote."))
+    }
+
+    @Test("A plain quote with no marker is unchanged")
+    func plainQuoteUnchanged() {
+        let blocks = BlockSerializer.parse(markdown: "> Just a quote.")
+
+        guard case let .blockQuote(_, text) = blocks[0] else {
+            Issue.record("Expected a block quote, got \(blocks[0])")
+            return
+        }
+        #expect(text == "Just a quote.")
+    }
+
+    @Test("A plain quote still round-trips")
+    func plainQuoteRoundTrips() {
+        let markdown = "> Just a quote."
+        #expect(BlockSerializer.serialize(blocks: BlockSerializer.parse(markdown: markdown)) == markdown)
+    }
+
+    @Test("A bracketed marker that is not a callout does not swallow the rest of the document")
+    func unknownMarkerLeavesFollowingBlocks() {
+        let blocks = BlockSerializer.parse(markdown: "> [!BANANA]\n> Quote.\n\n# Heading")
+
+        #expect(blocks.count == 2)
+        guard case .blockQuote = blocks[0] else {
+            Issue.record("Expected the quote first, got \(blocks[0])")
+            return
+        }
+        guard case let .heading(_, level, text) = blocks[1] else {
+            Issue.record("Expected a heading second, got \(blocks[1])")
+            return
+        }
+        #expect(level == 1)
+        #expect(text == "Heading")
+    }
+
+    // MARK: - Round-trip
+
+    @Test("A callout with a title round-trips exactly")
+    func titledRoundTrip() {
+        let markdown = "> [!NOTE] Local-first\n> This note stays readable outside the app."
+        #expect(BlockSerializer.serialize(blocks: BlockSerializer.parse(markdown: markdown)) == markdown)
+    }
+
+    @Test("A callout without a title round-trips exactly")
+    func untitledRoundTrip() {
+        let markdown = "> [!WARNING]\n> Careful here."
+        #expect(BlockSerializer.serialize(blocks: BlockSerializer.parse(markdown: markdown)) == markdown)
+    }
+
+    @Test("Every kind round-trips exactly", arguments: CalloutKind.allCases)
+    func everyKindRoundTrips(kind: CalloutKind) {
+        let markdown = "> [!\(kind.rawValue)] A title\n> Line one.\n> Line two."
+        #expect(BlockSerializer.serialize(blocks: BlockSerializer.parse(markdown: markdown)) == markdown)
+    }
+
+    @Test("A blank line inside the body round-trips as a bare marker")
+    func blankBodyLineRoundTrips() {
+        let markdown = "> [!TIP]\n> First.\n>\n> Second."
+        #expect(BlockSerializer.serialize(blocks: BlockSerializer.parse(markdown: markdown)) == markdown)
+    }
+
+    @Test("A header-only callout round-trips without gaining an empty quote line")
+    func headerOnlyRoundTrips() {
+        #expect(BlockSerializer.serialize(blocks: BlockSerializer.parse(markdown: "> [!NOTE]")) == "> [!NOTE]")
+    }
+
+    @Test("A callout between other blocks keeps its place")
+    func calloutAmongOtherBlocks() {
+        let markdown = "# Title\n\n> [!IMPORTANT] Read this\n> Body.\n\nA paragraph."
+        let blocks = BlockSerializer.parse(markdown: markdown)
+
+        #expect(blocks.count == 3)
+        guard case .heading = blocks[0] else {
+            Issue.record("Expected a heading first, got \(blocks[0])")
+            return
+        }
+        guard case .callout = blocks[1] else {
+            Issue.record("Expected a callout second, got \(blocks[1])")
+            return
+        }
+        guard case .paragraph = blocks[2] else {
+            Issue.record("Expected a paragraph third, got \(blocks[2])")
+            return
+        }
+        #expect(BlockSerializer.serialize(blocks: blocks) == markdown)
+    }
+
+    @Test("Two adjacent callouts stay two blocks")
+    func adjacentCallouts() {
+        let markdown = "> [!NOTE]\n> One.\n\n> [!TIP]\n> Two."
+        let blocks = BlockSerializer.parse(markdown: markdown)
+
+        #expect(blocks.count == 2)
+        #expect(BlockSerializer.serialize(blocks: blocks) == markdown)
+    }
+
+    @Test("Lower-case markers normalise to the spelling GitHub renders")
+    func lowerCaseNormalises() {
+        let output = BlockSerializer.serialize(blocks: BlockSerializer.parse(markdown: "> [!note]\n> Body."))
+        #expect(output == "> [!NOTE]\n> Body.")
+    }
+
+    // MARK: - Block behaviour
+
+    @Test("A callout is a text block so its body is editable")
+    func calloutIsATextBlock() {
+        #expect(Block.callout(id: UUID(), kind: .note, title: "", body: "x").isTextBlock)
+    }
+
+    @Test("textContent reads and writes the body, leaving kind and title alone")
+    func textContentMapsToBody() {
+        var block = Block.callout(id: UUID(), kind: .warning, title: "Heads up", body: "Old")
+        #expect(block.textContent == "Old")
+
+        block.textContent = "New"
+        guard case let .callout(_, kind, title, body) = block else {
+            Issue.record("Expected a callout, got \(block)")
+            return
+        }
+        #expect(kind == .warning)
+        #expect(title == "Heads up")
+        #expect(body == "New")
+    }
+
+    @Test("A callout is empty only when both title and body are blank")
+    func emptiness() {
+        #expect(Block.callout(id: UUID(), kind: .note, title: "", body: "   ").isEmpty)
+        #expect(Block.callout(id: UUID(), kind: .note, title: "Titled", body: "").isEmpty == false)
+        #expect(Block.callout(id: UUID(), kind: .note, title: "", body: "Body").isEmpty == false)
+    }
+
+    @Test("Title and body are both searchable")
+    func searchableTexts() {
+        let block = Block.callout(id: UUID(), kind: .tip, title: "Heading", body: "Body")
+        #expect(block.searchableTexts == ["Heading", "Body"])
+        #expect(Block.callout(id: UUID(), kind: .tip, title: "", body: "Body").searchableTexts == ["Body"])
+    }
+
+    @Test("Callouts differing only in kind or title are not equal")
+    func equality() {
+        let id = UUID()
+        let note = Block.callout(id: id, kind: .note, title: "T", body: "B")
+        #expect(note == Block.callout(id: id, kind: .note, title: "T", body: "B"))
+        #expect(note != Block.callout(id: id, kind: .tip, title: "T", body: "B"))
+        #expect(note != Block.callout(id: id, kind: .note, title: "Other", body: "B"))
+        #expect(note != Block.callout(id: id, kind: .note, title: "T", body: "Other"))
+    }
+
+    @Test("The factory makes an untitled note")
+    func factory() {
+        guard case let .callout(_, kind, title, body) = Block.emptyCallout() else {
+            Issue.record("Expected a callout from the factory")
+            return
+        }
+        #expect(kind == .note)
+        #expect(title.isEmpty)
+        #expect(body.isEmpty)
+    }
+
+    // MARK: - Kind metadata
+
+    @Test("Unrecognised markers are not a kind")
+    func unknownMarkerIsNotAKind() {
+        #expect(CalloutKind(marker: "BANANA") == nil)
+        #expect(CalloutKind(marker: "") == nil)
+    }
+
+    @Test("Every kind has a marker, a default title and a symbol")
+    func kindMetadata() {
+        for kind in CalloutKind.allCases {
+            #expect(!kind.rawValue.isEmpty)
+            #expect(!kind.defaultTitle.isEmpty)
+            #expect(!kind.symbolName.isEmpty)
+            #expect(CalloutKind(marker: kind.rawValue) == kind)
+        }
+    }
+
+    // MARK: - Slash menu
+
+    @Test("Callout is offered in the slash menu under Advanced")
+    func slashMenuEntry() {
+        #expect(BlockType.allCases.contains(.callout))
+        #expect(BlockType.callout.category == .advanced)
+        guard case let .callout(_, kind, title, body) = BlockType.callout.makeBlock(id: UUID(), text: "Carried") else {
+            Issue.record("Expected the callout block type to make a callout")
+            return
+        }
+        #expect(kind == .note)
+        #expect(title.isEmpty)
+        // Existing text becomes the body rather than the title.
+        #expect(body == "Carried")
+    }
+}

--- a/LogueTests/CalloutRoundTripEdgeTests.swift
+++ b/LogueTests/CalloutRoundTripEdgeTests.swift
@@ -1,0 +1,107 @@
+import Foundation
+@testable import Logue
+import Testing
+
+/// The two shapes where callout markdown does **not** come back byte-for-byte, pinned so the
+/// behaviour is a decision rather than a surprise.
+///
+/// This matters more than it looks: in markdown storage mode the file *is* the document, so any
+/// difference between what was read and what is written is the app rewriting the user's file the
+/// first time they open it. `CalloutBlockTests` covers everything that is exact; these are the
+/// exceptions, and each is checked against the plain-block-quote behaviour it inherits so a
+/// future reader can see which half is ours.
+@Suite("CalloutRoundTripEdges")
+struct CalloutRoundTripEdgeTests {
+    private func roundTrip(_ markdown: String) -> String {
+        BlockSerializer.serialize(blocks: BlockSerializer.parse(markdown: markdown))
+    }
+
+    // MARK: - Lazy continuation
+
+    /// CommonMark lazy continuation: the unquoted line belongs to the quote, and ending the
+    /// callout at the last `>` separates it rather than absorbing it.
+    @Test("An unquoted line after a callout is separated by a blank line")
+    func unquotedLineAfterCalloutGainsABlankLine() {
+        #expect(roundTrip("> [!NOTE]\n> Body\nRegular paragraph")
+            == "> [!NOTE]\n> Body\n\nRegular paragraph")
+    }
+
+    /// The separation is the point: both blocks survive. What this replaced was cmark folding
+    /// the callout and the paragraph into one quote, which lost the paragraph as a block.
+    @Test("Separating it keeps both blocks, which is why it is preferred to folding")
+    func lazyContinuationKeepsBothBlocks() {
+        let blocks = BlockSerializer.parse(markdown: "> [!NOTE]\n> Body\nRegular paragraph")
+
+        #expect(blocks.count == 2)
+        guard case let .callout(_, kind, _, body) = blocks[0] else {
+            Issue.record("Expected a callout first, got \(blocks[0])")
+            return
+        }
+        #expect(kind == .note)
+        #expect(body == "Body")
+        guard case let .paragraph(_, text) = blocks[1] else {
+            Issue.record("Expected a paragraph second, got \(blocks[1])")
+            return
+        }
+        #expect(text == "Regular paragraph")
+    }
+
+    /// Written with the blank line already there, it is exact — so the rewrite happens once and
+    /// is stable, rather than growing a line on every save.
+    @Test("The separated form is stable on a second pass")
+    func lazyContinuationIsIdempotent() {
+        let once = roundTrip("> [!NOTE]\n> Body\nRegular paragraph")
+        #expect(roundTrip(once) == once)
+    }
+
+    // MARK: - Unrecognised types
+
+    /// Inherited from block quotes rather than introduced here — see the baseline below.
+    @Test("An unrecognised type folds its line breaks")
+    func unrecognisedTypeFoldsLineBreaks() {
+        #expect(roundTrip("> [!BANANA]\n> Body") == "> [!BANANA] Body")
+    }
+
+    /// The baseline that proves the fold above is not ours: a plain multi-line quote does the
+    /// same thing, and did before callouts existed.
+    @Test("A plain multi-line quote folds the same way")
+    func plainQuoteFoldsTheSameWay() {
+        #expect(roundTrip("> One\n> Two") == "> One Two")
+        #expect(roundTrip("> Quoted\nRegular paragraph") == "> Quoted Regular paragraph")
+    }
+
+    /// The marker survives the fold, so nothing the user typed is dropped — it just stops being
+    /// a separate line.
+    @Test("An unrecognised marker is preserved, not discarded")
+    func unrecognisedMarkerSurvives() {
+        let output = roundTrip("> [!BANANA]\n> Body")
+        #expect(output.contains("[!BANANA]"))
+        #expect(output.contains("Body"))
+    }
+
+    // MARK: - Shapes that are exact, kept here as the boundary
+
+    /// With the blank line present the callout and the paragraph are both exact — this is the
+    /// shape the editor itself writes, so normal editing never hits the rewrite above.
+    @Test("A blank line between a callout and a paragraph round-trips exactly")
+    func blankLineSeparatedIsExact() {
+        let markdown = "> [!NOTE]\n> Body\n\nRegular paragraph"
+        #expect(roundTrip(markdown) == markdown)
+    }
+
+    /// Verified in review: a nested quote inside a callout body survives intact, because body
+    /// lines are taken verbatim after one `>` and a single space.
+    @Test("A nested quote inside a callout round-trips exactly")
+    func nestedQuoteIsExact() {
+        let markdown = "> [!NOTE]\n> > inner\n> after"
+        #expect(roundTrip(markdown) == markdown)
+    }
+
+    /// Also verified in review: indentation inside the body is the author's, and only the one
+    /// separator space after `>` is removed.
+    @Test("An indented body line keeps its indentation")
+    func indentedBodyIsExact() {
+        let markdown = "> [!TIP]\n>     indented code-ish\n> plain"
+        #expect(roundTrip(markdown) == markdown)
+    }
+}

--- a/LogueTests/DocumentIconTests.swift
+++ b/LogueTests/DocumentIconTests.swift
@@ -94,4 +94,21 @@ struct EditorLayoutModeTests {
     func stableRawValues() {
         #expect(EditorLayoutMode(rawValue: "allPanels") == .allPanels)
     }
+
+    /// The View menu builds its ⌘1 / ⌘2 / ⌘3 items from `1 ... allCases.count` and resolves
+    /// each through `init(shortcutNumber:)`, so a case added without a number would silently
+    /// go unbound rather than fail to compile.
+    @Test("Every layout is reachable from a shortcut number")
+    func everyLayoutHasAShortcut() {
+        let reachable = (1 ... EditorLayoutMode.allCases.count)
+            .compactMap { EditorLayoutMode(shortcutNumber: $0) }
+        #expect(Set(reachable) == Set(EditorLayoutMode.allCases))
+    }
+
+    /// A value written by a future version, or a corrupted one, must not leave the window in
+    /// a state no shortcut can describe — callers fall back to `allPanels`.
+    @Test("An unrecognised stored value is not a layout")
+    func unknownRawValue() {
+        #expect(EditorLayoutMode(rawValue: "splitScreenTriptych") == nil)
+    }
 }

--- a/LogueTests/DocumentIconTests.swift
+++ b/LogueTests/DocumentIconTests.swift
@@ -111,4 +111,39 @@ struct EditorLayoutModeTests {
     func unknownRawValue() {
         #expect(EditorLayoutMode(rawValue: "splitScreenTriptych") == nil)
     }
+
+    /// The regression this rule exists for. SwiftUI echoes the split view's visibility back
+    /// through the binding right after a menu item sets a mode, and the echo arrives while the
+    /// binding still reads the previous mode. If a "list is visible" report were allowed to
+    /// name a mode, that stale read is what it would name it from — which is how every ⌘3
+    /// pressed from editor-only used to land on editor-and-list.
+    @Test("A report that the list is visible never changes the mode")
+    func visibleListReportIsIgnored() {
+        #expect(EditorLayoutMode.modeAfterVisibilityReport(listIsVisible: true) == nil)
+    }
+
+    /// Specifically: from every mode, including the one whose stale `showsInspector` caused the
+    /// bug, a visible-list report must leave the stored mode alone.
+    @Test("No mode is rewritten by a visible-list report", arguments: EditorLayoutMode.allCases)
+    func visibleListReportPreservesEveryMode(mode: EditorLayoutMode) {
+        let reported = EditorLayoutMode.modeAfterVisibilityReport(listIsVisible: true)
+        #expect(reported == nil, "\(mode) would have been overwritten by a visible-list report")
+    }
+
+    /// The one direction that *is* inferred: the user dragging the sidebar shut is recorded, so
+    /// a collapsed sidebar does not come back on the next launch.
+    @Test("A collapse is recorded as editor-only")
+    func collapseReportIsRecorded() {
+        #expect(EditorLayoutMode.modeAfterVisibilityReport(listIsVisible: false) == .editorOnly)
+    }
+
+    /// Recording a collapse has to be idempotent, because the split view echoes our own
+    /// `.detailOnly` straight back at us.
+    @Test("Recording a collapse twice is stable")
+    func collapseIsIdempotent() {
+        let first = EditorLayoutMode.modeAfterVisibilityReport(listIsVisible: false)
+        #expect(first == .editorOnly)
+        #expect(first?.showsList == false)
+        #expect(EditorLayoutMode.modeAfterVisibilityReport(listIsVisible: first?.showsList ?? true) == .editorOnly)
+    }
 }

--- a/LogueTests/DocumentIconTests.swift
+++ b/LogueTests/DocumentIconTests.swift
@@ -137,6 +137,18 @@ struct EditorLayoutModeTests {
         #expect(EditorLayoutMode.modeAfterVisibilityReport(listIsVisible: false) == .editorOnly)
     }
 
+    /// Collapsing from `allPanels` lands on `editorOnly`, hiding the inspector as well as the
+    /// list. That is the only mode "no list" can mean — the three are a progression with no
+    /// editor-plus-inspector rung — so it is asserted rather than left as an accident of the
+    /// implementation.
+    @Test("Collapsing from all-panels also gives up the inspector")
+    func collapseFromAllPanelsDropsTheInspector() {
+        #expect(EditorLayoutMode.allPanels.showsInspector)
+        let afterCollapse = EditorLayoutMode.modeAfterVisibilityReport(listIsVisible: false)
+        #expect(afterCollapse == .editorOnly)
+        #expect(afterCollapse?.showsInspector == false)
+    }
+
     /// Recording a collapse has to be idempotent, because the split view echoes our own
     /// `.detailOnly` straight back at us.
     @Test("Recording a collapse twice is stable")

--- a/LogueTests/QuickOpenCandidateTests.swift
+++ b/LogueTests/QuickOpenCandidateTests.swift
@@ -1,0 +1,155 @@
+import Foundation
+@testable import Logue
+import Testing
+
+/// What quick-open offers, as opposed to how it ranks it — `QuickOpenTests` covers the matcher.
+///
+/// These are the rules the palette itself used to hold inline, where nothing could reach them:
+/// trashed items stay out, an untitled item is still findable, and the order handed to the
+/// matcher is recency.
+@Suite("QuickOpenCandidates")
+struct QuickOpenCandidateTests {
+    private func document(
+        _ title: String,
+        modified: TimeInterval,
+        trashed: Bool = false
+    ) -> WritingDocument {
+        var doc = WritingDocument()
+        doc.title = title
+        doc.modifiedAt = Date(timeIntervalSince1970: modified)
+        doc.isTrashed = trashed
+        return doc
+    }
+
+    private func meeting(
+        _ title: String,
+        modified: TimeInterval,
+        trashed: Bool = false
+    ) -> MeetingNote {
+        MeetingNote(
+            title: title,
+            modifiedAt: Date(timeIntervalSince1970: modified),
+            isTrashed: trashed
+        )
+    }
+
+    @Test("Documents and meetings both become candidates")
+    func bothKindsIncluded() {
+        let candidates = QuickOpenItem.candidates(
+            documents: [document("Roadmap", modified: 10)],
+            meetings: [meeting("Standup", modified: 20)]
+        )
+
+        #expect(candidates.count == 2)
+        #expect(candidates.contains { $0.title == "Roadmap" && $0.kind == .document })
+        #expect(candidates.contains { $0.title == "Standup" && $0.kind == .meeting })
+    }
+
+    @Test("Trashed documents are excluded")
+    func trashedDocumentsExcluded() {
+        let candidates = QuickOpenItem.candidates(
+            documents: [
+                document("Kept", modified: 10),
+                document("Deleted", modified: 20, trashed: true),
+            ],
+            meetings: []
+        )
+
+        #expect(candidates.map(\.title) == ["Kept"])
+    }
+
+    @Test("Trashed meetings are excluded")
+    func trashedMeetingsExcluded() {
+        let candidates = QuickOpenItem.candidates(
+            documents: [],
+            meetings: [
+                meeting("Kept", modified: 10),
+                meeting("Deleted", modified: 20, trashed: true),
+            ]
+        )
+
+        #expect(candidates.map(\.title) == ["Kept"])
+    }
+
+    /// Recency is not cosmetic: `QuickOpenMatcher` is stable within a rank, so this order is
+    /// what decides which of two equally good matches the user sees first.
+    @Test("Candidates are ordered most recently modified first, across both kinds")
+    func orderedByRecency() {
+        let candidates = QuickOpenItem.candidates(
+            documents: [
+                document("Oldest", modified: 10),
+                document("Newest", modified: 40),
+            ],
+            meetings: [
+                meeting("Middle", modified: 20),
+                meeting("Second newest", modified: 30),
+            ]
+        )
+
+        #expect(candidates.map(\.title) == ["Newest", "Second newest", "Middle", "Oldest"])
+    }
+
+    /// The interleaving matters — a naive "documents then meetings" concatenation would pass the
+    /// per-kind tests above and still put a stale document above a fresh meeting.
+    @Test("A recent meeting outranks an older document")
+    func kindsAreInterleavedByDate() {
+        let candidates = QuickOpenItem.candidates(
+            documents: [document("Old doc", modified: 10)],
+            meetings: [meeting("New meeting", modified: 99)]
+        )
+
+        #expect(candidates.first?.title == "New meeting")
+    }
+
+    @Test("An untitled document still has something to match against")
+    func untitledDocumentGetsDefaultTitle() {
+        let candidates = QuickOpenItem.candidates(documents: [document("", modified: 10)], meetings: [])
+        #expect(candidates.first?.title == AppConstants.defaultDocumentTitle)
+    }
+
+    @Test("An untitled meeting still has something to match against")
+    func untitledMeetingGetsDefaultTitle() {
+        let candidates = QuickOpenItem.candidates(documents: [], meetings: [meeting("", modified: 10)])
+        #expect(candidates.first?.title == AppConstants.defaultMeetingTitle)
+    }
+
+    @Test("An empty library produces no candidates")
+    func emptyLibrary() {
+        #expect(QuickOpenItem.candidates(documents: [], meetings: []).isEmpty)
+    }
+
+    @Test("A library of only trashed items produces no candidates")
+    func onlyTrashed() {
+        let candidates = QuickOpenItem.candidates(
+            documents: [document("Gone", modified: 10, trashed: true)],
+            meetings: [meeting("Also gone", modified: 20, trashed: true)]
+        )
+        #expect(candidates.isEmpty)
+    }
+
+    @Test("Candidate IDs are the underlying item IDs, so selection can open them")
+    func idsArePreserved() {
+        let doc = document("Roadmap", modified: 10)
+        let note = meeting("Standup", modified: 20)
+        let candidates = QuickOpenItem.candidates(documents: [doc], meetings: [note])
+
+        #expect(candidates.first(where: { $0.kind == .document })?.id == doc.id)
+        #expect(candidates.first(where: { $0.kind == .meeting })?.id == note.id)
+    }
+
+    /// The end-to-end shape the palette relies on: build, then rank, and the trashed item must
+    /// not come back at the matcher stage either.
+    @Test("Matching runs over the candidate list without reviving trashed items")
+    func matcherOverCandidates() {
+        let candidates = QuickOpenItem.candidates(
+            documents: [
+                document("Product Roadmap", modified: 30),
+                document("Product Retro", modified: 20, trashed: true),
+            ],
+            meetings: [meeting("Product Review", modified: 10)]
+        )
+        let results = QuickOpenMatcher.match(query: "prod", in: candidates)
+
+        #expect(results.map(\.title) == ["Product Roadmap", "Product Review"])
+    }
+}


### PR DESCRIPTION
Closes #9, #10, #11, #12, #13, #14, #15.

Seven issues. Five of them described a model or validator that was already in the tree and unit-tested, with nothing in the UI reaching it. One was a shortcut that never fired. One was a new block type with a worked example to follow.

## #9 — Zoom In on keyboards where `+` needs Shift

I measured this against the running app rather than reasoning about it. A key equivalent of `+` matches `⌘+` and nothing else; a key equivalent of `=` matches `⌘=` and nothing else. So both chords need separate bindings.

The alias is handled in `MainWindowView` rather than as a second menu item, because SwiftUI allows one shortcut per button and a second button makes the View menu list "Zoom In" twice.

**Verified on the running app:** `⌘=` and `⌘+` both zoom in, `⌘-` and `⌘0` unaffected, the View menu lists **one** Zoom In, and 25 presses of `⌘=` stop at `AppConstants.Editor.maxZoom` (3.0) — clamping still comes from `EditorZoom`.

`applyZoom` in `LogueApp` became `EditorZoom.mutatePersisted`, so the menu and the window share one clamped implementation instead of the menu owning a binding the window cannot reach.

## #10 — App-wide default document width

The control is in Settings → General. New documents adopt it in `draft(_:titled:spaceID:)`, the path both `createDocument` and the batch import share, so a 500-note import and a single ⌘N agree.

It is stamped only when the default is not `normal`, since `widthMode` already reads an absent value as `normal` — writing it regardless would add a redundant `width:` line to the frontmatter of every new file in markdown storage mode. Existing documents are untouched and the per-document ⋯ toggle still wins.

## #11 — Quick open (`⌘P` / `⌘O`)

**Answering the design question in the issue:** a separate surface, not a mode inside the existing palette. The command palette groups results by category and runs a debounced full-text search across bodies and transcripts; quick open is a single flat list ranked by title alone and filtered synchronously on every keystroke. Sharing one view meant threading a mode flag through the grouping, the debounce and the keyboard handling alike.

It is presented as a **sheet**, which the issue named as an acceptable shape. That was not a style preference in the end: an `.overlay` on this `NavigationSplitView` does not draw. Clicking the menu item posted the notification and flipped the state, and nothing appeared. **The same is true of the existing ⌘K command palette, which is built the same way and does not open either** — pre-existing, out of scope here, and left alone, but flagged in a code comment and worth its own issue. A sheet is also the modality quick open wants: it takes focus, and Esc dismisses it.

`⌘P` is a File menu item posting a notification rather than only an in-window key handler, so it fires while the editor's text view holds focus — a main-menu key equivalent is handled before the key event reaches any view. `⌘O` stays as the in-window binding.

All ranking is `QuickOpenMatcher`'s — there is no second matching implementation. `QuickOpenItem.candidates` takes plain arrays so that excluding trashed items, naming untitled ones and ordering by recency are tested rather than inlined in the view. Recency is not cosmetic: the matcher is stable within a rank, so the order handed to it is what breaks ties between equally good matches.

**Verified against the running app:** the menu item opens the sheet; results arrive recency-ordered with a Document/Meeting label per row and the first row selected; typing `hauz` filters 248 documents down to two, case-insensitively; Down moves the selection; Return opens the document in the editor; Esc dismisses without opening anything.

## #12 — Per-document icon picker

An emoji picker, since `DocumentIcon.sanitised` accepts exactly one grapheme — an SF Symbol name could never be a valid value, so `SpaceIconPicker` was not reusable. Every path out of the picker, grid and typed field alike, goes through `sanitised`; the reject-rather-than-truncate behaviour is unchanged.

`DocumentIconLabel` puts the icon **in place of** the document symbol in list rows and cards rather than beside it, so a document with no icon renders exactly as it does today — same glyph, same slot, no placeholder and nothing that shifts when one is set.

## #13 — Pane layout shortcuts

`⌘1` / `⌘2` / `⌘3` drive the split view's column visibility and the editor's tools sidebar, both reading `showsList` / `showsInspector` rather than re-deriving what each mode means. The menu builds its items from `1 ... allCases.count` and resolves each through `init(shortcutNumber:)`, so it cannot disagree with the model.

**A bug this turned up.** My first version made the column-visibility binding two-way, reconstructing the mode when the sidebar reappeared. Every `⌘3` pressed from editor-only landed on editor-and-list. SwiftUI echoes the new visibility back through the binding right after the menu sets a mode, and the echo arrives while the binding still reads the previous mode — `@AppStorage` caches, so a setter cannot see the write it is echoing, and the stale mode showed no inspector.

That rule now lives in `EditorLayoutMode.modeAfterVisibilityReport(listIsVisible:)`, where the reasoning for its asymmetry belongs and where tests can reach it: a visible-list report never names a mode (checked for every mode, including the one whose stale `showsInspector` caused the bug), a collapse is recorded as editor-only, and recording a collapse is idempotent because the split view echoes our own `.detailOnly` back at us.

**Verified on the running app:** all six transitions correct via the menu, and `⌘1` / `⌘2` / `⌘3` each land on the right mode. Focus Mode is untouched.

## #14 — Callout blocks

`> [!NOTE]` through `> [!CAUTION]` render with an icon, accent and heading, and the body stays editable through the same `editableTextView` a block quote uses.

Callouts are split out of the source before it reaches cmark, for the same reason `$$` fences already are: cmark reads a callout as a block quote and folds its line breaks into spaces, so a multi-line body could not be written back the way it arrived. `> [!BANANA]` is left in the markdown run and parsed as the block quote it already was; a plain `> quote` is unchanged.

**On round-tripping — narrowed after review.** A recognised callout on its own is byte-exact, including the optional title, a blank body line (`>`, not `"> "`), a header-only callout, a nested `> > inner`, and indented body lines. Two shapes are not, and review was right to push on the broader claim I made first:

- An unquoted line straight after a callout gains a blank line before it (`> [!NOTE]\n> Body\nRegular paragraph` → `> [!NOTE]\n> Body\n\nRegular paragraph`). CommonMark lazy continuation: that line belongs to the quote, and ending the callout at the last `>` separates it rather than absorbing it. The separation is what we want — cmark previously folded the paragraph into the quote and lost it as a block — but in markdown storage mode the file is the document, so this rewrites it on open. It is **idempotent**: the separated form round-trips exactly, so a file gains the blank line once, not once per save.
- An unrecognised type folds its line breaks (`> [!BANANA]\n> Body` → `> [!BANANA] Body`), because it degrades to a block quote and block quotes have always done that — `> One\n> Two` → `> One Two` on `main` too.

Both are pinned in `CalloutRoundTripEdgeTests`, alongside the plain-quote baseline that shows which half is inherited.

Reachable from the `/` menu, and from "Turn into", which also lets a callout go back to a plain quote. `CalloutKind` is closed on purpose: a type we cannot name is a type we cannot write back.

## #15 — Code block language picker

The menu is built from `CodeSyntaxHighlighter.supportedLanguages`, which lives next to the `rules(for:)` switch that consumes the same identifiers, so the offered list cannot drift from what highlighting actually exists. Aliases (`py`, `js`, `golang`) are deliberately absent — they highlight identically to their canonical spelling.

The existing free-text field stays alongside the menu, so a language that arrived in imported markdown, or one the highlighter does not know, can still be written into the fence by hand. The nice-to-have is in: the last language picked from the menu becomes the default for the next code block, and a remembered value that is no longer supported is discarded rather than written into a fence. Duplication already preserved the language; there is now a test saying so.

## Tests

813 tests across 71 suites pass (the LLM inference suites were skipped — they need a local model). SwiftFormat and SwiftLint `--strict` are both clean.

- `CalloutBlockTests` — new suite: every kind parses, titles are captured, multi-line bodies keep their breaks, exact round-trip per kind, blank body lines, header-only callouts, `[!BANANA]` degrading to a block quote without swallowing what follows, plus the block-level behaviour (`textContent`, `isEmpty`, `searchableTexts`, equality, the factory, the slash-menu entry).
- `QuickOpenCandidateTests` — new suite: both kinds included, trashed excluded on either side, recency ordering across kinds (including the interleaving a naive documents-then-meetings concatenation would get wrong), default titles for untitled items, IDs preserved so selection can open them, and matching run over the built list without reviving a trashed item.
- `EditorLayoutModeTests` — the issue pointed at `LogueTests/EditorLayoutModeTests.swift`; those six tests actually live in `DocumentIconTests.swift`. I added to them there rather than creating a second suite: every mode is reachable from a shortcut number (the View menu builds items from `allCases.count`, so a fourth case added without a number would silently go unbound), an unrecognised stored value is not a layout, and the four cases covering the write-back rule above.

## What is not verified

#9, #11 and #13 are verified end to end against the running app as described. The UI paths for #10, #12, #14 and #15 rest on unit tests and the build — their logic is covered, but I did not click through them.

One thing picked up separately: the ⌘K command palette does not open, for the same overlay reason quick open did not. It predates this branch and is now filed as #44, with the isolation steps and the reason it was deliberately not fixed here.