### PR TITLE
ci: run on every pull request, not only those targeting main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,11 @@ name: CI
 on:
   push:
     branches: [ "main", "dev" ]
+  # Every pull request, whatever it targets. Filtering by base branch meant a PR
+  # stacked on another PR's branch got no CI at all — it was reviewed, approved and
+  # merged on the strength of a green tick it never had. Pushes stay filtered:
+  # a branch with no PR open is someone's work in progress, not a thing to gate.
   pull_request:
-    branches: [ "main", "dev" ]
 
 # Least privilege: CI only reads the repo. Denies write access to the
 # GITHUB_TOKEN for all workflow runs, including those from fork pull requests.


### PR DESCRIPTION
## Why

`pull_request` was filtered to `main` and `dev`. A PR stacked on another PR's branch therefore got **no CI at all**.

That is not hypothetical — #69 targets `shan/issue-61-shared-session` and `gh pr checks 69` currently answers:

```
no checks reported on the 'shan/issue-61-run-scoping' branch
```

It is ready for review, and it could be reviewed, approved and merged on the strength of a green tick it never had.

This matters more now that the Ask Logue work (#61) is deliberately stacked — each PR's base is the branch below it, so under the old filter only the bottom of a stack was ever built or linted.

## What changed

One line: the base-branch filter comes off `pull_request`. Every PR is now built and linted whatever it targets.

**Pushes stay filtered** to `main` and `dev`. A branch with no PR open is work in progress, and building every push to it spends runner minutes on code nobody has been asked to look at yet.

## Cost

A stacked PR now runs the same Build and Lint jobs as any other — roughly ten minutes of runner time per push to a stacked branch. That is the price of the stack having a signal at all, and it is cheaper than the alternative, which is finding out at merge time.

## Note for the current stack

For `pull_request` events GitHub uses the workflow from the merge of base and head, so #69 will not pick this up until it is in its base branch. Once this lands on `main` I will merge `main` into `shan/issue-61-shared-session`, which gives both #66 and #69 the trigger.
