### PR TITLE
fix(command-center): let the Ask Logue island be dismissed again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   switching apps meant nothing to the island, so the prompt bar sat over every other app until
   Logue was quit or hidden. It now closes on its own shortcut, on Esc and on a click anywhere
   outside it, and gets out of the way when you switch apps — keeping a conversation or an
-  unsent prompt rather than discarding it.
+  unsent prompt rather than discarding it, and coming back to the front on the shortcut that
+  summoned it.
 - Lists no longer show an empty state while the library is still loading — launching used to
   flash "No Documents" and greet returning users with the new-user welcome screen.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,11 +26,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - The Ask Logue island can be put away again. Its shortcut rebuilt it instead of closing it,
-  which stranded the panel on screen with nothing able to dismiss it; Esc was watched in a way
-  that could not see the key press while Logue was frontmost; and switching apps meant nothing
-  to it, so the prompt bar sat over every other app until Logue was quit or hidden. It now
-  closes on its own shortcut and on Esc, and gets out of the way when you switch apps —
-  keeping a conversation or an unsent prompt rather than discarding it.
+  which stranded the panel on screen with every way out of it dead — often leaving quitting
+  Logue as the only escape. Esc and clicking outside were both watched in a way that could not
+  see the event while Logue itself was frontmost, so each worked only some of the time. And
+  switching apps meant nothing to the island, so the prompt bar sat over every other app until
+  Logue was quit or hidden. It now closes on its own shortcut, on Esc and on a click anywhere
+  outside it, and gets out of the way when you switch apps — keeping a conversation or an
+  unsent prompt rather than discarding it.
 - Lists no longer show an empty state while the library is still loading — launching used to
   flash "No Documents" and greet returning users with the new-user welcome screen.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The Ask Logue island can be put away again. Its shortcut rebuilt it instead of closing it,
+  which stranded the panel on screen with nothing able to dismiss it; Esc was watched in a way
+  that could not see the key press while Logue was frontmost; and switching apps meant nothing
+  to it, so the prompt bar sat over every other app until Logue was quit or hidden. It now
+  closes on its own shortcut and on Esc, and gets out of the way when you switch apps —
+  keeping a conversation or an unsent prompt rather than discarding it.
 - Lists no longer show an empty state while the library is still loading — launching used to
   flash "No Documents" and greet returning users with the new-user welcome screen.
 

--- a/Logue.xcodeproj/project.pbxproj
+++ b/Logue.xcodeproj/project.pbxproj
@@ -141,6 +141,7 @@
 		394298FD6FA5E69385C52C55 /* MemoryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54533945F253EFE4459AC3A2 /* MemoryStore.swift */; };
 		39662C74243A5431B46422BF /* PIIRegexScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791BA3A7ABEB9CC9E301FCE6 /* PIIRegexScanner.swift */; };
 		3A0604553EBC4F314C97193A /* EditorZoomTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7824CE8087F98B0143531A9F /* EditorZoomTests.swift */; };
+		3A1F8B924E2BAA7DD5C45A6A /* CommandCenterChatRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 136ABA45F11F81E853897C17 /* CommandCenterChatRuleTests.swift */; };
 		3ABDB2E2F4133D4F8293FE55 /* UnifiedSidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC3CE09FD46E14F97E07C0BF /* UnifiedSidebarView.swift */; };
 		3B58975589B53E6910C02FE8 /* AgentChatView+Input.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7B886861180D41A132F1B6A /* AgentChatView+Input.swift */; };
 		3BB74E6C769B50816B912D28 /* BulletRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B9F22B7392C28686BD5CE60 /* BulletRow.swift */; };
@@ -172,6 +173,7 @@
 		486082E3815CD2D7A4249A82 /* CalendarWriteTools.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6AC347933D7E812C30B26A8 /* CalendarWriteTools.swift */; };
 		496062886BC3CE21CE0651CC /* WritingLayoutManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 448C84F276994CA3F884806B /* WritingLayoutManager.swift */; };
 		49E5C7C344473205333ED65D /* InlineProgressLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97AEDA55455BF89C587E41B5 /* InlineProgressLabel.swift */; };
+		4BD0DCD9E20A28C06D40AF62 /* CommandCenterChatRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 865AE91088D3794F9C1CC457 /* CommandCenterChatRule.swift */; };
 		4C25F8B167705F018F107EEB /* LogueLogo.svg in Resources */ = {isa = PBXBuildFile; fileRef = EC3417F4F42C4F317FA8FD4C /* LogueLogo.svg */; };
 		4CBDF92105360575ED4D7688 /* WikiLinkParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 019756686F6D3BBAAE229D8F /* WikiLinkParserTests.swift */; };
 		4DFBBF9A94D043AEAE9573D1 /* SpaceFolderWriteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F13A88F235D33A5674EC6CB /* SpaceFolderWriteTests.swift */; };
@@ -592,6 +594,7 @@
 		132AE87705CAF5786CEA7086 /* StatusFilterChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusFilterChip.swift; sourceTree = "<group>"; };
 		132C503C3139368F66A16B8C /* MeetingStore+SeedData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MeetingStore+SeedData.swift"; sourceTree = "<group>"; };
 		133717C9C61937FC843612D1 /* MultiBlockKeyHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiBlockKeyHandler.swift; sourceTree = "<group>"; };
+		136ABA45F11F81E853897C17 /* CommandCenterChatRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandCenterChatRuleTests.swift; sourceTree = "<group>"; };
 		141A999128E664D7D97120BB /* CharCounter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharCounter.swift; sourceTree = "<group>"; };
 		14A204E44FBCA2412FF88EFA /* WritingDiffView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WritingDiffView.swift; sourceTree = "<group>"; };
 		153523A61D3B1E2AF4B2D108 /* OnboardingView+ModelPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OnboardingView+ModelPage.swift"; sourceTree = "<group>"; };
@@ -817,6 +820,7 @@
 		84D22CFDEB9D3FC3A4805089 /* UICopy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UICopy.swift; sourceTree = "<group>"; };
 		851703C5995A9B2FA0C07975 /* TemplateStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateStore.swift; sourceTree = "<group>"; };
 		860DFF869B9C6C39BE468431 /* DiagnosticsReportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsReportTests.swift; sourceTree = "<group>"; };
+		865AE91088D3794F9C1CC457 /* CommandCenterChatRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandCenterChatRule.swift; sourceTree = "<group>"; };
 		86F393DC727834A59AB47A62 /* AIChatPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatPanelView.swift; sourceTree = "<group>"; };
 		8756576B17C7D359AC9FC6A0 /* VerifyPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerifyPanelView.swift; sourceTree = "<group>"; };
 		876B3EAA03844355C80F1817 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -1147,6 +1151,7 @@
 				221BC5AEDD75B485C3384F37 /* BulkActionInboxTests.swift */,
 				46DB0259534855A640246B2A /* CalloutBlockTests.swift */,
 				4AB2A7A4F24E2BC67AEE4319 /* CalloutRoundTripEdgeTests.swift */,
+				136ABA45F11F81E853897C17 /* CommandCenterChatRuleTests.swift */,
 				83C272112D79CC98FD132288 /* ContentNavigatorTests.swift */,
 				263E3C59B8D03346E04E7C92 /* DeepLinkRoutingTests.swift */,
 				EB27F11A2333C941E28C916E /* DeepLinkTests.swift */,
