### PR TITLE
Stop rebuilding every block on every scrolled frame

### DIFF
--- a/Logue.xcodeproj/project.pbxproj
+++ b/Logue.xcodeproj/project.pbxproj
@@ -283,6 +283,7 @@
 		8305B9B5810624EA6AD19520 /* MarkdownStyler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D5F001CEA6CB89B25C75055 /* MarkdownStyler.swift */; };
 		83D4B061F474B55E93422576 /* DocumentRowCompact.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B122ABAFDC2934FB106C9C6 /* DocumentRowCompact.swift */; };
 		83F129EF9A0320C6AD1EF039 /* HandCursorArea.swift in Sources */ = {isa = PBXBuildFile; fileRef = 387EC57EC8BA655296463A43 /* HandCursorArea.swift */; };
+		855530A64C4C8BBBC9C995EE /* BlockFrameStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0946FCC63B694398DDCA143 /* BlockFrameStore.swift */; };
 		859BD1BDE5D6617990A2352C /* OfficeExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F686C58A65228625D6D45D32 /* OfficeExtractor.swift */; };
 		85BFFE25C6715ABAE40DFB2C /* RightIconToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 088E6D7B300F24ADC23373E8 /* RightIconToolbar.swift */; };
 		85C9F35793B4ACD6B226E085 /* BookmarkColorHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A930070B8B38F806BA54B436 /* BookmarkColorHelper.swift */; };
@@ -467,6 +468,7 @@
 		E4AB21C58F0BCE5EF7C8E037 /* LLMEngine+WritingAnalysis.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDA3B12D86E29B9012E0B96B /* LLMEngine+WritingAnalysis.swift */; };
 		E4B6FC3460A2639236E6E179 /* MeetingListContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88018F4CBB121A88EF363BBE /* MeetingListContentView.swift */; };
 		E536E26DFCF028B14B186996 /* SectionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1153D35EF20882A425B5D836 /* SectionHeader.swift */; };
+		E560D4C6313E3EBFDF0D32B3 /* BlockFrameStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3F2421D7F17F2EE5A04EF7F /* BlockFrameStoreTests.swift */; };
 		E5DF85C2C0803078D80C350C /* CommandCenterChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19129D8F0F9161BC3E21AA0F /* CommandCenterChatView.swift */; };
 		E607ACE5890354F65F74C864 /* LLMEngineStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3224E9FBD3E9D86A60DAA79C /* LLMEngineStatus.swift */; };
 		E63CD7720F92C807AEB1B7BE /* FactCheckCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B61F580088B1A2F4D33DE8 /* FactCheckCard.swift */; };
@@ -949,6 +951,7 @@
 		CF81895980E378C21F96AFD6 /* DocumentLLMTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentLLMTests.swift; sourceTree = "<group>"; };
 		CFB4EE100316EB840B5D93EE /* HoverToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverToolbar.swift; sourceTree = "<group>"; };
 		D02A1248D9EA3AC9CEDC508F /* SavedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedView.swift; sourceTree = "<group>"; };
+		D0946FCC63B694398DDCA143 /* BlockFrameStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockFrameStore.swift; sourceTree = "<group>"; };
 		D109C6B8E49B6D4DEC709DB5 /* WorkspaceTransferable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceTransferable.swift; sourceTree = "<group>"; };
 		D13D5598C230DA3644325779 /* FolderStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderStore.swift; sourceTree = "<group>"; };
 		D1A491C56C1501F3D06F7734 /* PulsingDot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PulsingDot.swift; sourceTree = "<group>"; };
@@ -997,6 +1000,7 @@
 		E2A54999991BFEA773747361 /* AgentReadAloudService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentReadAloudService.swift; sourceTree = "<group>"; };
 		E2CEF58FA0555995987FD7AE /* InputDialogTools.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputDialogTools.swift; sourceTree = "<group>"; };
 		E2F831E25CF9FDC86465A53D /* AgentChatGraph.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentChatGraph.swift; sourceTree = "<group>"; };
+		E3F2421D7F17F2EE5A04EF7F /* BlockFrameStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockFrameStoreTests.swift; sourceTree = "<group>"; };
 		E3FB4C4D5FE2C19460E3DFED /* VocabularyEnhancementPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VocabularyEnhancementPanelView.swift; sourceTree = "<group>"; };
 		E420BD97F84DEF6141ADEDA4 /* katex.min.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = katex.min.css; sourceTree = "<group>"; };
 		E5C05F2E155A2AA73ABC9F4D /* ContentLoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentLoadingView.swift; sourceTree = "<group>"; };
@@ -1114,6 +1118,7 @@
 			isa = PBXGroup;
 			children = (
 				79C6BA7C0C06C035AC3BFBD1 /* LLMIntegration */,
