### PR TITLE
ci: pin every runner to macOS 26 instead of tracking macos-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,16 @@ permissions:
 jobs:
   lint-check:
     name: Lint Check
-    runs-on: macos-latest
+    # Pinned for the same reason the tool versions below are: `macos-latest` is an alias
+    # GitHub repoints to a new major macOS on its own schedule, which would move this job
+    # off the runner the Build job uses without anything in the repo changing. It already
+    # had: the alias now serves macOS 26 while Build was pinned to 15.
+    #
+    # Pinned forward to 26 rather than back to 15, because 26 is what the app targets
+    # (`project.yml`: deploymentTarget 26.0, xcodeVersion 26.0) and what this job has
+    # been running on in practice. Bump all three `runs-on` pins together and
+    # deliberately: this job, Build below, and release.yml.
+    runs-on: macos-26
 
     steps:
       - name: Checkout Repository
@@ -73,7 +82,8 @@ jobs:
 
   build:
     name: Build
-    runs-on: macos-15
+    # One of the three pins — see the Lint Check job above.
+    runs-on: macos-26
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,9 +52,10 @@ env:
 jobs:
   build-and-release:
     name: Build, Sign, Notarize, Release
-    # GitHub-hosted runner (matches CI). Swap to a self-hosted runner if your
-    # required Xcode/SDK isn't available on the hosted image.
-    runs-on: macos-15
+    # GitHub-hosted runner. The third of the three pins — see the Lint Check job in
+    # ci.yml for why they are pinned and why to 26. Swap to a self-hosted runner if
+    # your required Xcode/SDK isn't available on the hosted image.
+    runs-on: macos-26
     timeout-minutes: 90
 
     steps:


### PR DESCRIPTION
Lint ran on `macos-latest` while Build and the release job pinned `macos-15`. That alias is
repointed to a new major macOS on GitHub's own schedule, so the jobs drift onto different
runners without anything in this repo changing — and the first sign of it would be a lint
failure nobody could reproduce locally.

**Revised after review** ([#discussion_r3763831165](https://github.com/bitwize-ai/Logue/pull/53#discussion_r3763831165)): the drift was not hypothetical, and this PR now pins *forward* rather than back.

## The split already existed

On the last `main` run before this branch ([31033559846](https://github.com/bitwize-ai/Logue/actions/runs/31033559846)), the Lint job log reads `Image: macos-26-arm64` while Build ran macOS 15. The alias had already moved; the two jobs were already on different major OSes.

The first version of this PR would have closed that gap by moving Lint *backwards* onto
macOS 15 — on a project whose `project.yml` sets `deploymentTarget.macOS: "26.0"` and
`xcodeVersion: "26.0"`, and with nothing scheduled to catch macOS 15's retirement. Same
determinism, but onto N-1.

So all three pins now say `macos-26`: the OS the app targets, and the image Lint has been
running on in practice.

## All three, not two

There are three `runs-on` pins, and the comment now names each of them so a future bump
moves them together:

| Job | File |
| --- | --- |
| Lint Check | `.github/workflows/ci.yml` |
| Build | `.github/workflows/ci.yml` |
| Build, Sign, Notarize, Release | `.github/workflows/release.yml` |

Leaving the signing/notarizing release build on a stale image would have reintroduced
exactly the split this change exists to remove.

## No cost change

`macos-26` is a standard GitHub-hosted runner — [the runner-images table](https://github.com/actions/runner-images#available-images) lists `macos-latest`, `macos-26` and `macos-26-xlarge` against macOS 26 Arm64, and only the `-large`/`-xlarge` variants are the paid ones. Per [GitHub's docs](https://docs.github.com/en/actions/reference/runners/github-hosted-runners):

> Use of the standard GitHub-hosted runners is free and unlimited on public repositories.

This repo is public, and the timing API confirms it directly for this image: run
31033559846 reports `"MACOS": {"total_ms": 0}`, including the Lint job that ran on
`macos-26-arm64`.

## Xcode on the new image

Both build jobs already select the newest installed Xcode rather than the image default
(the default was too old for the macOS 26 SDK and did not support `xcodebuild
-downloadComponent`). `macos-26-arm64` ships Xcode 26.0.1 through 26.6 with no Xcode 27
preview installed, so that step resolves to 26.6 — newer than the 26.3 the jobs were
picking up on macOS 15.

## Verification

- YAML parses; all three jobs resolve to `macos-26`.
- CI runs against this PR, which exercises the changed runner directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
