### PR TITLE
Ask Logue part 2: put the Command Center island on the shared agent loop

### DIFF
--- a/Logue.xcodeproj/project.pbxproj
+++ b/Logue.xcodeproj/project.pbxproj
@@ -343,6 +343,7 @@
 		772606DB94721219B135F7FA /* WeeklyActivityChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 707917F76D5706DB3B72EB07 /* WeeklyActivityChart.swift */; };
 		784D6D17FB7448EB715CD529 /* HighlightAnchor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D7288BD26E235EF2434855B /* HighlightAnchor.swift */; };
 		79784E41E35CF492424E5E02 /* BrowserBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DF44F4AF480BE5D761ACE31 /* BrowserBridgeTests.swift */; };
+		7978A00C56B10809E1BFBD1C /* AgentRunState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62CA343B98C1F62D9F89B0B6 /* AgentRunState.swift */; };
 		7A30C41E7B8898E2FF5CA750 /* TemplateStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 851703C5995A9B2FA0C07975 /* TemplateStore.swift */; };
 		7A79E80EA56AABEECB3D5DED /* MeetingNote.swift in Sources */ = {isa = PBXBuildFile; fileRef = D928297CC59CB70B20090442 /* MeetingNote.swift */; };
 		7B000982F90A41A9148CD0F7 /* AnthropicClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80F43E54BB04A47E0876AED0 /* AnthropicClient.swift */; };
@@ -461,6 +462,7 @@
 		A9B34E653A84128492DE6474 /* BlockRowView+Actions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FB93A6E198E565413AD03FC /* BlockRowView+Actions.swift */; };
 		A9C752BABC79AFFA2C4FD4F2 /* RecordingSpliceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94CFFCAEABE322C125D85AF3 /* RecordingSpliceTests.swift */; };
 		AA1456FCC75FBB7DFEFC1BE0 /* SpaceFileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 382510F54B865B60B16FDE73 /* SpaceFileTests.swift */; };
+		AAEF3C6465DC0A9EA911FE93 /* AgentRunStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86029AD56EBB4317FFDFB4E4 /* AgentRunStateTests.swift */; };
 		AB209D330BE40FEB735204C7 /* MermaidRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCEE1CC67630CF84E03498D5 /* MermaidRenderer.swift */; };
 		AB5ECDB7A635C2DB974F908D /* SeedDataBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9478E4D1E64E36CDE232568E /* SeedDataBannerView.swift */; };
 		ABEB7317A02B279F22E9AB8E /* SpaceContentTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08FACCA64C397DACFD78CE8C /* SpaceContentTypes.swift */; };
@@ -951,6 +953,7 @@
 		62246A7C11F1053FFF4915E4 /* TaskListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskListView.swift; sourceTree = "<group>"; };
 		6253F68F7BEF5952530CDA76 /* CodeBlockLanguageMemory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeBlockLanguageMemory.swift; sourceTree = "<group>"; };
 		62A5299B26C4D742EB7BABD3 /* SpaceFolderLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceFolderLayoutTests.swift; sourceTree = "<group>"; };
+		62CA343B98C1F62D9F89B0B6 /* AgentRunState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRunState.swift; sourceTree = "<group>"; };
 		6392D9C30DCF6BDFC18DCF63 /* WikiLinkStylingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WikiLinkStylingTests.swift; sourceTree = "<group>"; };
 		63AC1DBC374C162B470E69D4 /* RecentContentPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentContentPane.swift; sourceTree = "<group>"; };
 		6405B6178237C69E2674D9E9 /* SystemAudioArmingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemAudioArmingTests.swift; sourceTree = "<group>"; };
@@ -1051,6 +1054,7 @@
 		840A12365F18257475A34827 /* QuickPromptChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickPromptChip.swift; sourceTree = "<group>"; };
 		84D22CFDEB9D3FC3A4805089 /* UICopy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UICopy.swift; sourceTree = "<group>"; };
 		851703C5995A9B2FA0C07975 /* TemplateStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateStore.swift; sourceTree = "<group>"; };
+		86029AD56EBB4317FFDFB4E4 /* AgentRunStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRunStateTests.swift; sourceTree = "<group>"; };
 		860DFF869B9C6C39BE468431 /* DiagnosticsReportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsReportTests.swift; sourceTree = "<group>"; };
 		865AE91088D3794F9C1CC457 /* CommandCenterChatRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandCenterChatRule.swift; sourceTree = "<group>"; };
 		86C6E3021828B2B8589C720A /* AskRoute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AskRoute.swift; sourceTree = "<group>"; };
@@ -1435,6 +1439,7 @@
 			children = (
 				79C6BA7C0C06C035AC3BFBD1 /* LLMIntegration */,
 				AC241A87AE9D64BF9E0D2B66 /* ActionItemInboxTests.swift */,
+				86029AD56EBB4317FFDFB4E4 /* AgentRunStateTests.swift */,
 				4F21C87791C6ECF443D14823 /* AppVersionTests.swift */,
 				0A4CB54883E92F9A6F98BE77 /* AskRouteTests.swift */,
 				2476E5FAF6705D05BF8C22F2 /* AudioFileChunkReaderTests.swift */,
@@ -2153,6 +2158,7 @@
 				363A3EDC8BB82CC18EB86C1C /* AgentChatState.swift */,
 				A488F97BC5DBB0C094B1C74F /* AgentCoordinator.swift */,
 				0027C5C3EE6CAEEB887EAEC7 /* AgentCoordinator+Approval.swift */,