@@ -1293,6 +1298,7 @@
 			isa = PBXGroup;
 			children = (
 				9BFF6DFB33FFDD664F05A4E6 /* AccessibilityService.swift */,
+				865AE91088D3794F9C1CC457 /* CommandCenterChatRule.swift */,
 				C8D8F63B0BEBD964C1409AA5 /* CommandCenterController.swift */,
 				DD62B3D8FB4F2050661CE197 /* InlineAssistant.swift */,
 				29E0387E99032708C27EA914 /* KeyboardShortcut.swift */,
@@ -2162,6 +2168,7 @@
 				4F1D0B3B8CE3D50CCD09720C /* BulkActionInboxTests.swift in Sources */,
 				2ED027BF90138612DDE85A2C /* CalloutBlockTests.swift in Sources */,
 				B27F60023417DD2C91BC326C /* CalloutRoundTripEdgeTests.swift in Sources */,
+				3A1F8B924E2BAA7DD5C45A6A /* CommandCenterChatRuleTests.swift in Sources */,
 				2EBF59EE30602911A0C7236E /* ContentNavigatorTests.swift in Sources */,
 				8837715694AEB1053618212A /* DeepLinkRoutingTests.swift in Sources */,
 				52B089BBC06F1A4DC8CFA5CE /* DeepLinkTests.swift in Sources */,
@@ -2308,6 +2315,7 @@
 				32250FA08C8D190532365E94 /* CodeBlockLanguageMemory.swift in Sources */,
 				064963B61C0242F39204C049 /* CodeSyntaxHighlighter.swift in Sources */,
 				1CF5D6AE20C1BDE279762B9F /* ComingSoonPanelView.swift in Sources */,
+				4BD0DCD9E20A28C06D40AF62 /* CommandCenterChatRule.swift in Sources */,
 				E5DF85C2C0803078D80C350C /* CommandCenterChatView.swift in Sources */,
 				5CBFF3B40F91960EC8178989 /* CommandCenterComposeView.swift in Sources */,
 				99FCB8FEB17A1DA884E6892C /* CommandCenterController.swift in Sources */,

--- a/Logue/App/AppDelegate.swift
+++ b/Logue/App/AppDelegate.swift
@@ -696,7 +696,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     @objc
     private func showChatInterface() {
         suppressMainWindowRestore = true
-        commandCenterController?.showChatPanel()
+        commandCenterController?.toggleChatPanel()
     }
 
     @objc

--- a/Logue/CrossApp/CommandCenterChatRule.swift
+++ b/Logue/CrossApp/CommandCenterChatRule.swift
@@ -21,10 +21,11 @@ enum CommandCenterChatRule {
     /// What losing frontmost status should do to a chat island, or `nil` when the
     /// showing panel is not one.
     enum FocusLoss: Equatable {
-        /// Nothing has been said to it, so nothing is lost by closing it.
+        /// Empty, so nothing is lost by closing it.
         case dismiss
-        /// It holds a conversation that only exists in the view's state. Keep it,
-        /// but stop it covering the app being switched to.
+        /// It holds a conversation, or a prompt typed but not sent, and both live
+        /// only in the view's state. Keep it, but stop it covering the app being
+        /// switched to.
         case sendBehindOtherApps
     }
 
@@ -34,8 +35,8 @@ enum CommandCenterChatRule {
         return .replace
     }
 
-    static func focusLoss(mode: CommandCenterMode?, chatHasMessages: Bool) -> FocusLoss? {
+    static func focusLoss(mode: CommandCenterMode?, chatHasContent: Bool) -> FocusLoss? {
         guard case .chat = mode else { return nil }
-        return chatHasMessages ? .sendBehindOtherApps : .dismiss
+        return chatHasContent ? .sendBehindOtherApps : .dismiss
     }
 }

--- a/Logue/CrossApp/CommandCenterChatRule.swift
+++ b/Logue/CrossApp/CommandCenterChatRule.swift
@@ -1,12 +1,5 @@
 import Foundation
 
-/// What a Command Center trigger, or Logue losing frontmost status, means for the
-/// chat island.
-///
-/// Kept free of AppKit so the matrix is testable without an NSPanel. The controller
-/// owns the panel and only asks what to do with it — issue #46 was three separate
-/// wrong answers to these questions, none of which a test could have reached while
-/// they lived inside the window code.
 /// What the chat island is currently holding.
 ///
 /// The two are kept apart because they earn different protection. Deliberately
@@ -23,6 +16,13 @@ struct CommandCenterChatContent: Equatable {
     }
 }
 
+/// What a Command Center trigger, or Logue losing frontmost status, means for the
+/// chat island.
+///
+/// Kept free of AppKit so the matrix is testable without an NSPanel: the controller
+/// owns the panel and only asks what to do with it. Issue #46 was several wrong
+/// answers to these questions, none of which a test could reach while they lived
+/// inside the window code.
 enum CommandCenterChatRule {
     /// What pressing the Ask Logue shortcut should do.
     enum Trigger: Equatable {

--- a/Logue/CrossApp/CommandCenterChatRule.swift
+++ b/Logue/CrossApp/CommandCenterChatRule.swift
@@ -10,8 +10,12 @@ import Foundation
 enum CommandCenterChatRule {
     /// What pressing the Ask Logue shortcut should do.
     enum Trigger: Equatable {
-        /// The chat island is already up — the shortcut puts it away.
+        /// The chat island is up in front — the shortcut puts it away.
         case dismiss
+        /// The island was sent behind other apps when Logue lost focus. The
+        /// shortcut is how you ask for it back, so bring it forward rather than
+        /// destroying it along with whatever was typed into it.
+        case raise
         /// Another island is up and has to go first.
         case replace
         /// Nothing is up.
@@ -29,10 +33,14 @@ enum CommandCenterChatRule {
         case sendBehindOtherApps
     }
 
-    static func trigger(mode: CommandCenterMode?, isShowingPanel: Bool) -> Trigger {
+    static func trigger(
+        mode: CommandCenterMode?,
+        isShowingPanel: Bool,
+        isChatBehindOtherApps: Bool
+    ) -> Trigger {
         guard isShowingPanel else { return .present }
         if case .chat = mode {
-            return .dismiss
+            return isChatBehindOtherApps ? .raise : .dismiss
         }
         return .replace
     }

--- a/Logue/CrossApp/CommandCenterChatRule.swift
+++ b/Logue/CrossApp/CommandCenterChatRule.swift
@@ -7,6 +7,22 @@ import Foundation
 /// owns the panel and only asks what to do with it — issue #46 was three separate
 /// wrong answers to these questions, none of which a test could have reached while
 /// they lived inside the window code.
+/// What the chat island is currently holding.
+///
+/// The two are kept apart because they earn different protection. Deliberately
+/// putting the island away — clicking off it, Esc, the close button, the shortcut
+/// — has always destroyed an unsent prompt, and a conversation is what a click
+/// off the island must not throw away. Switching apps is not a decision about the
+/// island at all, so that leaves either alone.
+struct CommandCenterChatContent: Equatable {
+    var hasMessages: Bool
+    var hasDraft: Bool
+
+    var isEmpty: Bool {
+        !hasMessages && !hasDraft
+    }
+}
+
 enum CommandCenterChatRule {
     /// What pressing the Ask Logue shortcut should do.
     enum Trigger: Equatable {

--- a/Logue/CrossApp/CommandCenterChatRule.swift
+++ b/Logue/CrossApp/CommandCenterChatRule.swift
@@ -31,7 +31,9 @@ enum CommandCenterChatRule {
 
     static func trigger(mode: CommandCenterMode?, isShowingPanel: Bool) -> Trigger {
         guard isShowingPanel else { return .present }
-        if case .chat = mode { return .dismiss }
+        if case .chat = mode {
+            return .dismiss
+        }
         return .replace
     }
 

--- a/Logue/CrossApp/CommandCenterChatRule.swift
+++ b/Logue/CrossApp/CommandCenterChatRule.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// What a Command Center trigger, or Logue losing frontmost status, means for the
+/// chat island.
+///
+/// Kept free of AppKit so the matrix is testable without an NSPanel. The controller
+/// owns the panel and only asks what to do with it — issue #46 was three separate
+/// wrong answers to these questions, none of which a test could have reached while
+/// they lived inside the window code.
+enum CommandCenterChatRule {
+    /// What pressing the Ask Logue shortcut should do.
+    enum Trigger: Equatable {
+        /// The chat island is already up — the shortcut puts it away.
+        case dismiss
+        /// Another island is up and has to go first.
+        case replace
+        /// Nothing is up.
+        case present
+    }
+
+    /// What losing frontmost status should do to a chat island, or `nil` when the
+    /// showing panel is not one.
+    enum FocusLoss: Equatable {
+        /// Nothing has been said to it, so nothing is lost by closing it.
+        case dismiss
+        /// It holds a conversation that only exists in the view's state. Keep it,
+        /// but stop it covering the app being switched to.
+        case sendBehindOtherApps
+    }
+
+    static func trigger(mode: CommandCenterMode?, isShowingPanel: Bool) -> Trigger {
+        guard isShowingPanel else { return .present }
+        if case .chat = mode { return .dismiss }
+        return .replace
+    }
+
+    static func focusLoss(mode: CommandCenterMode?, chatHasMessages: Bool) -> FocusLoss? {
+        guard case .chat = mode else { return nil }
+        return chatHasMessages ? .sendBehindOtherApps : .dismiss
+    }
+}

--- a/Logue/CrossApp/CommandCenterController.swift
+++ b/Logue/CrossApp/CommandCenterController.swift
@@ -500,36 +500,40 @@ class CommandCenterController: ObservableObject {
         }
     }
 
-    /// Shared cleanup after a panel closes. Resets panel state and optionally
-    /// tears down recording observers if no recording is actively running.
+    /// Gives up ownership of the showing panel and hands it to the caller to
+    /// animate away. Every piece of state describing it is cleared here, before
+    /// returning — a dismissal takes 150–300ms to animate, and for that whole
+    /// window anything reading `panel` or `currentMode` would otherwise be
+    /// answered about a panel that is already leaving. That stale answer is what
+    /// made the shortcut, a menu-bar click and the dismiss notification act on a
+    /// dying panel instead of presenting a new one (issue #46).
     ///
-    /// `dismissed` is the panel whose close animation just finished. Dismissal is
-    /// animated, so a new panel can be created before this runs — clearing state
-    /// then would strand the live panel with no reference to it, leaving it on
-    /// screen with nothing able to close it (issue #46).
-    private func finalizeDismiss(_ dismissed: CommandCenterPanel, preserveRecordingState: Bool = false) {
-        guard panel === dismissed else { return }
+    /// Returns `nil` when there is nothing showing.
+    private func relinquishPanel() -> CommandCenterPanel? {
+        guard let dismissed = panel else { return nil }
+
+        // Keep recording state if a recording is still running (allows re-show from menu)
+        let keepRecordingState = RecordingSessionManager.shared.isRecording && activeRecordingMeetingID != nil
+
         panel = nil
         isVisible = false
         currentMode = nil
         chatHasContent = false
-        if !preserveRecordingState {
+        if !keepRecordingState {
             activeRecordingMeetingID = nil
             tearDownAppActiveObservers()
         }
+        return dismissed
     }
 
     func dismissPanel() {
         removeMonitors()
-        guard let panel else { return }
-
-        // Keep recording state if a recording is still running (allows re-show from menu)
-        let keepRecordingState = RecordingSessionManager.shared.isRecording && activeRecordingMeetingID != nil
         let isRecordingMode = if case .recording = currentMode {
             true
         } else {
             false
         }
+        guard let panel = relinquishPanel() else { return }
 
         if isRecordingMode {
             // Scale-down + slide-up into the notch area (macOS native feel)
@@ -548,18 +552,16 @@ class CommandCenterController: ObservableObject {
                     display: true
                 )
                 panel.animator().alphaValue = 0
-            } completionHandler: { [weak self] in
+            } completionHandler: {
                 panel.close()
-                Task { @MainActor in self?.finalizeDismiss(panel, preserveRecordingState: keepRecordingState) }
             }
         } else {
             NSAnimationContext.runAnimationGroup { ctx in
                 ctx.duration = 0.15
                 ctx.timingFunction = CAMediaTimingFunction(name: .easeIn)
                 panel.animator().alphaValue = 0
-            } completionHandler: { [weak self] in
+            } completionHandler: {
                 panel.close()
-                Task { @MainActor in self?.finalizeDismiss(panel, preserveRecordingState: keepRecordingState) }
             }
         }
     }
@@ -574,7 +576,7 @@ class CommandCenterController: ObservableObject {
         hiddenForMainWindow = false
         tearDownAppActiveObservers()
 
-        guard let panel else { return }
+        guard let panel = relinquishPanel() else { return }
 
         let originalFrame = panel.frame
         let collapsedWidth: CGFloat = 120
@@ -595,10 +597,7 @@ class CommandCenterController: ObservableObject {
             panel.animator().alphaValue = 0
         } completionHandler: { [weak self] in
             panel.close()
-            Task { @MainActor in
-                self?.finalizeDismiss(panel)
-                self?.showSavedToast(near: originalFrame)
-            }
+            Task { @MainActor in self?.showSavedToast(near: originalFrame) }
         }
     }
 

--- a/Logue/CrossApp/CommandCenterController.swift
+++ b/Logue/CrossApp/CommandCenterController.swift
@@ -70,6 +70,13 @@ private class TransparentContainerView: NSView {
 
     var onClickEmptyArea: (() -> Void)?
 
+    /// Whether a click on the empty area is ours to act on. Consulted during hit
+    /// testing, so it must answer without side effects. Answering `false` lets the
+    /// click through to whatever is behind the panel — the panel is far taller
+    /// than the pill drawn at the bottom of it, so claiming clicks we will not act
+    /// on turns the transparent region into a dead zone that swallows them.
+    var claimsEmptyAreaClicks: (() -> Bool)?
+
     override func draw(_ dirtyRect: NSRect) {
         // Fully transparent — do not draw anything.
     }
@@ -90,9 +97,9 @@ private class TransparentContainerView: NSView {
                 return hit
             }
         }
-        // No subview hit — return self only if we have an empty-area handler,
-        // otherwise return nil to let the click pass through entirely.
-        return onClickEmptyArea != nil ? self : nil
+        // No subview hit — claim it only if we will act on it, otherwise return nil
+        // to let the click pass through entirely.
+        return claimsEmptyAreaClicks?() == true ? self : nil
     }
 
     override func mouseDown(with event: NSEvent) {
@@ -302,10 +309,8 @@ class CommandCenterController: ObservableObject {
                 hv.topAnchor.constraint(greaterThanOrEqualTo: container.topAnchor),
             ])
 
-            container.onClickEmptyArea = { [weak self] in
-                guard let self, !self.chatHasContent else { return }
-                dismissPanel()
-            }
+            container.claimsEmptyAreaClicks = { [weak self] in self?.chatHasContent == false }
+            container.onClickEmptyArea = { [weak self] in self?.dismissPanel() }
 
             hostingView = container
             panelWidth = 740

--- a/Logue/CrossApp/CommandCenterController.swift
+++ b/Logue/CrossApp/CommandCenterController.swift
@@ -429,7 +429,13 @@ class CommandCenterController: ObservableObject {
 
     /// Shared cleanup after a panel closes. Resets panel state and optionally
     /// tears down recording observers if no recording is actively running.
-    private func finalizeDismiss(preserveRecordingState: Bool = false) {
+    ///
+    /// `dismissed` is the panel whose close animation just finished. Dismissal is
+    /// animated, so a new panel can be created before this runs — clearing state
+    /// then would strand the live panel with no reference to it, leaving it on
+    /// screen with nothing able to close it (issue #46).
+    private func finalizeDismiss(_ dismissed: CommandCenterPanel, preserveRecordingState: Bool = false) {
+        guard panel === dismissed else { return }
         panel = nil
         isVisible = false
         currentMode = nil
@@ -471,7 +477,7 @@ class CommandCenterController: ObservableObject {
                 panel.animator().alphaValue = 0
             } completionHandler: { [weak self] in
                 panel.close()
-                Task { @MainActor in self?.finalizeDismiss(preserveRecordingState: keepRecordingState) }
+                Task { @MainActor in self?.finalizeDismiss(panel, preserveRecordingState: keepRecordingState) }
             }
         } else {
             NSAnimationContext.runAnimationGroup { ctx in
@@ -480,7 +486,7 @@ class CommandCenterController: ObservableObject {
                 panel.animator().alphaValue = 0
             } completionHandler: { [weak self] in
                 panel.close()
-                Task { @MainActor in self?.finalizeDismiss(preserveRecordingState: keepRecordingState) }
+                Task { @MainActor in self?.finalizeDismiss(panel, preserveRecordingState: keepRecordingState) }
             }
         }
     }
@@ -517,7 +523,7 @@ class CommandCenterController: ObservableObject {
         } completionHandler: { [weak self] in
             panel.close()
             Task { @MainActor in
-                self?.finalizeDismiss()
+                self?.finalizeDismiss(panel)
                 self?.showSavedToast(near: originalFrame)
             }
         }

--- a/Logue/CrossApp/CommandCenterController.swift
+++ b/Logue/CrossApp/CommandCenterController.swift
@@ -428,25 +428,24 @@ class CommandCenterController: ObservableObject {
     // MARK: - Monitors
 
     private func setupMonitors(mode: CommandCenterMode) {
-        // A global monitor never sees events routed to our own app, and the panel
-        // is made key on creation — so Esc also needs a local monitor, or it only
-        // works while some other app is frontmost.
         escMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
             if event.keyCode == Self.escapeKeyCode {
                 Task { @MainActor in self?.dismissPanel() }
             }
         }
 
-        escLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
-            guard event.keyCode == Self.escapeKeyCode, let self, panel?.isKeyWindow == true else { return event }
-            dismissPanel()
-            return nil
-        }
-
+        // The local monitors below are chat-only on purpose. A global monitor never
+        // sees events routed to our own app, and creating a panel makes it key, so
+        // without them Esc and clicking away work only while some other app is
+        // frontmost. The recording island is left with exactly the behaviour it had
+        // rather than gaining an Esc that collapses it the instant recording starts.
         if case .chat = mode {
-            // Same blind spot as Esc: a click on one of Logue's own windows is
-            // routed to us and never reaches a global monitor, so clicking the main
-            // window beside the island left it sitting there. Watch both sides.
+            escLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+                guard event.keyCode == Self.escapeKeyCode, let self, panel?.isKeyWindow == true else { return event }
+                dismissPanel()
+                return nil
+            }
+
             clickMonitor = NSEvent.addGlobalMonitorForEvents(matching: .leftMouseDown) { [weak self] event in
                 let screenPoint = Self.screenPoint(for: event)
                 Task { @MainActor in self?.dismissIfClickMissedPanel(screenPoint) }

--- a/Logue/CrossApp/CommandCenterController.swift
+++ b/Logue/CrossApp/CommandCenterController.swift
@@ -132,12 +132,14 @@ class CommandCenterController: ObservableObject {
     /// Summons the chat island, or dismisses it when it is already up, so the
     /// activation shortcut is the same key that puts it away again.
     func toggleChatPanel() {
-        if case .chat = currentMode, panel != nil {
+        switch CommandCenterChatRule.trigger(mode: currentMode, isShowingPanel: panel != nil) {
+        case .dismiss:
             dismissPanel()
             return
-        }
-        if panel != nil {
+        case .replace:
             dismissPanel()
+        case .present:
+            break
         }
         currentMode = .chat
         chatHasMessages = false
@@ -219,18 +221,15 @@ class CommandCenterController: ObservableObject {
     }
 
     private func handleAppResignedActive() {
-        if case .chat = currentMode {
-            // An untouched island is disposable — same rule as a click outside it.
-            // Once there are messages the conversation only exists in the view's
-            // state, so drop the panel out of the floating level instead of
-            // destroying it: it stops covering the app being switched to, and
-            // comes back to the front with Logue.
-            if chatHasMessages {
-                panel?.level = .normal
-            } else {
-                dismissPanel()
-            }
+        switch CommandCenterChatRule.focusLoss(mode: currentMode, chatHasMessages: chatHasMessages) {
+        case .dismiss:
+            dismissPanel()
             return
+        case .sendBehindOtherApps:
+            panel?.level = .normal
+            return
+        case nil:
+            break
         }
         guard RecordingSessionManager.shared.isRecording, activeRecordingMeetingID != nil else { return }
         if hiddenForMainWindow {

--- a/Logue/CrossApp/CommandCenterController.swift
+++ b/Logue/CrossApp/CommandCenterController.swift
@@ -125,7 +125,13 @@ class CommandCenterController: ObservableObject {
 
     // MARK: - Public API
 
-    func showChatPanel() {
+    /// Summons the chat island, or dismisses it when it is already up, so the
+    /// activation shortcut is the same key that puts it away again.
+    func toggleChatPanel() {
+        if case .chat = currentMode, panel != nil {
+            dismissPanel()
+            return
+        }
         if panel != nil {
             dismissPanel()
         }

--- a/Logue/CrossApp/CommandCenterController.swift
+++ b/Logue/CrossApp/CommandCenterController.swift
@@ -124,7 +124,7 @@ class CommandCenterController: ObservableObject {
     private var clickMonitor: Any?
     private var clickLocalMonitor: Any?
     private var dismissObserver: NSObjectProtocol?
-    private var chatHasContent: Bool = false
+    private var chatContent = CommandCenterChatContent(hasMessages: false, hasDraft: false)
 
     /// The meeting ID of the active recording panel, used to restore the island.
     private(set) var activeRecordingMeetingID: UUID?
@@ -157,7 +157,7 @@ class CommandCenterController: ObservableObject {
             break
         }
         currentMode = .chat
-        chatHasContent = false
+        chatContent = CommandCenterChatContent(hasMessages: false, hasDraft: false)
         createPanel(mode: .chat)
         setupAppActiveObservers()
     }
@@ -247,7 +247,7 @@ class CommandCenterController: ObservableObject {
     }
 
     private func handleAppResignedActive() {
-        switch CommandCenterChatRule.focusLoss(mode: currentMode, chatHasContent: chatHasContent) {
+        switch CommandCenterChatRule.focusLoss(mode: currentMode, chatHasContent: !chatContent.isEmpty) {
         case .dismiss:
             dismissPanel()
             return
@@ -283,7 +283,7 @@ class CommandCenterController: ObservableObject {
         case .chat:
             let chatView = CommandCenterChatView(
                 onDismiss: { [weak self] in self?.dismissPanel() },
-                onContentChanged: { [weak self] hasContent in self?.chatHasContent = hasContent }
+                onContentChanged: { [weak self] content in self?.chatContent = content }
             )
             let hv = TransparentHostingView(rootView: chatView)
             hv.translatesAutoresizingMaskIntoConstraints = false
@@ -309,7 +309,7 @@ class CommandCenterController: ObservableObject {
                 hv.topAnchor.constraint(greaterThanOrEqualTo: container.topAnchor),
             ])
 
-            container.claimsEmptyAreaClicks = { [weak self] in self?.chatHasContent == false }
+            container.claimsEmptyAreaClicks = { [weak self] in self?.chatContent.hasMessages == false }
             container.onClickEmptyArea = { [weak self] in self?.dismissPanel() }
 
             hostingView = container
@@ -480,7 +480,7 @@ class CommandCenterController: ObservableObject {
     /// Puts an empty chat island away when a click lands anywhere but on it. An
     /// island holding a conversation or an unsent prompt stays.
     private func dismissIfClickMissedPanel(_ screenPoint: NSPoint) {
-        guard let panel, !chatHasContent, !panel.frame.contains(screenPoint) else { return }
+        guard let panel, !chatContent.hasMessages, !panel.frame.contains(screenPoint) else { return }
         dismissPanel()
     }
 
@@ -523,7 +523,7 @@ class CommandCenterController: ObservableObject {
         panel = nil
         isVisible = false
         currentMode = nil
-        chatHasContent = false
+        chatContent = CommandCenterChatContent(hasMessages: false, hasDraft: false)
         if !keepRecordingState {
             activeRecordingMeetingID = nil
             tearDownAppActiveObservers()

--- a/Logue/CrossApp/CommandCenterController.swift
+++ b/Logue/CrossApp/CommandCenterController.swift
@@ -1,10 +1,6 @@
 import Cocoa
 import SwiftUI
 
-extension Notification.Name {
-    static let dismissCommandCenter = Notification.Name("dismissCommandCenter")
-}
-
 /// Panel mode for Command Center — chat or recording.
 enum CommandCenterMode: Equatable {
     case chat
@@ -123,7 +119,6 @@ class CommandCenterController: ObservableObject {
     private var escLocalMonitor: Any?
     private var clickMonitor: Any?
     private var clickLocalMonitor: Any?
-    private var dismissObserver: NSObjectProtocol?
     private var chatContent = CommandCenterChatContent(hasMessages: false, hasDraft: false)
 
     /// The meeting ID of the active recording panel, used to restore the island.
@@ -462,12 +457,6 @@ class CommandCenterController: ObservableObject {
                 return event
             }
         }
-
-        dismissObserver = NotificationCenter.default.addObserver(
-            forName: .dismissCommandCenter, object: nil, queue: .main
-        ) { [weak self] _ in
-            Task { @MainActor in self?.dismissPanel() }
-        }
     }
 
     /// Where a click landed, in screen coordinates. Events from a global monitor
@@ -486,7 +475,7 @@ class CommandCenterController: ObservableObject {
 
     // MARK: - Dismiss
 
-    /// Removes event monitors and notification observers used by the active panel.
+    /// Removes the event monitors used by the active panel.
     private func removeMonitors() {
         if let monitor = escMonitor {
             NSEvent.removeMonitor(monitor); escMonitor = nil
@@ -499,9 +488,6 @@ class CommandCenterController: ObservableObject {
         }
         if let monitor = clickLocalMonitor {
             NSEvent.removeMonitor(monitor); clickLocalMonitor = nil
-        }
-        if let observer = dismissObserver {
-            NotificationCenter.default.removeObserver(observer); dismissObserver = nil
         }
     }
 

--- a/Logue/CrossApp/CommandCenterController.swift
+++ b/Logue/CrossApp/CommandCenterController.swift
@@ -142,6 +142,7 @@ class CommandCenterController: ObservableObject {
         currentMode = .chat
         chatHasMessages = false
         createPanel(mode: .chat)
+        setupAppActiveObservers()
     }
 
     func showRecordingPanel(meetingID: UUID) {
@@ -198,6 +199,10 @@ class CommandCenterController: ObservableObject {
     }
 
     private func handleAppBecameActive() {
+        if case .chat = currentMode {
+            panel?.level = .floating
+            return
+        }
         guard case .recording = currentMode else { return }
         // Skip if this activation was triggered by panel creation
         if suppressNextActiveHide {
@@ -214,6 +219,19 @@ class CommandCenterController: ObservableObject {
     }
 
     private func handleAppResignedActive() {
+        if case .chat = currentMode {
+            // An untouched island is disposable — same rule as a click outside it.
+            // Once there are messages the conversation only exists in the view's
+            // state, so drop the panel out of the floating level instead of
+            // destroying it: it stops covering the app being switched to, and
+            // comes back to the front with Logue.
+            if chatHasMessages {
+                panel?.level = .normal
+            } else {
+                dismissPanel()
+            }
+            return
+        }
         guard RecordingSessionManager.shared.isRecording, activeRecordingMeetingID != nil else { return }
         if hiddenForMainWindow {
             hiddenForMainWindow = false

--- a/Logue/CrossApp/CommandCenterController.swift
+++ b/Logue/CrossApp/CommandCenterController.swift
@@ -116,7 +116,7 @@ class CommandCenterController: ObservableObject {
     private var escLocalMonitor: Any?
     private var clickMonitor: Any?
     private var dismissObserver: NSObjectProtocol?
-    private var chatHasMessages: Bool = false
+    private var chatHasContent: Bool = false
 
     /// The meeting ID of the active recording panel, used to restore the island.
     private(set) var activeRecordingMeetingID: UUID?
@@ -142,7 +142,7 @@ class CommandCenterController: ObservableObject {
             break
         }
         currentMode = .chat
-        chatHasMessages = false
+        chatHasContent = false
         createPanel(mode: .chat)
         setupAppActiveObservers()
     }
@@ -221,7 +221,7 @@ class CommandCenterController: ObservableObject {
     }
 
     private func handleAppResignedActive() {
-        switch CommandCenterChatRule.focusLoss(mode: currentMode, chatHasMessages: chatHasMessages) {
+        switch CommandCenterChatRule.focusLoss(mode: currentMode, chatHasContent: chatHasContent) {
         case .dismiss:
             dismissPanel()
             return
@@ -257,7 +257,7 @@ class CommandCenterController: ObservableObject {
         case .chat:
             let chatView = CommandCenterChatView(
                 onDismiss: { [weak self] in self?.dismissPanel() },
-                onMessagesChanged: { [weak self] hasMessages in self?.chatHasMessages = hasMessages }
+                onContentChanged: { [weak self] hasContent in self?.chatHasContent = hasContent }
             )
             let hv = TransparentHostingView(rootView: chatView)
             hv.translatesAutoresizingMaskIntoConstraints = false
@@ -284,7 +284,7 @@ class CommandCenterController: ObservableObject {
             ])
 
             container.onClickEmptyArea = { [weak self] in
-                guard let self, !self.chatHasMessages else { return }
+                guard let self, !self.chatHasContent else { return }
                 dismissPanel()
             }
 
@@ -431,7 +431,7 @@ class CommandCenterController: ObservableObject {
                 Task { @MainActor in
                     guard let self, let panel = self.panel else { return }
                     // Don't dismiss on outside click when there are messages
-                    if self.chatHasMessages {
+                    if self.chatHasContent {
                         return
                     }
                     if !panel.frame.contains(screenPoint) {
@@ -478,7 +478,7 @@ class CommandCenterController: ObservableObject {
         panel = nil
         isVisible = false
         currentMode = nil
-        chatHasMessages = false
+        chatHasContent = false
         if !preserveRecordingState {
             activeRecordingMeetingID = nil
             tearDownAppActiveObservers()

--- a/Logue/CrossApp/CommandCenterController.swift
+++ b/Logue/CrossApp/CommandCenterController.swift
@@ -115,6 +115,7 @@ class CommandCenterController: ObservableObject {
     private var escMonitor: Any?
     private var escLocalMonitor: Any?
     private var clickMonitor: Any?
+    private var clickLocalMonitor: Any?
     private var dismissObserver: NSObjectProtocol?
     private var chatHasContent: Bool = false
 
@@ -425,19 +426,18 @@ class CommandCenterController: ObservableObject {
         }
 
         if case .chat = mode {
+            // Same blind spot as Esc: a click on one of Logue's own windows is
+            // routed to us and never reaches a global monitor, so clicking the main
+            // window beside the island left it sitting there. Watch both sides.
             clickMonitor = NSEvent.addGlobalMonitorForEvents(matching: .leftMouseDown) { [weak self] event in
-                let clickLocation = event.locationInWindow
-                let screenPoint = event.window?.convertPoint(toScreen: clickLocation) ?? clickLocation
-                Task { @MainActor in
-                    guard let self, let panel = self.panel else { return }
-                    // Don't dismiss on outside click when there are messages
-                    if self.chatHasContent {
-                        return
-                    }
-                    if !panel.frame.contains(screenPoint) {
-                        self.dismissPanel()
-                    }
-                }
+                let screenPoint = Self.screenPoint(for: event)
+                Task { @MainActor in self?.dismissIfClickMissedPanel(screenPoint) }
+            }
+
+            clickLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseDown) { [weak self] event in
+                let screenPoint = Self.screenPoint(for: event)
+                Task { @MainActor in self?.dismissIfClickMissedPanel(screenPoint) }
+                return event
             }
         }
 
@@ -446,6 +446,20 @@ class CommandCenterController: ObservableObject {
         ) { [weak self] _ in
             Task { @MainActor in self?.dismissPanel() }
         }
+    }
+
+    /// Where a click landed, in screen coordinates. Events from a global monitor
+    /// carry no window and are already in screen space.
+    private static func screenPoint(for event: NSEvent) -> NSPoint {
+        guard let window = event.window else { return event.locationInWindow }
+        return window.convertPoint(toScreen: event.locationInWindow)
+    }
+
+    /// Puts an empty chat island away when a click lands anywhere but on it. An
+    /// island holding a conversation or an unsent prompt stays.
+    private func dismissIfClickMissedPanel(_ screenPoint: NSPoint) {
+        guard let panel, !chatHasContent, !panel.frame.contains(screenPoint) else { return }
+        dismissPanel()
     }
 
     // MARK: - Dismiss
@@ -460,6 +474,9 @@ class CommandCenterController: ObservableObject {
         }
         if let monitor = clickMonitor {
             NSEvent.removeMonitor(monitor); clickMonitor = nil
+        }
+        if let monitor = clickLocalMonitor {
+            NSEvent.removeMonitor(monitor); clickLocalMonitor = nil
         }
         if let observer = dismissObserver {
             NotificationCenter.default.removeObserver(observer); dismissObserver = nil

--- a/Logue/CrossApp/CommandCenterController.swift
+++ b/Logue/CrossApp/CommandCenterController.swift
@@ -133,9 +133,16 @@ class CommandCenterController: ObservableObject {
     /// Summons the chat island, or dismisses it when it is already up, so the
     /// activation shortcut is the same key that puts it away again.
     func toggleChatPanel() {
-        switch CommandCenterChatRule.trigger(mode: currentMode, isShowingPanel: panel != nil) {
+        switch CommandCenterChatRule.trigger(
+            mode: currentMode,
+            isShowingPanel: panel != nil,
+            isChatBehindOtherApps: panel?.level == .normal
+        ) {
         case .dismiss:
             dismissPanel()
+            return
+        case .raise:
+            raiseChatPanel()
             return
         case .replace:
             dismissPanel()
@@ -146,6 +153,17 @@ class CommandCenterController: ObservableObject {
         chatHasContent = false
         createPanel(mode: .chat)
         setupAppActiveObservers()
+    }
+
+    /// Brings an island that was sent behind other apps back to the front, with
+    /// whatever was typed into it still there. Reached from the shortcut while
+    /// another app is frontmost, where nothing else would re-promote it.
+    private func raiseChatPanel() {
+        guard let panel else { return }
+        panel.level = .floating
+        panel.orderFrontRegardless()
+        panel.makeKey()
+        NSApp.activate(ignoringOtherApps: true)
     }
 
     func showRecordingPanel(meetingID: UUID) {

--- a/Logue/CrossApp/CommandCenterController.swift
+++ b/Logue/CrossApp/CommandCenterController.swift
@@ -107,9 +107,13 @@ private class TransparentContainerView: NSView {
 class CommandCenterController: ObservableObject {
     @Published var isVisible: Bool = false
 
+    /// Virtual key code for Escape.
+    private static let escapeKeyCode: UInt16 = 53
+
     private var panel: CommandCenterPanel?
     private var currentMode: CommandCenterMode?
     private var escMonitor: Any?
+    private var escLocalMonitor: Any?
     private var clickMonitor: Any?
     private var dismissObserver: NSObjectProtocol?
     private var chatHasMessages: Bool = false
@@ -388,10 +392,19 @@ class CommandCenterController: ObservableObject {
     // MARK: - Monitors
 
     private func setupMonitors(mode: CommandCenterMode) {
+        // A global monitor never sees events routed to our own app, and the panel
+        // is made key on creation — so Esc also needs a local monitor, or it only
+        // works while some other app is frontmost.
         escMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
-            if event.keyCode == 53 {
+            if event.keyCode == Self.escapeKeyCode {
                 Task { @MainActor in self?.dismissPanel() }
             }
+        }
+
+        escLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            guard event.keyCode == Self.escapeKeyCode, let self, panel?.isKeyWindow == true else { return event }
+            dismissPanel()
+            return nil
         }
 
         if case .chat = mode {
@@ -424,6 +437,9 @@ class CommandCenterController: ObservableObject {
     private func removeMonitors() {
         if let monitor = escMonitor {
             NSEvent.removeMonitor(monitor); escMonitor = nil
+        }
+        if let monitor = escLocalMonitor {
+            NSEvent.removeMonitor(monitor); escLocalMonitor = nil
         }
         if let monitor = clickMonitor {
             NSEvent.removeMonitor(monitor); clickMonitor = nil

--- a/Logue/Views/CrossApp/CommandCenterChatView.swift
+++ b/Logue/Views/CrossApp/CommandCenterChatView.swift
@@ -27,7 +27,7 @@ struct EphemeralChatMessage: Identifiable, Equatable {
 /// Prompt pill at bottom, messages float above with glass backdrop.
 struct CommandCenterChatView: View {
     let onDismiss: () -> Void
-    let onMessagesChanged: (Bool) -> Void
+    let onContentChanged: (Bool) -> Void
 
     @State private var messages: [EphemeralChatMessage] = []
     @State private var inputText: String = ""
@@ -44,6 +44,12 @@ struct CommandCenterChatView: View {
     }
 
     private let pillWidth: CGFloat = 740
+
+    /// Whether the island is holding anything the user would miss — a sent
+    /// conversation, or a prompt typed but not sent yet.
+    private var hasContent: Bool {
+        !messages.isEmpty || !inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -76,7 +82,10 @@ struct CommandCenterChatView: View {
             synthesizer.stopSpeaking(at: .immediate)
         }
         .onChange(of: messages.count) { _, _ in
-            onMessagesChanged(!messages.isEmpty)
+            onContentChanged(hasContent)
+        }
+        .onChange(of: inputText) { _, _ in
+            onContentChanged(hasContent)
         }
         // U7: Replaced continuous Timer.publish with onChange-triggered task
         .onChange(of: speakingMessageID) { _, newValue in

--- a/Logue/Views/CrossApp/CommandCenterChatView.swift
+++ b/Logue/Views/CrossApp/CommandCenterChatView.swift
@@ -27,7 +27,7 @@ struct EphemeralChatMessage: Identifiable, Equatable {
 /// Prompt pill at bottom, messages float above with glass backdrop.
 struct CommandCenterChatView: View {
     let onDismiss: () -> Void
-    let onContentChanged: (Bool) -> Void
+    let onContentChanged: (CommandCenterChatContent) -> Void
 
     @State private var messages: [EphemeralChatMessage] = []
     @State private var inputText: String = ""
@@ -45,10 +45,11 @@ struct CommandCenterChatView: View {
 
     private let pillWidth: CGFloat = 740
 
-    /// Whether the island is holding anything the user would miss — a sent
-    /// conversation, or a prompt typed but not sent yet.
-    private var hasContent: Bool {
-        !messages.isEmpty || !inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    private var content: CommandCenterChatContent {
+        CommandCenterChatContent(
+            hasMessages: !messages.isEmpty,
+            hasDraft: !inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        )
     }
 
     var body: some View {
@@ -82,10 +83,10 @@ struct CommandCenterChatView: View {
             synthesizer.stopSpeaking(at: .immediate)
         }
         .onChange(of: messages.count) { _, _ in
-            onContentChanged(hasContent)
+            onContentChanged(content)
         }
         .onChange(of: inputText) { _, _ in
-            onContentChanged(hasContent)
+            onContentChanged(content)
         }
         // U7: Replaced continuous Timer.publish with onChange-triggered task
         .onChange(of: speakingMessageID) { _, newValue in

--- a/LogueTests/CommandCenterChatRuleTests.swift
+++ b/LogueTests/CommandCenterChatRuleTests.swift
@@ -96,4 +96,28 @@ struct CommandCenterChatRuleTests {
     func focusLossIgnoresIdle() {
         #expect(CommandCenterChatRule.focusLoss(mode: nil, chatHasContent: false) == nil)
     }
+
+    // MARK: - What the island is holding
+
+    @Test("An island is empty only with neither a conversation nor a draft")
+    func contentIsEmptyOnlyWhenBothAreAbsent() {
+        #expect(CommandCenterChatContent(hasMessages: false, hasDraft: false).isEmpty)
+        #expect(!CommandCenterChatContent(hasMessages: true, hasDraft: false).isEmpty)
+        #expect(!CommandCenterChatContent(hasMessages: false, hasDraft: true).isEmpty)
+        #expect(!CommandCenterChatContent(hasMessages: true, hasDraft: true).isEmpty)
+    }
+
+    @Test("A draft survives an app switch but not a deliberate dismissal")
+    func draftIsProtectedFromFocusLossOnly() {
+        let draftOnly = CommandCenterChatContent(hasMessages: false, hasDraft: true)
+
+        // Switching apps is not a decision about the island, so it keeps the draft.
+        #expect(CommandCenterChatRule.focusLoss(mode: .chat, chatHasContent: !draftOnly.isEmpty)
+            == .sendBehindOtherApps)
+
+        // Clicking off it is such a decision, and has always discarded an unsent
+        // prompt. Protecting the draft here would leave an island with no visible
+        // way out — the close button only exists once there are messages.
+        #expect(!draftOnly.hasMessages)
+    }
 }

--- a/LogueTests/CommandCenterChatRuleTests.swift
+++ b/LogueTests/CommandCenterChatRuleTests.swift
@@ -39,25 +39,27 @@ struct CommandCenterChatRuleTests {
 
     // MARK: - Focus loss
 
-    @Test("Switching apps closes an island nothing was said to")
+    @Test("Switching apps closes an empty island")
     func focusLossDismissesEmptyChat() {
-        #expect(CommandCenterChatRule.focusLoss(mode: .chat, chatHasMessages: false) == .dismiss)
+        #expect(CommandCenterChatRule.focusLoss(mode: .chat, chatHasContent: false) == .dismiss)
     }
 
-    @Test("Switching apps keeps a conversation but stops it covering them")
-    func focusLossDemotesChatWithMessages() {
-        #expect(CommandCenterChatRule.focusLoss(mode: .chat, chatHasMessages: true) == .sendBehindOtherApps)
+    @Test("Switching apps keeps what the island holds but stops it covering them")
+    func focusLossDemotesChatWithContent() {
+        // Content is a sent conversation or a prompt typed and not sent — the view
+        // reports either, so switching apps mid-sentence cannot throw the draft away.
+        #expect(CommandCenterChatRule.focusLoss(mode: .chat, chatHasContent: true) == .sendBehindOtherApps)
     }
 
     @Test("The recording island is left alone")
     func focusLossIgnoresRecording() {
         let recording = CommandCenterMode.recording(meetingID: UUID())
 
-        #expect(CommandCenterChatRule.focusLoss(mode: recording, chatHasMessages: false) == nil)
+        #expect(CommandCenterChatRule.focusLoss(mode: recording, chatHasContent: false) == nil)
     }
 
     @Test("Nothing showing means nothing to do")
     func focusLossIgnoresIdle() {
-        #expect(CommandCenterChatRule.focusLoss(mode: nil, chatHasMessages: false) == nil)
+        #expect(CommandCenterChatRule.focusLoss(mode: nil, chatHasContent: false) == nil)
     }
 }

--- a/LogueTests/CommandCenterChatRuleTests.swift
+++ b/LogueTests/CommandCenterChatRuleTests.swift
@@ -5,28 +5,58 @@ import Testing
 /// The chat island's lifecycle rules — issue #46.
 ///
 /// Reported as "the Ask Logue bar never closes, and sits over every other app".
-/// Each of the three causes has a test here: the shortcut rebuilt the island
-/// instead of closing it, and losing frontmost status meant nothing at all to a
-/// chat island, whether or not anything had been said to it.
+/// These cover the two decisions that were wrong and are expressible without
+/// AppKit: what the shortcut does to a showing island, and what losing frontmost
+/// status means to one. The rest of the fix — panel identity through the close
+/// animation, and monitor add/remove symmetry — lives in the controller and is
+/// not reachable from here.
 @Suite("Command Center chat rules")
 struct CommandCenterChatRuleTests {
     // MARK: - Trigger
 
-    @Test("The shortcut closes a chat island that is already up")
+    @Test("The shortcut closes a chat island that is up in front")
     func triggerDismissesShowingChat() {
-        #expect(CommandCenterChatRule.trigger(mode: .chat, isShowingPanel: true) == .dismiss)
+        #expect(
+            CommandCenterChatRule.trigger(mode: .chat, isShowingPanel: true, isChatBehindOtherApps: false)
+                == .dismiss
+        )
+    }
+
+    @Test("The shortcut brings back an island sent behind other apps")
+    func triggerRaisesDemotedChat() {
+        // Pressing the shortcut from another app is how you ask for the island
+        // back. Dismissing it there would destroy an unsent prompt and show
+        // nothing in its place — the reported symptom, reintroduced.
+        #expect(
+            CommandCenterChatRule.trigger(mode: .chat, isShowingPanel: true, isChatBehindOtherApps: true)
+                == .raise
+        )
     }
 
     @Test("The shortcut opens the chat island when nothing is up")
     func triggerPresentsWhenIdle() {
-        #expect(CommandCenterChatRule.trigger(mode: nil, isShowingPanel: false) == .present)
+        #expect(
+            CommandCenterChatRule.trigger(mode: nil, isShowingPanel: false, isChatBehindOtherApps: false)
+                == .present
+        )
     }
 
     @Test("The recording island gives way to the chat island")
     func triggerReplacesRecording() {
         let recording = CommandCenterMode.recording(meetingID: UUID())
 
-        #expect(CommandCenterChatRule.trigger(mode: recording, isShowingPanel: true) == .replace)
+        #expect(
+            CommandCenterChatRule.trigger(mode: recording, isShowingPanel: true, isChatBehindOtherApps: false)
+                == .replace
+        )
+    }
+
+    @Test("A panel with no mode is replaced rather than left alone")
+    func triggerReplacesWhenModeIsMissing() {
+        #expect(
+            CommandCenterChatRule.trigger(mode: nil, isShowingPanel: true, isChatBehindOtherApps: false)
+                == .replace
+        )
     }
 
     @Test("A stale mode with no panel still opens one")
@@ -34,7 +64,10 @@ struct CommandCenterChatRuleTests {
         // The mode is cleared after the close animation, so a trigger can arrive
         // while it still reads .chat with nothing on screen. Dismissing then would
         // be a shortcut that does nothing.
-        #expect(CommandCenterChatRule.trigger(mode: .chat, isShowingPanel: false) == .present)
+        #expect(
+            CommandCenterChatRule.trigger(mode: .chat, isShowingPanel: false, isChatBehindOtherApps: false)
+                == .present
+        )
     }
 
     // MARK: - Focus loss
@@ -51,11 +84,12 @@ struct CommandCenterChatRuleTests {
         #expect(CommandCenterChatRule.focusLoss(mode: .chat, chatHasContent: true) == .sendBehindOtherApps)
     }
 
-    @Test("The recording island is left alone")
+    @Test("The recording island is left alone whatever the chat island holds")
     func focusLossIgnoresRecording() {
         let recording = CommandCenterMode.recording(meetingID: UUID())
 
         #expect(CommandCenterChatRule.focusLoss(mode: recording, chatHasContent: false) == nil)
+        #expect(CommandCenterChatRule.focusLoss(mode: recording, chatHasContent: true) == nil)
     }
 
     @Test("Nothing showing means nothing to do")

--- a/LogueTests/CommandCenterChatRuleTests.swift
+++ b/LogueTests/CommandCenterChatRuleTests.swift
@@ -1,0 +1,63 @@
+import Foundation
+@testable import Logue
+import Testing
+
+/// The chat island's lifecycle rules — issue #46.
+///
+/// Reported as "the Ask Logue bar never closes, and sits over every other app".
+/// Each of the three causes has a test here: the shortcut rebuilt the island
+/// instead of closing it, and losing frontmost status meant nothing at all to a
+/// chat island, whether or not anything had been said to it.
+@Suite("Command Center chat rules")
+struct CommandCenterChatRuleTests {
+    // MARK: - Trigger
+
+    @Test("The shortcut closes a chat island that is already up")
+    func triggerDismissesShowingChat() {
+        #expect(CommandCenterChatRule.trigger(mode: .chat, isShowingPanel: true) == .dismiss)
+    }
+
+    @Test("The shortcut opens the chat island when nothing is up")
+    func triggerPresentsWhenIdle() {
+        #expect(CommandCenterChatRule.trigger(mode: nil, isShowingPanel: false) == .present)
+    }
+
+    @Test("The recording island gives way to the chat island")
+    func triggerReplacesRecording() {
+        let recording = CommandCenterMode.recording(meetingID: UUID())
+
+        #expect(CommandCenterChatRule.trigger(mode: recording, isShowingPanel: true) == .replace)
+    }
+
+    @Test("A stale mode with no panel still opens one")
+    func triggerPresentsWhenModeOutlivesPanel() {
+        // The mode is cleared after the close animation, so a trigger can arrive
+        // while it still reads .chat with nothing on screen. Dismissing then would
+        // be a shortcut that does nothing.
+        #expect(CommandCenterChatRule.trigger(mode: .chat, isShowingPanel: false) == .present)
+    }
+
+    // MARK: - Focus loss
+
+    @Test("Switching apps closes an island nothing was said to")
+    func focusLossDismissesEmptyChat() {
+        #expect(CommandCenterChatRule.focusLoss(mode: .chat, chatHasMessages: false) == .dismiss)
+    }
+
+    @Test("Switching apps keeps a conversation but stops it covering them")
+    func focusLossDemotesChatWithMessages() {
+        #expect(CommandCenterChatRule.focusLoss(mode: .chat, chatHasMessages: true) == .sendBehindOtherApps)
+    }
+
+    @Test("The recording island is left alone")
+    func focusLossIgnoresRecording() {
+        let recording = CommandCenterMode.recording(meetingID: UUID())
+
+        #expect(CommandCenterChatRule.focusLoss(mode: recording, chatHasMessages: false) == nil)
+    }
+
+    @Test("Nothing showing means nothing to do")
+    func focusLossIgnoresIdle() {
+        #expect(CommandCenterChatRule.focusLoss(mode: nil, chatHasMessages: false) == nil)
+    }
+}


### PR DESCRIPTION
Fixes #46.

## What was reported

The Ask Logue bar stayed on screen over every other app, and `Cmd+Shift+W` did
nothing to put it away. Separately: clicking outside it dismissed it sometimes
and did nothing other times, and it could reach a state where quitting Logue was
the only way to get rid of it.

## Why it happened

**The shortcut rebuilt the island instead of closing it.** `showChatPanel` tore
the panel down and immediately built a new one, so pressing the shortcut on a
showing island just blinked it.

**That rebuild then stranded the panel.** Dismissal is animated, and the
completion handler ran ~0.15s later against whatever `panel` pointed at *by
then* — the replacement. It cleared the state describing a live window, and from
that moment every route out died at once: `dismissPanel` returned early on the
nil reference, so Esc, the close button and the click-outside handler were all
dead, and each further press stacked another orphan. This is both the "never
closes" in the title and the "only quitting the app clears it".

**Esc and click-outside could not see their events.** Both were watched with
global monitors only, and a global monitor never receives events routed to our
own app. Creating the panel makes it key and activates Logue, so Esc was
guaranteed not to work right after summoning it, and clicking Logue's own window
beside the island did nothing while clicking another app worked.

**Nothing watched activation for chat.** The app-active observers were only
installed for the recording island. The chat island is created at the floating
level with `hidesOnDeactivate` off and `canJoinAllSpaces` on — right for a
recording island, wrong for a prompt bar — so it sat above everything until
Logue was quit or hidden.

## What changed

- Dismissal is atomic: `relinquishPanel()` clears every piece of state describing
  the panel and hands it back to be animated away, so a dying panel can never be
  mistaken for a live one.
- The shortcut dismisses an island that is up in front, and *raises* one that was
  sent behind other apps rather than destroying it.
- Esc and click-outside are watched globally *and* locally, so they behave the
  same whichever app is frontmost. Local monitors are chat-only; the recording
  island keeps the behaviour it had.
- Losing frontmost status is now meaningful to the chat island: an empty one is
  discarded, matching what a click outside it does.

## What the island protects, and from what

The two are deliberately not the same promise:

- **A conversation** must survive a stray click off the island. Unchanged.
- **An unsent prompt** survives switching apps — you are coming back to it — but
  not Esc, the close button, the shortcut or a click off the island, which are
  all decisions to put the island away and have always discarded it.

Collapsing those into one flag was tried and reverted: it left a draft-only
island with no way out at all, and turned the transparent region above the pill
into a dead zone. The container now asks whether a click is its own before
claiming it during hit testing, so clicks it will not act on pass through.

## Tests

The decisions that were wrong lived inside the window code, where no test could
reach them. They are now `CommandCenterChatRule`, which knows nothing about
`NSPanel` — the same pure-rules pattern as `ExternalChangePlan` and
`SpaceFolderAdoption`.

- 10 rule tests over the trigger, focus-loss and content matrices
- Full non-LLM suite green: 900 tests in 77 suites
- SwiftFormat and SwiftLint `--strict` run locally against the pinned CI
  versions (0.62.1 / 0.65.0): clean

## Checked by hand, not covered by tests

The AppKit half — window level changes, monitor lifetime, panel identity — is
not reachable from the test target. Worth a reviewer's eye on the recording
island, which shares `dismissPanel` and the activation observers with chat.

Known and deliberately not addressed here: a transient deactivation such as a
first-run microphone permission prompt will dismiss an empty island, and key
codes are still spelled three ways across `CommandCenterController`,
`ShortcutManager` and `AppDelegate`. Both deserve their own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01565d5yT4e5oTCNdxdWvtVP