### PR TITLE
ci(release): keep pre-release tags out of the appcast

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,19 @@ jobs:
             VERSION="${GITHUB_REF#refs/tags/v}"
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "Building version: $VERSION"
+
+          # Decided once, here, so the GitHub Release flag and the appcast step cannot
+          # disagree about what a pre-release is. A version carrying a `-rc` or `-beta`
+          # suffix is a build for testing: it gets a GitHub Release so it can be
+          # downloaded, and it must NOT reach `appcast.xml`, which is the file every
+          # installed copy polls for updates.
+          if [[ "$VERSION" == *-rc* || "$VERSION" == *-beta* ]]; then
+            PRERELEASE=true
+          else
+            PRERELEASE=false
+          fi
+          echo "prerelease=$PRERELEASE" >> "$GITHUB_OUTPUT"
+          echo "Building version: $VERSION (prerelease: $PRERELEASE)"
 
       # ── Select latest Xcode ───────────────────────────────
       # The default Xcode on the hosted image is too old for the macOS 26 SDK
@@ -501,7 +513,7 @@ jobs:
           name: "Logue ${{ steps.version.outputs.version }}"
           body_path: /tmp/release_body.md
           draft: false
-          prerelease: ${{ contains(steps.version.outputs.version, 'beta') || contains(steps.version.outputs.version, 'rc') }}
+          prerelease: ${{ steps.version.outputs.prerelease }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -509,7 +521,12 @@ jobs:
       # The appcast MUST be regenerated on top of the base branch's current appcast,
       # not the tag's stale copy. Otherwise the 2nd+ release drops earlier entries and
       # `git checkout origin/main` aborts on the dirty working-tree appcast.xml.
+      # Skipped for pre-releases. `SUFeedURL` points at `appcast.xml` on `main`, so an
+      # entry landing there is offered to every installed copy — which is exactly what a
+      # build cut for testing must not do. Gating the step, rather than relying on someone
+      # remembering not to merge the PR it opens, is what makes that true.
       - name: Update appcast and open PR
+        if: steps.version.outputs.prerelease != 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -313,4 +313,27 @@ because nothing can infer them:
 release. It answers "what is this app for", not "what changed", and a newcomer handed the
 upgrade deck gets a dozen cards of features they have no context for yet.
 
+### Cutting a build for testing
+
+Tag `vX.Y.Z-rc.N` (or `-beta.N`) instead. The workflow builds, signs and notarizes it
+exactly as it would a real release and publishes it to GitHub Releases marked as a
+pre-release — but it **skips the appcast step**, so nothing is offered to installed copies.
+
+That skip is the whole point, and it is structural rather than remembered: `SUFeedURL`
+points at `appcast.xml` on `main`, so an entry landing there reaches every existing user.
+The version step decides pre-release once and both the GitHub Release flag and the appcast
+gate read that one value, so they cannot drift apart.
+
+Two things follow from the suffix:
+
+- **Leave `## [Unreleased]` where it is.** No `## [X.Y.Z-rc.N]` section exists, so the
+  extractor falls back to `[Unreleased]` — which is what the build is testing. Move it into
+  a versioned section when cutting the real release, not before.
+- **`AppVersion` orders `1.1.0-rc.1` as `1.1.0`.** The What's New pane therefore shows the
+  1.1.0 cards in the RC, which is what makes them testable — and a tester who has seen them
+  is not shown them again on the final build.
+
+Testers install the RC by downloading it from its GitHub Release. It will not auto-update
+to itself, and it *will* be offered the real release when that ships.
+
 Full runbook, including screenshots and the version stamp: **[docs/WHATS_NEW.md](docs/WHATS_NEW.md)**.


### PR DESCRIPTION
## Why

`SUFeedURL` points at `appcast.xml` on `main`. Anything that lands in that file is offered to every installed copy of Logue, by every running Sparkle check.

The workflow already marked `-rc` and `-beta` builds as GitHub pre-releases — but it still ran the appcast step for them. It opens a PR rather than pushing, so nothing leaked automatically, but the only thing standing between a build cut for testing and every user's update prompt was somebody remembering not to merge that PR.

## What changed

- **The appcast step is skipped for pre-release tags.** A pre-release now cannot reach the feed even if the PR were merged, because the PR is never opened.
- **Pre-release is decided once**, in the version step, and both the GitHub Release flag and the appcast gate read that single output. They were two separate copies of the same `contains(...)` expression, which is exactly how two conditions drift into disagreeing.

Nothing about a real `vX.Y.Z` release changes: `prerelease` evaluates false and the appcast PR opens as before.

## Runbook

`CLAUDE.md` gains a "Cutting a build for testing" section covering the two things that are non-obvious:

- **Leave `## [Unreleased]` in place for an RC.** No `## [X.Y.Z-rc.N]` section exists, so the extractor falls back to `[Unreleased]` — which is the content the build is testing. It moves into a versioned section when the real release is cut.
- **`AppVersion` orders `1.1.0-rc.1` as `1.1.0`.** So the What's New cards are visible in the RC, which is what makes them testable, and a tester who has seen them is not shown them again on the final build.

## Verification

`release.yml` parses as YAML. The gate is a step-level `if`, so the rest of the job — build, sign, notarize, publish — is untouched for both kinds of tag.

Not exercised end to end: that needs a tag push, which is the thing this PR exists to make safe. The intended first use is `v1.1.0-rc.1`.