+				62CA343B98C1F62D9F89B0B6 /* AgentRunState.swift */,
 				B1CF9F695CCB56896DC9A02C /* ApprovalGate.swift */,
 				86C6E3021828B2B8589C720A /* AskRoute.swift */,
 				4B2F874FCD0AF25F7B37D3FC /* MalformedToolCall.swift */,
@@ -2637,6 +2643,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C7E2AEAF97B253EDD23DA5B5 /* ActionItemInboxTests.swift in Sources */,
+				AAEF3C6465DC0A9EA911FE93 /* AgentRunStateTests.swift in Sources */,
 				B71E1192276BBC1904238D1A /* AppVersionTests.swift in Sources */,
 				85FB21E5E26B2D3D46093D47 /* AskRouteTests.swift in Sources */,
 				08CC77D0F8EB0A6EAB31D544 /* AudioFileChunkReaderTests.swift in Sources */,
@@ -2795,6 +2802,7 @@
 				F375EEE815F82028E8B21648 /* AgentCoordinator.swift in Sources */,
 				35592A04877BCC129AE90A1E /* AgentDictationService.swift in Sources */,
 				88A664FB0F648002373F7656 /* AgentReadAloudService.swift in Sources */,
+				7978A00C56B10809E1BFBD1C /* AgentRunState.swift in Sources */,
 				17F7BAF0DBA60523B8EFD5C7 /* AgentTool.swift in Sources */,
 				A8432BB73EAB05259ECC7E6E /* AgentToolSpec.swift in Sources */,
 				7B000982F90A41A9148CD0F7 /* AnthropicClient.swift in Sources */,