+				E3F2421D7F17F2EE5A04EF7F /* BlockFrameStoreTests.swift */,
 				8D204801C0C2BADD68D406D7 /* BlockMoveTests.swift */,
 				88C42C0A1E60F8FC22AC2EF3 /* BlockPasteTests.swift */,
 				7A450984B8338837BFDFF868 /* BlockTypeSlashMenuTests.swift */,
@@ -1288,6 +1293,7 @@
 			children = (
 				3C1F2914E4AE0CEBC75367EC /* Block.swift */,
 				493337C75A0D4F073E22C76F /* BlockEditorDocument.swift */,
+				D0946FCC63B694398DDCA143 /* BlockFrameStore.swift */,
 				BFE45DD206DEC983F8781BB2 /* BlockSerializer.swift */,
 				D7D771D4ECF4472264165F1C /* DocumentSearchState.swift */,
 				7CB8F29FAA5817D348722762 /* MultiBlockSelectionState.swift */,
@@ -2116,6 +2122,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E560D4C6313E3EBFDF0D32B3 /* BlockFrameStoreTests.swift in Sources */,
 				362E757F0940BDB7CB5E560A /* BlockMoveTests.swift in Sources */,
 				6E66E9B993B63623F605E552 /* BlockPasteTests.swift in Sources */,
 				F990F4EC5E8A9FEBA4C9FD3F /* BlockTypeSlashMenuTests.swift in Sources */,
@@ -2233,6 +2240,7 @@
 				BCE7CC5D10CC3B52CDF54B6E /* BlockEditorDocument.swift in Sources */,
 				136DA7C6E8212377AEF7906B /* BlockEditorView+Reorder.swift in Sources */,
 				A633B36972CE37D81CE875A9 /* BlockEditorView.swift in Sources */,
+				855530A64C4C8BBBC9C995EE /* BlockFrameStore.swift in Sources */,
 				A9B34E653A84128492DE6474 /* BlockRowView+Actions.swift in Sources */,
 				372D7C7E58F4EF0B8305E096 /* BlockRowView.swift in Sources */,
 				B0F79BB2896CD38F5076C649 /* BlockSerializer.swift in Sources */,

--- a/Logue/Views/Editor/BlockEditor/Model/BlockFrameStore.swift
+++ b/Logue/Views/Editor/BlockEditor/Model/BlockFrameStore.swift
@@ -29,13 +29,20 @@ final class BlockFrameStore: @unchecked Sendable {
     /// Hit-tests which block sits at the given point.
     ///
     /// Vertical-only: blocks span the full content width, so the x coordinate carries no
-    /// information. Ties are impossible in practice because block frames don't overlap
-    /// vertically, but a deterministic answer still beats an arbitrary one, so the topmost
-    /// match wins.
+    /// information.
+    ///
+    /// The bounds are inclusive at both ends, so any two frames that touch or overlap both
+    /// contain the point on their shared edge. The editor's current layout does not produce
+    /// that case — its `VStack` spacing leaves a measured 4pt gap between consecutive row
+    /// frames, and a point inside a gap matches nothing — but the store cannot assume a
+    /// caller's frames are disjoint, and dropping that spacing to zero would create a tie at
+    /// every boundary. Resolving to the topmost match keeps the answer stable either way;
+    /// picking whichever key dictionary iteration happened to yield first would not.
     func blockID(at point: CGPoint) -> BlockID? {
         lock.lock()
         defer { lock.unlock() }
-        return frames
+        // `lazy` so the filter doesn't build an intermediate dictionary on every hit test.
+        return frames.lazy
             .filter { point.y >= $0.value.minY && point.y <= $0.value.maxY }
             .min { $0.value.minY < $1.value.minY }?
             .key

--- a/Logue/Views/Editor/BlockEditor/Model/BlockFrameStore.swift
+++ b/Logue/Views/Editor/BlockEditor/Model/BlockFrameStore.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+// MARK: - BlockFrameStore
+
+/// Holds each block's on-screen frame so a cross-block drag can hit-test which block the
+/// pointer is over.
+///
+/// Deliberately a plain reference type rather than `@State` storage or `@Observable`.
+/// Every block reports its frame in the scroll coordinate space, so *all* of those frames
+/// change on every frame of a scroll. Keeping them in observed view state meant each scrolled
+/// frame invalidated the whole editor body, which rebuilt every block row and ran
+/// `updateNSView` on every block's text view — measured at ~48 body evaluations and ~2,200
+/// text-view updates per second on a 45-block document, which is what made scrolling stutter.
+/// Nothing renders from these frames, so writing them must not invalidate anything.
+///
+/// Thread-safety: every access goes through `lock`. The frames are written from SwiftUI's
+/// preference callback and read from an `NSEvent` monitor; both run on the main thread today,
+/// but the lock means that isn't load-bearing.
+final class BlockFrameStore: @unchecked Sendable {
+    private let lock = NSLock()
+    private var frames: [BlockID: CGRect] = [:]
+
+    func replaceAll(with newFrames: [BlockID: CGRect]) {
+        lock.lock()
+        defer { lock.unlock() }
+        frames = newFrames
+    }
+
+    /// Hit-tests which block sits at the given point.
+    ///
+    /// Vertical-only: blocks span the full content width, so the x coordinate carries no
+    /// information. Ties are impossible in practice because block frames don't overlap
+    /// vertically, but a deterministic answer still beats an arbitrary one, so the topmost
+    /// match wins.
+    func blockID(at point: CGPoint) -> BlockID? {
+        lock.lock()
+        defer { lock.unlock() }
+        return frames
+            .filter { point.y >= $0.value.minY && point.y <= $0.value.maxY }
+            .min { $0.value.minY < $1.value.minY }?
+            .key
+    }
+}

--- a/Logue/Views/Editor/BlockEditor/Views/BlockEditorView.swift
+++ b/Logue/Views/Editor/BlockEditor/Views/BlockEditorView.swift
@@ -59,7 +59,9 @@ struct BlockEditorView: View {
 
     // Extension-visible: +Reorder
     @State var multiBlockSelection = MultiBlockSelectionState()
-    @State private var blockFrames: [BlockID: CGRect] = [:]
+    /// Block frames for drag hit-testing. Held in a store rather than in view state because
+    /// they change on every frame of a scroll — see `BlockFrameStore`.
+    @State private var blockFrameStore = BlockFrameStore()
     @State private var dragMonitor: Any?
     @State private var mouseUpMonitor: Any?
     @State private var isDraggingAcrossBlocks = false
@@ -113,8 +115,8 @@ struct BlockEditorView: View {
                         .padding(.vertical, AppThemeConstants.editorVerticalInset)
                     }
                     .coordinateSpace(name: "editorScroll")
-                    .onPreferenceChange(BlockFramePreferenceKey.self) { newFrames in
-                        blockFrames = newFrames
+                    .onPreferenceChange(BlockFramePreferenceKey.self) { [blockFrameStore] newFrames in
+                        blockFrameStore.replaceAll(with: newFrames)
                     }
                     .onScrollPhaseChange { _, newPhase in
                         // Dismiss floating selection toolbar when scrolling starts
@@ -763,16 +765,7 @@ extension BlockEditorView {
 
     /// Hit-tests which block is at the given point (in content view coordinates).
     private func blockAtPoint(_ point: CGPoint) -> BlockID? {
-        // Convert content view point to scroll coordinate space
-        // blockFrames are in the "editorScroll" coordinate space
-        // We need to find which block's frame contains the point
-        for (blockID, frame) in blockFrames {
-            // Use a vertical-only hit test (ignore X since blocks span full width)
-            if point.y >= frame.minY, point.y <= frame.maxY {
-                return blockID
-            }
-        }
-        return nil
+        blockFrameStore.blockID(at: point)
     }
 
     /// Selects all blocks in the contiguous range between two block IDs.

--- a/LogueTests/BlockFrameStoreTests.swift
+++ b/LogueTests/BlockFrameStoreTests.swift
@@ -1,0 +1,73 @@
+import Foundation
+import Testing
+
+@testable import Logue
+
+@Suite("Block frame hit-testing")
+struct BlockFrameStoreTests {
+    /// Three stacked blocks, 100pt tall each, matching how the editor lays rows out.
+    private func stackedStore() -> (BlockFrameStore, [BlockID]) {
+        let ids = [UUID(), UUID(), UUID()]
+        let store = BlockFrameStore()
+        store.replaceAll(with: [
+            ids[0]: CGRect(x: 0, y: 0, width: 600, height: 100),
+            ids[1]: CGRect(x: 0, y: 100, width: 600, height: 100),
+            ids[2]: CGRect(x: 0, y: 200, width: 600, height: 100),
+        ])
+        return (store, ids)
+    }
+
+    @Test("Finds the block containing the point")
+    func findsContainingBlock() {
+        let (store, ids) = stackedStore()
+        #expect(store.blockID(at: CGPoint(x: 30, y: 50)) == ids[0])
+        #expect(store.blockID(at: CGPoint(x: 30, y: 150)) == ids[1])
+        #expect(store.blockID(at: CGPoint(x: 30, y: 250)) == ids[2])
+    }
+
+    @Test("Ignores the x coordinate, since blocks span the full width")
+    func ignoresHorizontalPosition() {
+        let (store, ids) = stackedStore()
+        #expect(store.blockID(at: CGPoint(x: -500, y: 150)) == ids[1])
+        #expect(store.blockID(at: CGPoint(x: 99999, y: 150)) == ids[1])
+    }
+
+    @Test("Returns nil above and below the content")
+    func missesOutsideContent() {
+        let (store, _) = stackedStore()
+        #expect(store.blockID(at: CGPoint(x: 30, y: -1)) == nil)
+        #expect(store.blockID(at: CGPoint(x: 30, y: 301)) == nil)
+    }
+
+    @Test("An empty store hit-tests to nothing rather than trapping")
+    func emptyStoreMisses() {
+        #expect(BlockFrameStore().blockID(at: .zero) == nil)
+    }
+
+    @Test("Overlapping frames resolve to the topmost block, not an arbitrary one")
+    func overlapIsDeterministic() {
+        // Dictionary iteration order is unstable, so an arbitrary pick would make a drag over
+        // overlapping frames select different blocks on different runs.
+        let upper = UUID()
+        let lower = UUID()
+        let store = BlockFrameStore()
+        store.replaceAll(with: [
+            upper: CGRect(x: 0, y: 0, width: 600, height: 100),
+            lower: CGRect(x: 0, y: 50, width: 600, height: 100),
+        ])
+        for _ in 0 ..< 50 {
+            #expect(store.blockID(at: CGPoint(x: 30, y: 75)) == upper)
+        }
+    }
+
+    @Test("Replacing frames drops the previous layout entirely")
+    func replaceAllDiscardsStaleFrames() {
+        let (store, ids) = stackedStore()
+        let replacement = UUID()
+        store.replaceAll(with: [replacement: CGRect(x: 0, y: 0, width: 600, height: 100)])
+        #expect(store.blockID(at: CGPoint(x: 30, y: 50)) == replacement)
+        // Blocks from the old layout must not linger and win a later hit test.
+        #expect(store.blockID(at: CGPoint(x: 30, y: 250)) == nil)
+        #expect(!ids.contains(where: { $0 == store.blockID(at: CGPoint(x: 30, y: 50)) }))
+    }
+}

--- a/LogueTests/BlockFrameStoreTests.swift
+++ b/LogueTests/BlockFrameStoreTests.swift
@@ -3,6 +3,14 @@ import Testing
 
 @testable import Logue
 
+/// Covers `BlockFrameStore` in isolation: frames go in, a block comes out.
+///
+/// Every case here supplies coordinates in one consistent space, so a passing suite says
+/// nothing about whether cross-block drag selection works in the app. It cannot: the drag
+/// path feeds this store a point in the window's `contentView` coordinates while the frames
+/// are captured in the `editorScroll` space, and those two disagree on both origin and y
+/// direction. That mismatch is tracked separately — don't read these tests as coverage of
+/// the drag feature.
 @Suite("Block frame hit-testing")
 struct BlockFrameStoreTests {
     /// Three stacked blocks, 100pt tall each, matching how the editor lays rows out.
@@ -42,6 +50,38 @@ struct BlockFrameStoreTests {
     @Test("An empty store hit-tests to nothing rather than trapping")
     func emptyStoreMisses() {
         #expect(BlockFrameStore().blockID(at: .zero) == nil)
+    }
+
+    @Test("A point between two blocks matches neither")
+    func gapBetweenBlocksMisses() {
+        // The editor's VStack spacing leaves a measured 4pt gap between consecutive row
+        // frames, so there is a thin band between blocks that belongs to no block.
+        let upper = UUID()
+        let lower = UUID()
+        let store = BlockFrameStore()
+        store.replaceAll(with: [
+            upper: CGRect(x: 0, y: 0, width: 600, height: 100),
+            lower: CGRect(x: 0, y: 104, width: 600, height: 100),
+        ])
+        #expect(store.blockID(at: CGPoint(x: 30, y: 100)) == upper)
+        #expect(store.blockID(at: CGPoint(x: 30, y: 102)) == nil)
+        #expect(store.blockID(at: CGPoint(x: 30, y: 104)) == lower)
+    }
+
+    @Test("Two frames sharing an edge resolve to the upper one")
+    func sharedEdgeResolvesUpward() {
+        // Not reachable through the editor's current spacing, but the bounds are inclusive,
+        // so this is what a zero-spacing layout would hit — and it must not be arbitrary.
+        let upper = UUID()
+        let lower = UUID()
+        let store = BlockFrameStore()
+        store.replaceAll(with: [
+            upper: CGRect(x: 0, y: 0, width: 600, height: 100),
+            lower: CGRect(x: 0, y: 100, width: 600, height: 100),
+        ])
+        for _ in 0 ..< 50 {
+            #expect(store.blockID(at: CGPoint(x: 30, y: 100)) == upper)
+        }
     }
 
     @Test("Overlapping frames resolve to the topmost block, not an arbitrary one")


### PR DESCRIPTION
## Problem

Scrolling a document stuttered, and it stuttered whether the document was small or large. Idle was fine — the cost only appeared while scrolling.

Every block published its frame through a SwiftUI preference, measured in the `editorScroll` coordinate space. Scrolling changes *every* block's frame, so on each layout pass:

preference recomputes → `onPreferenceChange` writes `@State blockFrames` → invalidates `BlockEditorView.body` → rebuilds **all** rows and runs `updateNSView` on **all** block text views → produces the next layout pass → repeat.

The scroll fed itself. The tell, when instrumented, was that body evaluations and preference callbacks came out to exactly the same count: every single body evaluation was caused by that state write.

## Why the frames don't belong in view state

`blockFrames` had exactly one consumer — `blockAtPoint`, reached from the `leftMouseDragged` monitor that implements cross-block selection. Nothing renders from it. Writing it therefore should not invalidate anything, so it moves into a plain reference type (`BlockFrameStore`) held by `@State` — the reference is stable, so SwiftUI sees no change.

## Measurements

Instrumented body evaluations, row builds and `updateNSView` calls, then drove identical synthetic scroll gestures over two generated documents.

**45 blocks / 916 words** — a small document, the case that should never have been slow:

| Metric | Before | After |
| --- | --- | --- |
| body evaluations/sec | 48 | **0** |
| row builds/sec | 2,208 | **0** |
| `updateNSView` calls/sec | 2,208 | **~18** |

**450 blocks / 9,751 words:**

| Metric | Before | After |
| --- | --- | --- |
| layout passes/sec | **4–6** (≈5fps) | 17–20 |
| row builds/sec | ~2,700 | **0** |
| `updateNSView` calls/sec | ~2,700 | **~18** |

Idle was 0 in both builds, which is why this only showed up in motion. On the long document the one-second sampling timer itself slipped to 1.24s before the change — the main thread was saturated, which is what the stutter was.

## Behaviour

The hit test returns the same block as before for the non-overlapping frames the editor actually produces. The one deliberate difference: overlapping frames now resolve to the topmost block instead of whichever one dictionary iteration order happened to surface first, so the result is deterministic.

Cross-block drag selection was exercised with the same synthetic drag against both the original and the patched build and behaves identically.

## Testing

- `LogueTests/BlockFrameStoreTests.swift` — 6 tests covering containment, x-independence, misses above and below content, the empty store, deterministic overlap resolution, and that replacing frames discards the previous layout. All passing.
- `swiftlint` and `swiftformat` clean on the changed files.
- Verified interactively on both document sizes, plus a drag-selection comparison against `main`.

## Follow-up, not included here

The per-block `GeometryReader` still collects frames on every layout pass, so that bookkeeping remains O(number of blocks) per frame — it is now the only thing in the scroll path that scales with document length. Comparing post-fix layout passes per second between the two documents above (~40–55/s at 45 blocks vs ~11–20/s at 450) shows the remaining cost. That is tracked separately in #42 and is deliberately out of scope here to keep this diff small.

Also noticed while in this code, and **not** addressed: `blockAtPoint` compares a point in the window's `contentView` coordinates against frames captured in the `editorScroll` coordinate space. Those spaces do not share an origin, so cross-block drag selection appears not to trigger in practice. Pre-existing, unchanged by this PR, and noted in #42.