--- a/Logue/Agent/AgentCoordinator.swift
+++ b/Logue/Agent/AgentCoordinator.swift
@@ -12,16 +12,49 @@ final class AgentCoordinator {
 
     // MARK: - State
 
-    private(set) var isProcessing = false
-    private(set) var streamingText = ""
-    private(set) var isStreaming = false
-    private(set) var activeToolCalls: [AgentToolCall] = []
+    /// The live run, and which conversation it belongs to.
+    ///
+    /// These were five global flags. That was harmless while one surface existed, because
+    /// there was only ever one thread on screen. It stops being harmless the moment the
+    /// Command Center island runs the same loop: a run started there sets the same flags the
+    /// main window reads, and the island's spinner, streaming text and tool cards paint onto
+    /// whatever thread the main window happens to be showing.
+    ///
+    /// Reads are scoped — see `isProcessing(in:)` and friends — so a surface can only see its
+    /// own activity.
+    private(set) var run = AgentRunState()
 
-    /// Last conversation-level error surfaced to the UI. Cleared automatically on the
-    /// next `send`/`regenerate`, or explicitly via `dismissError()`.
-    /// Stays set even after `isStreaming` flips to false, so the UI can show a
-    /// persistent banner until the user acknowledges or sends again.
-    private(set) var lastError: String?
+    /// Whether *any* run is in flight, regardless of whose.
+    ///
+    /// For the coordinator's own re-entrancy guards, which are about the singleton being
+    /// busy rather than about a conversation. A surface asking "am I busy" wants
+    /// `isProcessing(in:)`; asking this instead is how the island would report the main
+    /// window's work as its own.
+    var isProcessingAnyConversation: Bool {
+        run.isProcessing
+    }
+
+    // MARK: - Scoped reads
+
+    func isProcessing(in conversationID: UUID) -> Bool {
+        run.isProcessing(for: conversationID)
+    }
+
+    func isStreaming(in conversationID: UUID) -> Bool {
+        run.isStreaming(for: conversationID)
+    }
+
+    func streamingText(in conversationID: UUID) -> String {
+        run.streamingText(for: conversationID)
+    }
+
+    func lastError(in conversationID: UUID) -> String? {
+        run.lastError(for: conversationID)
+    }
+
+    func activeToolCalls(in conversationID: UUID) -> [AgentToolCall] {
+        run.activeToolCalls(for: conversationID)
+    }
 
     private var processingTask: Task<Void, Never>?
     private let logger = Logger(subsystem: AppConstants.bundleID, category: "AgentCoordinator")
@@ -222,8 +255,8 @@ final class AgentCoordinator {
         attachments: [TempAttachment] = [],
         oneShotWebSearch: Bool = false
     ) {
-        guard !isProcessing else { return }
-        lastError = nil
+        guard !isProcessingAnyConversation else { return }
+        run.dismissError()
         processingTask?.cancel()
         if oneShotWebSearch {
             setOneShotIncludeWebTools(true)
@@ -248,8 +281,8 @@ final class AgentCoordinator {
     }
 
     func sendWithoutAppendingUser(conversationID: UUID, oneShotWebSearch: Bool = false) {
-        guard !isProcessing else { return }
-        lastError = nil
+        guard !isProcessingAnyConversation else { return }
+        run.dismissError()
         processingTask?.cancel()
         if oneShotWebSearch {
             setOneShotIncludeWebTools(true)
@@ -269,7 +302,7 @@ final class AgentCoordinator {
 
     /// Clears the last surfaced error. Called when the user dismisses the error banner.
     func dismissError() {
-        lastError = nil
+        run.dismissError()
     }
 
     /// Regenerates the assistant response from an edited user message. Truncates every
@@ -277,8 +310,8 @@ final class AgentCoordinator {
     /// restarts the agent loop. If the coordinator is already processing, the request
     /// is ignored (UI should disable the edit affordance in that state).
     func regenerateFromUserMessage(messageID: UUID, in conversationID: UUID, newContent: String) {
-        guard !isProcessing else { return }
-        lastError = nil
+        guard !isProcessingAnyConversation else { return }
+        run.dismissError()
         processingTask?.cancel()
         // Resolve any dangling approvals before we overwrite the conversation tail.
         Task { await ApprovalGate.shared.rejectAllPending() }
@@ -294,10 +327,7 @@ final class AgentCoordinator {
     func cancel() {
         processingTask?.cancel()
         processingTask = nil
-        isProcessing = false
-        isStreaming = false
-        streamingText = ""
-        activeToolCalls = []
+        run.finish()
         // Belt-and-braces: if the cancelled Task hadn't reached its `defer` yet
         // (e.g. cancel landed before the Task's body started), the per-send web
         // override is still set. Drop it here so the next send isn't poisoned.
@@ -316,15 +346,9 @@ final class AgentCoordinator {
     // Orchestrates the full agent loop: streaming, node output handling, tool result posting, cleanup.
     // swiftlint:disable:next function_body_length cyclomatic_complexity
     private func runGraph(conversationID: UUID) async {
-        isProcessing = true
-        streamingText = ""
-        isStreaming = false
-        activeToolCalls = []
+        run.begin(conversationID: conversationID)
         defer {
-            isProcessing = false
-            isStreaming = false
-            streamingText = ""
-            activeToolCalls = []
+            run.finish()
             // Reset any per-send web-search override so the next regular send
             // doesn't accidentally inherit it (success, error, and cancellation
             // all flow through this defer).
@@ -386,8 +410,7 @@ final class AgentCoordinator {
         let threadId = conversationID.uuidString
 
         // Set up token-level streaming callback
-        isStreaming = true
-        streamingText = ""
+        run.beginStreaming()
         // Create placeholder for streaming reasoning
         store.appendMessage(AgentMessage(role: .assistant, content: ""), to: conversationID)
 
@@ -395,8 +418,8 @@ final class AgentCoordinator {
             onToken: { [weak self] token in
                 Task { @MainActor [weak self] in
                     guard let self else { return }
-                    streamingText += token
-                    store.updateLastAssistantMessage(in: conversationID, content: streamingText)
+                    run.appendToken(token)
+                    store.updateLastAssistantMessage(in: conversationID, content: run.streamingText)
                 }
             },
             onToolCall: { _ in
@@ -425,12 +448,12 @@ final class AgentCoordinator {
             )
         } catch {
             logger.error("Failed to start agent graph: \(error.localizedDescription)")
-            lastError = "Couldn't start the agent: \(error.localizedDescription)"
+            run.fail("Couldn't start the agent: \(error.localizedDescription)")
             store.updateLastAssistantMessage(
                 in: conversationID,
                 content: "I encountered an error starting the agent. Please try again."
             )
-            isStreaming = false
+            run.endStreaming()
             await AgentChatGraph.shared.clearCallbacks()
             return
         }
@@ -451,9 +474,9 @@ final class AgentCoordinator {
 
                     // Handle errors
                     if !error.isEmpty {
-                        lastError = error
+                        run.fail(error)
                         store.updateLastAssistantMessage(in: conversationID, content: error)
-                        isStreaming = false
+                        run.endStreaming()
                         await AgentChatGraph.shared.clearCallbacks()
                         store.persistConversation(conversationID)
                         return
@@ -461,18 +484,18 @@ final class AgentCoordinator {
 
                     if hasTools {
                         // Finalize the streaming reasoning text (if any) before tool cards
-                        if !streamingText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                            store.updateLastAssistantMessage(in: conversationID, content: streamingText)
+                        if !run.streamingText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                            store.updateLastAssistantMessage(in: conversationID, content: run.streamingText)
                         } else {
                             // Remove empty placeholder
                             store.removeLastAssistantMessage(from: conversationID)
                         }
                         // Reset streaming for next round
-                        streamingText = ""
+                        run.resetStreamingText()
                     } else {
                         // No tools — streaming text is the final answer
-                        if !streamingText.isEmpty {
-                            store.updateLastAssistantMessage(in: conversationID, content: streamingText)
+                        if !run.streamingText.isEmpty {
+                            store.updateLastAssistantMessage(in: conversationID, content: run.streamingText)
                         }
                         _ = reasoning // preserved intentionally — kept for future diagnostics
                     }
@@ -488,10 +511,10 @@ final class AgentCoordinator {
                     for result in newResults {
                         postToolResult(result, in: conversationID)
                     }
-                    activeToolCalls = []
+                    run.setActiveToolCalls([])
 
                     // Create new placeholder for next reasoning round
-                    streamingText = ""
+                    run.resetStreamingText()
                     store.appendMessage(AgentMessage(role: .assistant, content: ""), to: conversationID)
 
                 default:
@@ -500,15 +523,15 @@ final class AgentCoordinator {
             }
         } catch {
             logger.error("Agent graph stream error: \(error.localizedDescription)")
-            lastError = "Agent stream failed: \(error.localizedDescription)"
-            if streamingText.isEmpty {
+            run.fail("Agent stream failed: \(error.localizedDescription)")
+            if run.streamingText.isEmpty {
                 store.updateLastAssistantMessage(
                     in: conversationID, content: "I encountered an error. Please try again."
                 )
             }
         }
 
-        isStreaming = false
+        run.endStreaming()
         await AgentChatGraph.shared.clearCallbacks()
 
         // Clean up: if last assistant message is empty (no final answer), remove it

--- a/Logue/Agent/AgentRunState.swift
+++ b/Logue/Agent/AgentRunState.swift
@@ -72,6 +72,19 @@ struct AgentRunState {
         lastError = nil
     }
 
+    /// Stops streaming without ending the run.
+    ///
+    /// Separate from `finish()` because the graph stops streaming several times inside one
+    /// run — after each tool call, and on a recoverable error — and the run is still
+    /// processing. Collapsing the two would clear `isProcessing` mid-run and let a second
+    /// send start on top of the first.
+    ///
+    /// `streamingText` is deliberately left alone: the tokens streamed so far are what the
+    /// caller is about to commit as a message.
+    mutating func endStreaming() {
+        isStreaming = false
+    }
+
     /// Ends the run. Keeps `conversationID` and `lastError` so the owning surface
     /// can still show a banner for a run that has finished.
     mutating func finish() {

--- a/Logue/Agent/AgentRunState.swift
+++ b/Logue/Agent/AgentRunState.swift
@@ -1,0 +1,110 @@
+import Foundation
+
+/// The live state of one agent run, and which conversation it belongs to.
+///
+/// `AgentCoordinator` is a singleton, and its `isProcessing` / `isStreaming` /
+/// `streamingText` / `activeToolCalls` are global flags. With one surface that was
+/// harmless — there was only ever one thread on screen. With two, it is not: a run
+/// started from the Command Center island sets the same flags the main window's
+/// conversation reads, so the island's spinner, its streaming text and its tool
+/// cards all paint onto whatever thread the main window happens to be showing.
+///
+/// This is that state with an owner attached. Every read is scoped to a
+/// conversation and answers for the idle state when the run belongs to a different
+/// one, so a surface can only ever see its own activity.
+///
+/// Pure and free of `@Observable`, actors and the engine, so the scoping rule is
+/// testable without a model — one of the ground rules on issue #56.
+struct AgentRunState {
+    /// The conversation the current — or most recent — run belongs to.
+    ///
+    /// Deliberately survives `finish()`: `lastError` outlives the run so the banner
+    /// can persist until acknowledged, and an error with no owner would paint on
+    /// every surface. Cleared on the next `begin`.
+    private(set) var conversationID: UUID?
+
+    private(set) var isProcessing = false
+    private(set) var isStreaming = false
+    private(set) var streamingText = ""
+    private(set) var activeToolCalls: [AgentToolCall] = []
+    private(set) var lastError: String?
+
+    init() {}
+
+    // MARK: - Transitions
+
+    /// Starts a run and takes ownership for `conversationID`.
+    ///
+    /// Clears the previous run's error: the existing coordinator drops `lastError`
+    /// at the top of every `send`, and a stale error surviving into an unrelated
+    /// run would be attributed to the wrong turn.
+    mutating func begin(conversationID: UUID) {
+        self.conversationID = conversationID
+        isProcessing = true
+        isStreaming = false
+        streamingText = ""
+        activeToolCalls = []
+        lastError = nil
+    }
+
+    mutating func beginStreaming() {
+        isStreaming = true
+        streamingText = ""
+    }
+
+    mutating func appendToken(_ token: String) {
+        streamingText += token
+    }
+
+    mutating func resetStreamingText() {
+        streamingText = ""
+    }
+
+    mutating func setActiveToolCalls(_ calls: [AgentToolCall]) {
+        activeToolCalls = calls
+    }
+
+    mutating func fail(_ message: String) {
+        lastError = message
+    }
+
+    mutating func dismissError() {
+        lastError = nil
+    }
+
+    /// Ends the run. Keeps `conversationID` and `lastError` so the owning surface
+    /// can still show a banner for a run that has finished.
+    mutating func finish() {
+        isProcessing = false
+        isStreaming = false
+        streamingText = ""
+        activeToolCalls = []
+    }
+
+    // MARK: - Scoped reads
+
+    /// Whether the live run, if any, belongs to this conversation.
+    func owns(_ conversationID: UUID) -> Bool {
+        self.conversationID == conversationID
+    }
+
+    func isProcessing(for conversationID: UUID) -> Bool {
+        owns(conversationID) && isProcessing
+    }
+
+    func isStreaming(for conversationID: UUID) -> Bool {
+        owns(conversationID) && isStreaming
+    }
+
+    func streamingText(for conversationID: UUID) -> String {
+        owns(conversationID) ? streamingText : ""
+    }
+
+    func activeToolCalls(for conversationID: UUID) -> [AgentToolCall] {
+        owns(conversationID) ? activeToolCalls : []
+    }
+
+    func lastError(for conversationID: UUID) -> String? {
+        owns(conversationID) ? lastError : nil
+    }
+}

--- a/Logue/Services/AgentConversationStore.swift
+++ b/Logue/Services/AgentConversationStore.swift
@@ -28,12 +28,23 @@ final class AgentConversationStore {
 
     // MARK: - CRUD
 
-    /// Creates a new conversation and selects it.
+    /// Creates a new conversation.
+    ///
+    /// - Parameter select: whether to make it the selected conversation. `true` for the main
+    ///   window, where creating a thread means opening it. The Command Center island passes
+    ///   `false`: it floats over another app with its own thread, and selecting that thread
+    ///   would change what the main window is showing behind it — a window the user is not
+    ///   looking at, silently navigated away from whatever they left open.
     @discardableResult
-    func createConversation(title: String = "New Conversation") -> AgentConversation {
+    func createConversation(
+        title: String = "New Conversation",
+        select: Bool = true
+    ) -> AgentConversation {
         let conversation = AgentConversation(title: title)
         conversations.insert(conversation, at: 0)
-        selectedConversationID = conversation.id
+        if select {
+            selectedConversationID = conversation.id
+        }
         save(conversation)
         pruneIfNeeded()
         return conversation

--- a/Logue/Views/Agent/AgentChatView.swift
+++ b/Logue/Views/Agent/AgentChatView.swift
@@ -276,10 +276,13 @@ struct AgentChatView: View {
     private func hasMessagesLayout(conversation: AgentConversation) -> some View {
         MessageListView(
             messages: conversation.messages,
-            activeToolCalls: coordinator.activeToolCalls,
-            isProcessing: coordinator.isProcessing,
-            isStreaming: coordinator.isStreaming,
-            streamingText: coordinator.streamingText,
+            // Scoped to the conversation on screen. Read globally, a run started from the
+            // Command Center island would paint its spinner, its streaming text and its
+            // tool cards onto whatever thread this view happens to be showing.
+            activeToolCalls: coordinator.activeToolCalls(in: conversation.id),
+            isProcessing: coordinator.isProcessing(in: conversation.id),
+            isStreaming: coordinator.isStreaming(in: conversation.id),
+            streamingText: coordinator.streamingText(in: conversation.id),
             conversationID: conversation.id,
             scrollToTopTrigger: scrollToTopTrigger,
             scrollTargetID: scrollTargetID,
@@ -292,7 +295,7 @@ struct AgentChatView: View {
             }
         )
 
-        if let error = coordinator.lastError {
+        if let error = coordinator.lastError(in: conversation.id) {
             errorBanner(error)
                 .transition(.move(edge: .bottom).combined(with: .opacity))
         }
@@ -315,7 +318,7 @@ struct AgentChatView: View {
             inputText: $inputText,
             focusRequest: focusRequest,
             attachments: $inputAttachments,
-            isProcessing: coordinator.isProcessing || deepResearchCoordinator.isRunning,
+            isProcessing: isThisConversationProcessing || deepResearchCoordinator.isRunning,
             isBusy: isBusy,
             onSend: {
                 let text = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -363,7 +366,7 @@ struct AgentChatView: View {
                 }
             }
         )
-        .disabled(isBusy && !coordinator.isProcessing)
+        .disabled(isBusy && !isThisConversationProcessing)
     }
 
     // MARK: - Window Toolbar
@@ -414,12 +417,27 @@ struct AgentChatView: View {
         }
     }
 
+    /// Whether the live run belongs to the conversation this view is showing.
+    ///
+    /// `false` with no conversation selected: a surface showing nothing has no run of its
+    /// own, and answering `true` here is how the main window would report the island's work.
+    private var isThisConversationProcessing: Bool {
+        guard let id = activeConversation?.id else { return false }
+        return coordinator.isProcessing(in: id)
+    }
+
+    private var isThisConversationStreaming: Bool {
+        guard let id = activeConversation?.id else { return false }
+        return coordinator.isStreaming(in: id)
+    }
+
     private var topBarSubtitle: String {
         let messageCount = activeConversation?.messages.count ?? 0
-        if coordinator.isStreaming || coordinator.isProcessing {
+        if isThisConversationStreaming || isThisConversationProcessing {
             // Vary the subtitle by the active tool so users see what the
             // agent is actually doing, not a static "Thinking…".
-            let activeTool = coordinator.activeToolCalls.last?.toolName
+            let activeTool = activeConversation
+                .map { coordinator.activeToolCalls(in: $0.id) }?.last?.toolName
             return UICopy.Status.describe(toolName: activeTool)
         }
         if messageCount == 0 {

--- a/Logue/Views/CrossApp/CommandCenterChatView.swift
+++ b/Logue/Views/CrossApp/CommandCenterChatView.swift
@@ -2,21 +2,17 @@ import AVFoundation
 import SwiftUI
 import Textual
 
-/// Ephemeral chat message with mutable content for streaming support.
+/// One bubble in the island, mapped from the conversation's `AgentMessage`.
+///
+/// No longer ephemeral despite the name: it is a view model over stored messages, and `id`
+/// is the stored message's, so bubbles keep their identity across a re-render rather than
+/// being reissued every time the mapping runs.
 struct EphemeralChatMessage: Identifiable, Equatable {
     let id: UUID
     var content: String
     let isUser: Bool
     var isStreaming: Bool
     let timestamp: Date
-
-    init(content: String, isUser: Bool, isStreaming: Bool = false) {
-        id = UUID()
-        self.content = content
-        self.isUser = isUser
-        self.isStreaming = isStreaming
-        timestamp = Date()
-    }
 
     static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.id == rhs.id && lhs.content == rhs.content && lhs.isStreaming == rhs.isStreaming
@@ -29,10 +25,14 @@ struct CommandCenterChatView: View {
     let onDismiss: () -> Void
     let onContentChanged: (CommandCenterChatContent) -> Void
 
-    @State private var messages: [EphemeralChatMessage] = []
+    /// The island's own thread, created on first send and never selected.
+    ///
+    /// Created with `select: false`: this floats over another app, and selecting its thread
+    /// would navigate the main window sitting behind it away from whatever the user left open.
+    @State private var conversationID: UUID?
+    @State private var store = AgentConversationStore.shared
+    @State private var coordinator = AgentCoordinator.shared
     @State private var inputText: String = ""
-    @State private var isGenerating: Bool = false
-    @State private var streamTask: Task<Void, Never>?
     @State private var copiedMessageID: UUID?
     @State private var savedMessageID: UUID?
     @State private var speakingMessageID: UUID?
@@ -41,6 +41,42 @@ struct CommandCenterChatView: View {
 
     private var voiceManager: VoicePushToTalkManager {
         .shared
+    }
+
+    /// The island's thread, as the bubbles want it.
+    ///
+    /// Read from the store rather than held here. That is the whole point of the change: the
+    /// island used to keep its own array and throw it away on dismiss, so a question asked
+    /// here had no history, no tools and no memory. It is now the same conversation the rest
+    /// of Logue can see.
+    private var messages: [EphemeralChatMessage] {
+        guard let conversationID,
+              let conversation = store.conversations.first(where: { $0.id == conversationID })
+        else { return [] }
+
+        let live = coordinator.isStreaming(in: conversationID)
+        return conversation.messages.enumerated().compactMap { index, message in
+            switch message.role {
+            case .user, .assistant: break
+            // Tool and system turns are the agent's bookkeeping. The main window renders
+            // them as cards; the island is a pill over someone else's app and has no room.
+            default: return nil
+            }
+            let isLast = index == conversation.messages.count - 1
+            return EphemeralChatMessage(
+                id: message.id,
+                content: message.content,
+                isUser: message.role == .user,
+                isStreaming: live && isLast && message.role == .assistant,
+                timestamp: message.timestamp
+            )
+        }
+    }
+
+    /// Whether the island's own thread is busy — never the main window's.
+    private var isGenerating: Bool {
+        guard let conversationID else { return false }
+        return coordinator.isProcessing(in: conversationID)
     }
 
     private let pillWidth: CGFloat = 740
@@ -365,11 +401,20 @@ struct CommandCenterChatView: View {
 
     private func sendMessage() {
         let text = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !text.isEmpty, !isGenerating else { return }
 
-        messages.append(EphemeralChatMessage(content: text, isUser: true))
+        // The same routing decision the main window makes. The island has no Deep Research
+        // chip and no attachments yet, so those inputs are false — but it asks the one
+        // router rather than carrying a second opinion that can drift from it.
+        let route = AskRouter.route(
+            for: AskRouter.Request(
+                text: text,
+                imageIntentFires: PromptIntentClassifier.shared.shouldPresentImagePlayground(for: text)
+            )
+        )
+        guard let route, !isGenerating else { return }
+
+        let conversationID = ensureConversation()
         inputText = ""
-        isGenerating = true
 
         // Re-focus input after state update
         Task {
@@ -377,55 +422,48 @@ struct CommandCenterChatView: View {
             isInputFocused = true
         }
 
-        let aiMessage = EphemeralChatMessage(content: "", isUser: false, isStreaming: true)
-        let aiID = aiMessage.id
-        messages.append(aiMessage)
-
-        streamTask = Task { @MainActor in
-            do {
-                let stream = await LLMEngine.shared.chatStream(prompt: text)
-                for try await chunk in stream {
-                    guard !Task.isCancelled else { break }
-                    if let idx = messages.firstIndex(where: { $0.id == aiID }) {
-                        messages[idx].content += chunk
-                    }
-                }
-                if let idx = messages.firstIndex(where: { $0.id == aiID }) {
-                    messages[idx].isStreaming = false
-                }
-                isGenerating = false
-                isInputFocused = true
-            } catch {
-                if !Task.isCancelled {
-                    if let idx = messages.firstIndex(where: { $0.id == aiID }) {
-                        messages[idx].content = "No AI model loaded. Open Logue and set up a model in Settings \u{2192} Models first."
-                        messages[idx].isStreaming = false
-                    }
-                    isGenerating = false
-                    isInputFocused = true
-                }
-            }
+        switch route {
+        case .agentLoop, .deepResearch:
+            // Deep Research is unreachable from here — no chip lights it — and if it ever
+            // becomes reachable it belongs on the same coordinator, not a second pipeline.
+            coordinator.send(message: text, conversationID: conversationID)
+        case let .imagePlayground(concept):
+            // ImagePlayground presents a sheet, which a floating pill cannot host. Answer it
+            // as a normal turn rather than silently dropping the send.
+            coordinator.send(message: concept, conversationID: conversationID)
         }
+    }
+
+    /// The island's thread, made on first use.
+    ///
+    /// Deliberately not selected — see `conversationID`. Titled so it is identifiable in the
+    /// main window's list rather than appearing as another "New Conversation" the user did
+    /// not knowingly start.
+    private func ensureConversation() -> UUID {
+        if let conversationID {
+            return conversationID
+        }
+        let conversation = store.createConversation(title: "Command Center", select: false)
+        conversationID = conversation.id
+        return conversation.id
     }
 
     private func stopStreaming() {
-        streamTask?.cancel()
-        streamTask = nil
-        if let lastIdx = messages.indices.last, messages[lastIdx].isStreaming {
-            messages[lastIdx].isStreaming = false
-        }
-        isGenerating = false
+        coordinator.cancel()
         isInputFocused = true
     }
 
+    /// Starts a fresh thread rather than erasing one.
+    ///
+    /// The old island discarded its messages because they existed nowhere else. They are a
+    /// real conversation now, so "clear" means the island stops pointing at it — deleting it
+    /// would throw away something the user can still open from the main window.
     private func clearSession() {
-        streamTask?.cancel()
-        streamTask = nil
+        coordinator.cancel()
         synthesizer.stopSpeaking(at: .immediate)
         speakingMessageID = nil
-        messages.removeAll()
+        conversationID = nil
         inputText = ""
-        isGenerating = false
         isInputFocused = true
     }
 

--- a/LogueTests/AgentRunStateTests.swift
+++ b/LogueTests/AgentRunStateTests.swift
@@ -1,0 +1,163 @@
+import Foundation
+import Testing
+
+@testable import Logue
+
+/// The invariant issue #61 exists to establish, stated as tests: a run on one
+/// surface can never paint an indicator onto the other's thread.
+///
+/// Every case here fails against a global flag — which is what
+/// `AgentCoordinator.isProcessing` is today — so this suite is what stops the
+/// scoping being quietly removed later.
+@Suite("AgentRunState")
+struct AgentRunStateTests {
+    private let island = UUID()
+    private let mainWindow = UUID()
+
+    private func toolCall(_ name: String) -> AgentToolCall {
+        AgentToolCall(toolName: name, arguments: "{}")
+    }
+
+    // MARK: - Idle
+
+    @Test("A fresh state owns no conversation and shows nothing")
+    func idleShowsNothing() {
+        let state = AgentRunState()
+        #expect(state.owns(island) == false)
+        #expect(state.isProcessing(for: island) == false)
+        #expect(state.isStreaming(for: island) == false)
+        #expect(state.streamingText(for: island).isEmpty)
+        #expect(state.activeToolCalls(for: island).isEmpty)
+        #expect(state.lastError(for: island) == nil)
+    }
+
+    // MARK: - Scoping
+
+    @Test("A run is visible to the conversation that started it")
+    func runVisibleToOwner() {
+        var state = AgentRunState()
+        state.begin(conversationID: island)
+        #expect(state.isProcessing(for: island))
+    }
+
+    @Test("A run is invisible to every other conversation")
+    func runInvisibleToOthers() {
+        // The whole point: the island runs, the main window shows nothing.
+        var state = AgentRunState()
+        state.begin(conversationID: island)
+        #expect(state.isProcessing(for: mainWindow) == false)
+    }
+
+    @Test("Streaming text does not leak to another conversation")
+    func streamingTextDoesNotLeak() {
+        var state = AgentRunState()
+        state.begin(conversationID: island)
+        state.beginStreaming()
+        state.appendToken("Hello")
+        state.appendToken(" world")
+        #expect(state.streamingText(for: island) == "Hello world")
+        #expect(state.streamingText(for: mainWindow).isEmpty)
+        #expect(state.isStreaming(for: mainWindow) == false)
+    }
+
+    @Test("Tool cards do not leak to another conversation")
+    func toolCallsDoNotLeak() {
+        var state = AgentRunState()
+        state.begin(conversationID: island)
+        state.setActiveToolCalls([toolCall("web_search")])
+        #expect(state.activeToolCalls(for: island).count == 1)
+        #expect(state.activeToolCalls(for: mainWindow).isEmpty)
+    }
+
+    @Test("An error does not leak to another conversation")
+    func errorDoesNotLeak() {
+        var state = AgentRunState()
+        state.begin(conversationID: island)
+        state.fail("Couldn't start the agent")
+        #expect(state.lastError(for: island) == "Couldn't start the agent")
+        #expect(state.lastError(for: mainWindow) == nil)
+    }
+
+    // MARK: - Lifecycle
+
+    @Test("Finishing clears live state but keeps the error for its owner")
+    func finishKeepsErrorForOwner() {
+        // The banner has to outlive the run — the coordinator's own comment says it
+        // stays set after isStreaming flips to false, until acknowledged.
+        var state = AgentRunState()
+        state.begin(conversationID: island)
+        state.beginStreaming()
+        state.appendToken("partial")
+        state.setActiveToolCalls([toolCall("web_search")])
+        state.fail("Agent stream failed")
+        state.finish()
+
+        #expect(state.isProcessing(for: island) == false)
+        #expect(state.isStreaming(for: island) == false)
+        #expect(state.streamingText(for: island).isEmpty)
+        #expect(state.activeToolCalls(for: island).isEmpty)
+        #expect(state.lastError(for: island) == "Agent stream failed")
+        // Still not the other surface's error.
+        #expect(state.lastError(for: mainWindow) == nil)
+    }
+
+    @Test("Starting a new run clears the previous run's error")
+    func beginClearsPreviousError() {
+        var state = AgentRunState()
+        state.begin(conversationID: island)
+        state.fail("Agent stream failed")
+        state.finish()
+        state.begin(conversationID: mainWindow)
+        #expect(state.lastError(for: mainWindow) == nil)
+    }
+
+    @Test("A finished run's error does not follow ownership to the next conversation")
+    func errorDoesNotFollowOwnership() {
+        // Regression guard: keeping conversationID after finish must not mean the
+        // next owner inherits the last owner's banner.
+        var state = AgentRunState()
+        state.begin(conversationID: island)
+        state.fail("island failure")
+        state.finish()
+        state.begin(conversationID: mainWindow)
+        #expect(state.lastError(for: island) == nil)
+        #expect(state.lastError(for: mainWindow) == nil)
+    }
+
+    @Test("Taking over mid-run hands live state to the new conversation only")
+    func takeoverScopesToNewOwner() {
+        var state = AgentRunState()
+        state.begin(conversationID: island)
+        state.beginStreaming()
+        state.appendToken("island tokens")
+        state.begin(conversationID: mainWindow)
+
+        #expect(state.isProcessing(for: mainWindow))
+        #expect(state.isProcessing(for: island) == false)
+        #expect(state.streamingText(for: island).isEmpty)
+        #expect(state.streamingText(for: mainWindow).isEmpty)
+    }
+
+    @Test("Dismissing an error clears it")
+    func dismissClearsError() {
+        var state = AgentRunState()
+        state.begin(conversationID: island)
+        state.fail("boom")
+        state.dismissError()
+        #expect(state.lastError(for: island) == nil)
+    }
+
+    @Test("Resetting streaming text between tool rounds keeps ownership")
+    func resetStreamingTextKeepsOwnership() {
+        // The coordinator clears streamingText between reasoning rounds; that must
+        // not look like the run changing hands.
+        var state = AgentRunState()
+        state.begin(conversationID: island)
+        state.beginStreaming()
+        state.appendToken("round one")
+        state.resetStreamingText()
+        #expect(state.owns(island))
+        #expect(state.isProcessing(for: island))
+        #expect(state.streamingText(for: island).isEmpty)
+    }
+}

--- a/LogueTests/AgentRunStateTests.swift
+++ b/LogueTests/AgentRunStateTests.swift
@@ -160,4 +160,43 @@ struct AgentRunStateTests {
         #expect(state.isProcessing(for: island))
         #expect(state.streamingText(for: island).isEmpty)
     }
+
+    // MARK: - Streaming stops more than once per run
+
+    @Test("Ending streaming leaves the run processing")
+    func endStreamingKeepsTheRunAlive() {
+        // The graph stops streaming after every tool call and resumes; the run is still
+        // going. If this cleared `isProcessing`, `send`'s `guard !isProcessing` would let a
+        // second send start on top of the first, mid-run.
+        var state = AgentRunState()
+        let id = UUID()
+        state.begin(conversationID: id)
+        state.beginStreaming()
+        state.appendToken("partial")
+
+        state.endStreaming()
+
+        #expect(state.isStreaming == false)
+        #expect(state.isProcessing, "the run has not finished")
+        #expect(state.owns(id))
+        // The tokens so far are what the caller is about to commit as a message.
+        #expect(state.streamingText == "partial")
+    }
+
+    @Test("A conversation that does not own the run still sees nothing mid-stream")
+    func foreignConversationSeesIdleWhileStreaming() {
+        var state = AgentRunState()
+        let mine = UUID()
+        let theirs = UUID()
+        state.begin(conversationID: mine)
+        state.beginStreaming()
+        state.appendToken("hello")
+
+        #expect(state.isStreaming(for: theirs) == false)
+        #expect(state.streamingText(for: theirs).isEmpty)
+        #expect(state.isProcessing(for: theirs) == false)
+        // …while the owner sees all of it.
+        #expect(state.isStreaming(for: mine))
+        #expect(state.streamingText(for: mine) == "hello")
+    }
 }


### PR DESCRIPTION
**Part of #61** — this finishes item 1. **Stacked on #66**; review that first, and this diff shrinks to just this change once it merges.

## The problem

Ask Logue was reachable from two places and they were not the same product.

`CommandCenterChatView` ran `LLMEngine.shared.chatStream(prompt:)` and kept its history in local `@State`. A question asked from the island got **no tools, no memory, no attachments, no web search**, and the conversation was discarded on dismiss. The same question asked from the main window got the full `AgentCoordinator` loop with the tool registry and the approval gate.

Which window you asked from decided what Logue was. Everything after this — MCP (#55), skills — lands on both surfaces, so built before this, each of them gets built twice.

## What is here

The island now runs the same loop. Four commits, in the order the safety had to exist before the change that needed it.

**1. `AgentRunState` — a run that knows whose it is.** `AgentCoordinator` is a singleton and its `isProcessing`, `isStreaming`, `streamingText` and `activeToolCalls` were global. That was harmless with one surface, because there was only ever one thread on screen. With two it is a bug: a run started from the island sets the flags the main window reads, so the island's spinner, streaming text and tool cards paint onto whichever thread the main window happens to be showing. The state now carries an owner and every read is scoped.

**2. `endStreaming()`.** The graph stops streaming several times inside one run — after each tool call, and on recoverable errors — while the run is still processing. Without this the adoption would have reached for `finish()` at those points, clearing `isProcessing`; `send` guards on exactly that flag, so a second send could have started on top of a run still in flight.

**3. The coordinator moved onto it.** Removing the un-scoped properties turned every read into a compile error — nine across the coordinator and `AgentChatView` — so each had to be answered deliberately rather than found by reading. `isProcessingAnyConversation` survives for the coordinator's own re-entrancy guards, named for what it means so a surface asking "am I busy" does not reach for it by accident.

**4. `createConversation(select:)`.** The island floats over another app with its own thread. Creating it the old way would have set `selectedConversationID` and navigated the main window *behind* the island away from whatever the user left open. Found by reading the store before wiring onto it. All five existing callers are unchanged — `select` defaults to `true`, which is what the main window wants.

**5. The island itself.** Sends go through the coordinator; routing calls `AskRouter` rather than carrying a second opinion; messages are read from the store with `EphemeralChatMessage` surviving as a view model that carries the stored id, so bubbles keep identity across a re-render. Tool and system turns are filtered — the main window renders them as cards and a pill over someone else's app has no room. "Clear" now starts a new thread instead of erasing one, because the messages are a real conversation the user can still open from the main window.

## Behaviour in the main window

Unchanged. It is the only surface running today, so every scoped read resolves to the answer it gave before.

## Verification

**1520 tests in 129 suites** pass. `AgentRunStateTests` covers ownership across `begin`/`finish`, the error outliving the run, streaming stopping without ending it, and — the point of the type — a conversation that does not own the run reading as idle mid-stream. SwiftFormat 0.62.1 and SwiftLint 0.65.0 clean at the versions CI pins.

## What a reviewer should actually click

This is the largest behaviour change on the branch and it is **verified by build and tests only** — the island needs a loaded model and Accessibility permission, which I could not exercise here. Worth clicking:

1. **Ask something from the island.** It should use tools and remember context across turns, which the old path could not do at all.
2. **While it answers, look at the main window behind it.** Its thread should be untouched: no spinner, no streaming text, no tool cards — and it should still be showing whatever conversation was open before.
3. **Ask from the main window while the island is idle**, and confirm the island shows nothing of it.
4. **Dismiss and reopen the island.** The thread should still be there, and findable in the main window's conversation list as "Command Center".
5. **Clear the island.** It should start a fresh thread, and the previous one should still exist in the main window rather than having been deleted.

## Not here

`AgentConversationStore` has no test coverage for `select:`. It is a singleton with a `private init()` that persists to disk, so exercising it from a test writes into the user's real conversation library — the same trap as a `UserDefaults` suite falling back to `.standard`. The seam worth building is an injectable store, which is more than this branch should carry; noting it as a known gap rather than an assumed absence.
