### PR TITLE
Ask Logue part 4: shared attachment intake, mode chips, and a composer on the island

### DIFF
--- a/Logue.xcodeproj/project.pbxproj
+++ b/Logue.xcodeproj/project.pbxproj
@@ -204,6 +204,7 @@
 		457B5F17B248B73950E85F0C /* CanvasSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31784F4F4DF98021B23FFFA9 /* CanvasSnapshot.swift */; };
 		45C718CBF00AF53ECFD9267D /* Neighborhood.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9017DE8546F2B3F48A6C3EB /* Neighborhood.swift */; };
 		4670A7C21D3D7C569ED2C057 /* VoiceInputIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D147FADD3CE97D983829125 /* VoiceInputIndicator.swift */; };
+		46C1636E40764DBB285B5C03 /* CommandCenterChatView+Composer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026499B13ACB9A5937CCC44A /* CommandCenterChatView+Composer.swift */; };
 		472EB0BDEFF4B649154E4D12 /* CharCounter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 141A999128E664D7D97120BB /* CharCounter.swift */; };
 		477DF8B7B1F59630238F15A1 /* FilterChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1422ADE4317F2B8650E23D7 /* FilterChip.swift */; };
 		47AF1C29A0DE6C0767146BA6 /* LLMClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA90D7698CBC2EB6CBF52AFB /* LLMClient.swift */; };
@@ -612,6 +613,7 @@
 		E4DE20313B09FFD5F231BFBB /* TranscriptionGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C7DA3D5F0B7598F71D9D15 /* TranscriptionGateTests.swift */; };
 		E536E26DFCF028B14B186996 /* SectionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1153D35EF20882A425B5D836 /* SectionHeader.swift */; };
 		E560D4C6313E3EBFDF0D32B3 /* BlockFrameStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3F2421D7F17F2EE5A04EF7F /* BlockFrameStoreTests.swift */; };
+		E5908FC6811FA07E101AB6F1 /* AttachmentIntakeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A8627FAD5FB6C9F54FE23A2 /* AttachmentIntakeTests.swift */; };
 		E5DF85C2C0803078D80C350C /* CommandCenterChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19129D8F0F9161BC3E21AA0F /* CommandCenterChatView.swift */; };
 		E607ACE5890354F65F74C864 /* LLMEngineStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3224E9FBD3E9D86A60DAA79C /* LLMEngineStatus.swift */; };
 		E63CD7720F92C807AEB1B7BE /* FactCheckCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B61F580088B1A2F4D33DE8 /* FactCheckCard.swift */; };
@@ -709,6 +711,7 @@
 		019756686F6D3BBAAE229D8F /* WikiLinkParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WikiLinkParserTests.swift; sourceTree = "<group>"; };
 		01DF49AA771F4050417643F2 /* DocumentType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentType.swift; sourceTree = "<group>"; };
 		0252C590E08043FE0A4200C7 /* MainWindowView+Navigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MainWindowView+Navigation.swift"; sourceTree = "<group>"; };
+		026499B13ACB9A5937CCC44A /* CommandCenterChatView+Composer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CommandCenterChatView+Composer.swift"; sourceTree = "<group>"; };
 		05509BDEDCFFC620AB9B8777 /* TranscriptTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptTimelineView.swift; sourceTree = "<group>"; };
 		058B2966E8BD330957460206 /* TranscriptTimelineView+Bookmarks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TranscriptTimelineView+Bookmarks.swift"; sourceTree = "<group>"; };
 		06255FC9EEF089BB08B5232B /* whatsnew-writing-editor.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "whatsnew-writing-editor.png"; sourceTree = "<group>"; };
@@ -1110,6 +1113,7 @@
 		98CF1BA4C3D6569694E01167 /* MarkdownImportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownImportTests.swift; sourceTree = "<group>"; };
 		998619AE2882C267AC86850D /* swift-markdown */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "swift-markdown"; path = "Vendor/swift-markdown"; sourceTree = SOURCE_ROOT; };
 		99E36F742DA233D8616E8CC1 /* CardSectionHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardSectionHeader.swift; sourceTree = "<group>"; };
+		9A8627FAD5FB6C9F54FE23A2 /* AttachmentIntakeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentIntakeTests.swift; sourceTree = "<group>"; };
 		9AAC8C464AD83B42DE49792C /* WikiLinkCandidates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WikiLinkCandidates.swift; sourceTree = "<group>"; };
 		9B611C161962C154FC8DA451 /* FolderIconPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderIconPicker.swift; sourceTree = "<group>"; };
 		9BFF6DFB33FFDD664F05A4E6 /* AccessibilityService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityService.swift; sourceTree = "<group>"; };
@@ -1448,6 +1452,7 @@
 				86029AD56EBB4317FFDFB4E4 /* AgentRunStateTests.swift */,
 				4F21C87791C6ECF443D14823 /* AppVersionTests.swift */,
 				0A4CB54883E92F9A6F98BE77 /* AskRouteTests.swift */,
+				9A8627FAD5FB6C9F54FE23A2 /* AttachmentIntakeTests.swift */,
 				2476E5FAF6705D05BF8C22F2 /* AudioFileChunkReaderTests.swift */,
 				5FBB6345B454F1E296E6DE8D /* AudioTimelineMixerTests.swift */,
 				505AF0501A911C8BE2CB13CC /* BatchTranscriptFilterTests.swift */,
@@ -2286,6 +2291,7 @@
 			children = (
 				19129D8F0F9161BC3E21AA0F /* CommandCenterChatView.swift */,
 				F7847A3DB8F8CA72ECAE813F /* CommandCenterChatView+Bubbles.swift */,
+				026499B13ACB9A5937CCC44A /* CommandCenterChatView+Composer.swift */,
 				7ABC89CED798F0088E00B682 /* CommandCenterComposeView.swift */,
 				E7300054D056065027CC1FF3 /* CommandCenterNewMeetingView.swift */,
 				24578E3A172E90DC703D4C9D /* CommandCenterPIIView.swift */,
@@ -2655,6 +2661,7 @@
 				AAEF3C6465DC0A9EA911FE93 /* AgentRunStateTests.swift in Sources */,
 				B71E1192276BBC1904238D1A /* AppVersionTests.swift in Sources */,
 				85FB21E5E26B2D3D46093D47 /* AskRouteTests.swift in Sources */,
+				E5908FC6811FA07E101AB6F1 /* AttachmentIntakeTests.swift in Sources */,
 				08CC77D0F8EB0A6EAB31D544 /* AudioFileChunkReaderTests.swift in Sources */,
 				47F0712575338CEF0C0411F0 /* AudioTimelineMixerTests.swift in Sources */,
 				FE2FB582956D1251285E5C43 /* BatchTranscriptFilterTests.swift in Sources */,
@@ -2878,6 +2885,7 @@
 				1CF5D6AE20C1BDE279762B9F /* ComingSoonPanelView.swift in Sources */,
 				4BD0DCD9E20A28C06D40AF62 /* CommandCenterChatRule.swift in Sources */,
 				74E1ECCB2472ED6957C5E552 /* CommandCenterChatView+Bubbles.swift in Sources */,
+				46C1636E40764DBB285B5C03 /* CommandCenterChatView+Composer.swift in Sources */,
 				E5DF85C2C0803078D80C350C /* CommandCenterChatView.swift in Sources */,
 				5CBFF3B40F91960EC8178989 /* CommandCenterComposeView.swift in Sources */,
 				99FCB8FEB17A1DA884E6892C /* CommandCenterController.swift in Sources */,

--- a/Logue.xcodeproj/project.pbxproj
+++ b/Logue.xcodeproj/project.pbxproj
@@ -104,6 +104,7 @@
 		1BE965CE5953BCA256111BEA /* MeetingRowCompact.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72EE330160AA0276B2907F2A /* MeetingRowCompact.swift */; };
 		1C1775454781744474E68510 /* ToolApprovalButtons.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4DB5AD462B4A863201D5D61 /* ToolApprovalButtons.swift */; };
 		1C4A675BEB767A50A29D970F /* katex.min.css in Resources */ = {isa = PBXBuildFile; fileRef = E420BD97F84DEF6141ADEDA4 /* katex.min.css */; };
+		1C5F8AF69527526490E8CA54 /* AttachmentIntake.swift in Sources */ = {isa = PBXBuildFile; fileRef = 417436A70F2C0F1DDA347DC4 /* AttachmentIntake.swift */; };
 		1CCAD60D4518A9CCED75F860 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7449F6B54F0F197D704E4C59 /* AppDelegate.swift */; };
 		1CF5D6AE20C1BDE279762B9F /* ComingSoonPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4846B28779DCE95A2E8E9D23 /* ComingSoonPanelView.swift */; };
 		1CFA41464BB0BBD94D0F51D1 /* DurationFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D766396CB3F843CD222C7F46 /* DurationFormatter.swift */; };
@@ -873,6 +874,7 @@
 		3FF85EA0F9822CBD660E9AAB /* MarkdownStorageWarningSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownStorageWarningSheet.swift; sourceTree = "<group>"; };
 		40381D10206F56D057943756 /* SpaceContentPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceContentPane.swift; sourceTree = "<group>"; };
 		4066081DEC2821193FE7D882 /* WikiLinkURLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WikiLinkURLTests.swift; sourceTree = "<group>"; };
+		417436A70F2C0F1DDA347DC4 /* AttachmentIntake.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentIntake.swift; sourceTree = "<group>"; };
 		41C0416ED8CE675F6EF78FA0 /* TaskStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskStoreTests.swift; sourceTree = "<group>"; };
 		42BFEBF99163808EE4126279 /* HomeContextBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeContextBar.swift; sourceTree = "<group>"; };
 		42FA58E9E9D16008C0F7FF4E /* TaskTriage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskTriage.swift; sourceTree = "<group>"; };
@@ -2165,6 +2167,7 @@
 				62CA343B98C1F62D9F89B0B6 /* AgentRunState.swift */,
 				B1CF9F695CCB56896DC9A02C /* ApprovalGate.swift */,
 				86C6E3021828B2B8589C720A /* AskRoute.swift */,
+				417436A70F2C0F1DDA347DC4 /* AttachmentIntake.swift */,
 				4B2F874FCD0AF25F7B37D3FC /* MalformedToolCall.swift */,
 				B55FA53C32F4D2968C07CEE5 /* MessageActions.swift */,
 				6711FB8D13DD53809A655A14 /* WritingAgentGraph.swift */,
@@ -2819,6 +2822,7 @@
 				ED283783D6A185FB3914A331 /* ApprovalGate.swift in Sources */,
 				556246B3C2F8B616A0CDD27B /* AskRoute.swift in Sources */,
 				B62AF07AD0FDB3E3E4B31D77 /* AssistantActionRow.swift in Sources */,
+				1C5F8AF69527526490E8CA54 /* AttachmentIntake.swift in Sources */,
 				ECB8B236B80423C7D1A752FF /* AudioFileChunkReader.swift in Sources */,
 				DEDC62FB8C63F071222D9115 /* AudioLevelNormalizer.swift in Sources */,
 				86E9087748D55EBF2768316A /* AudioPlaybackService.swift in Sources */,

--- a/Logue.xcodeproj/project.pbxproj
+++ b/Logue.xcodeproj/project.pbxproj
@@ -466,6 +466,7 @@
 		A9B34E653A84128492DE6474 /* BlockRowView+Actions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FB93A6E198E565413AD03FC /* BlockRowView+Actions.swift */; };
 		A9C752BABC79AFFA2C4FD4F2 /* RecordingSpliceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94CFFCAEABE322C125D85AF3 /* RecordingSpliceTests.swift */; };
 		AA1456FCC75FBB7DFEFC1BE0 /* SpaceFileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 382510F54B865B60B16FDE73 /* SpaceFileTests.swift */; };
+		AAD4545E8533F6E509CC380C /* ModeChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD351EF77433FF052A024BAF /* ModeChip.swift */; };
 		AAEF3C6465DC0A9EA911FE93 /* AgentRunStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86029AD56EBB4317FFDFB4E4 /* AgentRunStateTests.swift */; };
 		AB209D330BE40FEB735204C7 /* MermaidRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCEE1CC67630CF84E03498D5 /* MermaidRenderer.swift */; };
 		AB5ECDB7A635C2DB974F908D /* SeedDataBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9478E4D1E64E36CDE232568E /* SeedDataBannerView.swift */; };
@@ -1379,6 +1380,7 @@
 		FBCD9FE533E01D4D082FF3EC /* WritingNSTextView+ListContinuation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WritingNSTextView+ListContinuation.swift"; sourceTree = "<group>"; };
 		FC17E4D853587B8D1F0BED80 /* DocumentIconPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentIconPicker.swift; sourceTree = "<group>"; };
 		FCEBD05BEF5831C92DDDE40E /* SuggestionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionParser.swift; sourceTree = "<group>"; };
+		FD351EF77433FF052A024BAF /* ModeChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModeChip.swift; sourceTree = "<group>"; };
 		FD9DB88569857E33E72CCFAE /* OverviewRecentActivityCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverviewRecentActivityCard.swift; sourceTree = "<group>"; };
 		FDFC48D1348543B9A74105F1 /* SpaceStore+MarkdownFolder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SpaceStore+MarkdownFolder.swift"; sourceTree = "<group>"; };
 		FE07F5F09706EA33B61BEF24 /* DocumentTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentTemplate.swift; sourceTree = "<group>"; };
@@ -2020,6 +2022,7 @@
 				C2A85CBFCD11CDF2FB693F73 /* InlineDiagramView.swift */,
 				8CCF492C5BB1691EC0946B25 /* InlineLaTeXView.swift */,
 				0AC3AC1CC9E373112B4CBCBC /* MemoryListView.swift */,
+				FD351EF77433FF052A024BAF /* ModeChip.swift */,
 				D1A491C56C1501F3D06F7734 /* PulsingDot.swift */,
 				2B203FDECC75AFF647507580 /* SourcesPanelView.swift */,
 				A4DB5AD462B4A863201D5D61 /* ToolApprovalButtons.swift */,
@@ -3089,6 +3092,7 @@
 				AB209D330BE40FEB735204C7 /* MermaidRenderer.swift in Sources */,
 				8E93C898597CE89098CAA75E /* MessageActions.swift in Sources */,
 				077711B2656A23EF7E7727AF /* MicrophoneSpeechGate.swift in Sources */,
+				AAD4545E8533F6E509CC380C /* ModeChip.swift in Sources */,
 				C5DD444112B8F0EBD6B1089D /* ModelAction.swift in Sources */,
 				E20DD767DAF8932B1D24E243 /* ModelChip.swift in Sources */,
 				E16818A635960352322D24E5 /* ModelConfiguration.swift in Sources */,

--- a/Logue/Agent/AttachmentIntake.swift
+++ b/Logue/Agent/AttachmentIntake.swift
@@ -1,0 +1,107 @@
+import AppKit
+import UniformTypeIdentifiers
+
+/// Getting files into a message, from wherever the message is being written.
+///
+/// Extracted from `InputBarView`, where it was `private` and therefore unreachable from the
+/// Command Center island — which is why the island has never accepted an attachment at all,
+/// despite `AgentCoordinator.send` taking them since the two surfaces were joined.
+///
+/// The rules here are the ones that were easy to get subtly different in a second copy:
+/// which types are offered, and what happens when the same file arrives twice.
+@MainActor
+enum AttachmentIntake {
+    /// What the picker offers, and by extension what a surface claims to accept.
+    ///
+    /// Drops are deliberately *not* filtered against this. A file manager hands over a URL
+    /// with no type negotiation, and `TempAttachmentLoader` already refuses what it cannot
+    /// read — filtering twice, in two places, is how a file that loads fine starts being
+    /// rejected on one surface and not the other.
+    static let acceptedTypes: [UTType] = [
+        .pdf, .plainText, .text, .image,
+        UTType("org.openxmlformats.spreadsheetml.sheet") ?? .data,
+        UTType("org.openxmlformats.wordprocessingml.document") ?? .data,
+        UTType("org.openxmlformats.presentationml.presentation") ?? .data,
+    ]
+
+    /// Adds `incoming` to `existing`, skipping anything already there.
+    ///
+    /// De-duped by display name rather than by URL: dragging the same file twice is a slip,
+    /// not a request for two copies, and the two drags can carry different URLs for one file
+    /// — a security-scoped copy the second time, for instance.
+    static func merging(
+        _ incoming: [TempAttachment],
+        into existing: [TempAttachment]
+    ) -> [TempAttachment] {
+        var result = existing
+        for attachment in incoming
+            where !result.contains(where: { $0.displayName == attachment.displayName })
+        {
+            result.append(attachment)
+        }
+        return result
+    }
+
+    /// Loads whatever of `urls` can be read. Unreadable files are dropped rather than
+    /// failing the batch: attaching four files and getting none because one was a broken
+    /// alias is worse than attaching three.
+    static func load(urls: [URL]) async -> [TempAttachment] {
+        var loaded: [TempAttachment] = []
+        for url in urls {
+            if let attachment = await TempAttachmentLoader.load(from: url) {
+                loaded.append(attachment)
+            }
+        }
+        return loaded
+    }
+
+    /// Presents the open panel and returns what the user picked, or nothing if they cancelled.
+    static func pickFiles() async -> [TempAttachment] {
+        let panel = NSOpenPanel()
+        panel.allowsMultipleSelection = true
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowedContentTypes = acceptedTypes
+        panel.prompt = "Attach"
+        panel.message = "Select files to attach to your message"
+
+        let urls: [URL] = await withCheckedContinuation { continuation in
+            panel.begin { response in
+                continuation.resume(returning: response == .OK ? panel.urls : [])
+            }
+        }
+        return await load(urls: urls)
+    }
+
+    /// Pulls file URLs out of a drop.
+    ///
+    /// `NSItemProvider` hands back either a `URL` or its `Data` representation depending on
+    /// where the drag came from, so both are unpacked. Anything else is not a file.
+    static func urls(from providers: [NSItemProvider]) async -> [URL] {
+        await withTaskGroup(of: URL?.self) { group in
+            for provider in providers {
+                group.addTask {
+                    await withCheckedContinuation { continuation in
+                        provider.loadItem(forTypeIdentifier: UTType.fileURL.identifier) { item, _ in
+                            switch item {
+                            case let url as URL:
+                                continuation.resume(returning: url)
+                            case let data as Data:
+                                continuation.resume(returning: URL(dataRepresentation: data, relativeTo: nil))
+                            default:
+                                continuation.resume(returning: nil)
+                            }
+                        }
+                    }
+                }
+            }
+            var found: [URL] = []
+            for await url in group {
+                if let url {
+                    found.append(url)
+                }
+            }
+            return found
+        }
+    }
+}

--- a/Logue/Views/Agent/AgentChatView+Input.swift
+++ b/Logue/Views/Agent/AgentChatView+Input.swift
@@ -58,14 +58,8 @@ extension AgentChatView {
             UTType("org.openxmlformats.wordprocessingml.document") ?? .data,
             UTType("org.openxmlformats.presentationml.presentation") ?? .data,
         ]
-        /// File-picker allowlist. Same set, but the picker filters more strictly
-        /// than the drop target.
-        static let acceptedPickerTypes: [UTType] = [
-            .pdf, .plainText, .text, .image,
-            UTType("org.openxmlformats.spreadsheetml.sheet") ?? .data,
-            UTType("org.openxmlformats.wordprocessingml.document") ?? .data,
-            UTType("org.openxmlformats.presentationml.presentation") ?? .data,
-        ]
+        // File-picker allowlist. Same set, but the picker filters more strictly
+        // than the drop target.
 
         var body: some View {
             VStack(spacing: 0) {
@@ -387,50 +381,19 @@ extension AgentChatView {
         /// same `TempAttachmentLoader` as drag-and-drop so the resulting chips and
         /// extracted text use one code path. De-duplicates by display name.
         private func openFilePicker() {
-            let panel = NSOpenPanel()
-            panel.allowsMultipleSelection = true
-            panel.canChooseFiles = true
-            panel.canChooseDirectories = false
-            panel.allowedContentTypes = Self.acceptedPickerTypes
-            panel.prompt = "Attach"
-            panel.message = "Select files to attach to your message"
-            panel.begin { response in
-                guard response == .OK else { return }
-                let urls = panel.urls
-                Task { @MainActor in
-                    for url in urls {
-                        guard let attachment = await TempAttachmentLoader.load(from: url) else { continue }
-                        if !attachments.contains(where: { $0.displayName == attachment.displayName }) {
-                            attachments.append(attachment)
-                        }
-                    }
-                }
+            Task { @MainActor in
+                let picked = await AttachmentIntake.pickFiles()
+                attachments = AttachmentIntake.merging(picked, into: attachments)
             }
         }
 
         // MARK: - Drop handling
 
         private func handleDrop(providers: [NSItemProvider]) {
-            for provider in providers {
-                provider.loadItem(forTypeIdentifier: UTType.fileURL.identifier) { item, _ in
-                    let url: URL? = switch item {
-                    case let dataURL as URL:
-                        dataURL
-                    case let data as Data:
-                        URL(dataRepresentation: data, relativeTo: nil)
-                    default:
-                        nil
-                    }
-                    guard let url else { return }
-                    Task { @MainActor in
-                        if let attachment = await TempAttachmentLoader.load(from: url) {
-                            // De-dupe by URL filename — dragging the same file twice is a no-op.
-                            if !attachments.contains(where: { $0.displayName == attachment.displayName }) {
-                                attachments.append(attachment)
-                            }
-                        }
-                    }
-                }
+            Task { @MainActor in
+                let urls = await AttachmentIntake.urls(from: providers)
+                let loaded = await AttachmentIntake.load(urls: urls)
+                attachments = AttachmentIntake.merging(loaded, into: attachments)
             }
         }
 

--- a/Logue/Views/Agent/AgentChatView+Input.swift
+++ b/Logue/Views/Agent/AgentChatView+Input.swift
@@ -160,7 +160,7 @@ extension AgentChatView {
         private var activeModeChips: some View {
             HStack(spacing: 6) {
                 if isWebSearchOnce {
-                    modeChip(
+                    ModeChip(
                         title: "Search",
                         systemImage: "globe",
                         tint: AppThemeConstants.brandPrimary
@@ -169,7 +169,7 @@ extension AgentChatView {
                     }
                 }
                 if isDeepResearch {
-                    modeChip(
+                    ModeChip(
                         title: "Deep research",
                         systemImage: "sparkle.magnifyingglass",
                         tint: AppThemeConstants.brandPrimary
@@ -179,38 +179,6 @@ extension AgentChatView {
                 }
                 Spacer(minLength: 0)
             }
-        }
-
-        private func modeChip(
-            title: String,
-            systemImage: String,
-            tint: Color,
-            onDismiss: @escaping () -> Void
-        ) -> some View {
-            HStack(spacing: 4) {
-                Image(systemName: systemImage)
-                    .font(.caption)
-                Text(title)
-                    .font(.caption.weight(.medium))
-                Button {
-                    onDismiss()
-                } label: {
-                    Image(systemName: "xmark")
-                        .font(.caption2)
-                }
-                .buttonStyle(.plain)
-                .help("Turn off \(title)")
-            }
-            .padding(.horizontal, 8)
-            .padding(.vertical, 3)
-            .foregroundStyle(tint)
-            .background(
-                Capsule().fill(tint.opacity(0.14))
-            )
-            .overlay(
-                Capsule().strokeBorder(tint.opacity(0.45), lineWidth: 0.5)
-            )
-            .transition(.scale.combined(with: .opacity))
         }
 
         // MARK: - Card Chrome

--- a/Logue/Views/Agent/ModeChip.swift
+++ b/Logue/Views/Agent/ModeChip.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+/// A mode that is on for the next send, with a way to turn it off.
+///
+/// Lifted out of `InputBarView` so the Command Center island shows the same chip rather than
+/// drawing its own. The modes are stored in `UserDefaults` and read by both surfaces *and* by
+/// the coordinator, so a chip that looked different on one of them would be describing the
+/// same state in two voices.
+struct ModeChip: View {
+    let title: String
+    let systemImage: String
+    let tint: Color
+    /// Turns the mode off. The `×` exists so a mode can be dropped without reopening the menu
+    /// that set it.
+    let onDismiss: () -> Void
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Image(systemName: systemImage)
+                .font(.caption)
+            Text(title)
+                .font(.caption.weight(.medium))
+            Button(action: onDismiss) {
+                Image(systemName: "xmark")
+                    .font(.caption2)
+            }
+            .buttonStyle(.plain)
+            .help("Turn off \(title)")
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 3)
+        .foregroundStyle(tint)
+        .background(Capsule().fill(tint.opacity(0.14)))
+        .overlay(Capsule().strokeBorder(tint.opacity(0.45), lineWidth: 0.5))
+        .transition(.scale.combined(with: .opacity))
+    }
+}

--- a/Logue/Views/CrossApp/CommandCenterChatView+Composer.swift
+++ b/Logue/Views/CrossApp/CommandCenterChatView+Composer.swift
@@ -1,0 +1,148 @@
+import SwiftUI
+
+/// The island's composer: the prompt pill, what is staged for the next send, and the two ways
+/// a file gets in.
+///
+/// Split out for the same reason as `+Bubbles` — giving the island attachments took the view's
+/// body past the 450-line cap. The intake itself lives in `AttachmentIntake`, shared with the
+/// main window; this is only how the island presents it.
+extension CommandCenterChatView {
+    /// Rendered by the view itself, so it crosses the file boundary.
+    var promptPill: some View {
+        HStack(alignment: .center, spacing: 12) {
+            // App logo
+            Image(nsImage: NSApp.applicationIconImage)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 28, height: 28)
+                .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+
+            // Input field
+            TextField("What can I help you with?", text: $inputText, axis: .vertical)
+                .font(.body)
+                .foregroundStyle(.white)
+                .textFieldStyle(.plain)
+                .focused($isInputFocused)
+                .lineLimit(1 ... 4)
+                .onKeyPress(.return, phases: .down) { _ in
+                    if NSEvent.modifierFlags.contains(.shift) {
+                        inputText += "\n"
+                        return .handled
+                    } else if canSend {
+                        sendMessage()
+                        return .handled
+                    }
+                    return .handled
+                }
+
+            // Attach
+            Button {
+                Task { @MainActor in
+                    let picked = await AttachmentIntake.pickFiles()
+                    attachments = AttachmentIntake.merging(picked, into: attachments)
+                }
+            } label: {
+                Image(systemName: "paperclip")
+                    .font(.subheadline.weight(.medium))
+                    .foregroundStyle(.white.opacity(0.4))
+                    .frame(width: 28, height: 28)
+            }
+            .buttonStyle(.plain)
+            .disabled(isGenerating)
+            .help("Attach files")
+
+            // Mic button
+            Button {
+                voiceManager.toggle()
+            } label: {
+                Image(systemName: voiceManager.isRecording ? "mic.fill" : "mic")
+                    .font(.subheadline.weight(.medium))
+                    .foregroundStyle(voiceManager.isRecording ? AppThemeConstants.error : .white.opacity(0.4))
+                    .frame(width: 28, height: 28)
+            }
+            .buttonStyle(.plain)
+            .disabled(isGenerating)
+            .help(voiceManager.isRecording ? "Stop voice input" : "Voice input")
+
+            // Send / Stop
+            if isGenerating {
+                Button(action: stopStreaming) {
+                    Image(systemName: "stop.fill")
+                        .font(.subheadline.weight(.bold))
+                        .foregroundStyle(.white)
+                        .frame(width: 32, height: 32)
+                        .background(Circle().fill(AppThemeConstants.error))
+                }
+                .buttonStyle(.plain)
+            } else {
+                Button(action: sendMessage) {
+                    Image(systemName: "arrow.up")
+                        .font(.subheadline.weight(.bold))
+                        .foregroundStyle(canSend ? .white : .white.opacity(0.25))
+                        .frame(width: 32, height: 32)
+                        .background(
+                            Circle().fill(canSend ? AppThemeConstants.brandPrimary : Color.white.opacity(0.08))
+                        )
+                }
+                .buttonStyle(.plain)
+                .disabled(!canSend || LLMEngineStatus.shared.isBusy)
+                .keyboardShortcut(.return, modifiers: .command)
+            }
+        }
+        .padding(.leading, 14)
+        .padding(.trailing, 10)
+        .padding(.vertical, 10)
+        .background(
+            RoundedRectangle(cornerRadius: 22, style: .continuous)
+                .fill(Color(nsColor: NSColor(red: 0.11, green: 0.11, blue: 0.12, alpha: 0.92)))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 22, style: .continuous)
+                .stroke(Color.white.opacity(0.07), lineWidth: 0.5)
+        )
+        .shadow(color: .black.opacity(0.35), radius: 30, y: 12)
+        .overlay(alignment: .top) {
+            if !attachments.isEmpty {
+                attachmentChips
+                    .offset(y: -34)
+            }
+        }
+        // Dropping onto the pill is the same intake as the picker, so a file arrives the
+        // same way whichever route the user takes.
+        .onDrop(of: [.fileURL], isTargeted: nil) { providers in
+            Task { @MainActor in
+                let urls = await AttachmentIntake.urls(from: providers)
+                let loaded = await AttachmentIntake.load(urls: urls)
+                attachments = AttachmentIntake.merging(loaded, into: attachments)
+            }
+            return true
+        }
+    }
+
+    /// What is staged for the next send, with a way to take each one back off.
+    private var attachmentChips: some View {
+        HStack(spacing: 6) {
+            ForEach(attachments) { attachment in
+                HStack(spacing: 4) {
+                    Image(systemName: "doc")
+                        .font(.caption2)
+                    Text(attachment.displayName)
+                        .font(.caption2)
+                        .lineLimit(1)
+                    Button {
+                        attachments.removeAll { $0.id == attachment.id }
+                    } label: {
+                        Image(systemName: "xmark")
+                            .font(.system(size: 8, weight: .bold))
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Remove \(attachment.displayName)")
+                }
+                .foregroundStyle(.white.opacity(0.8))
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(Capsule().fill(Color.white.opacity(0.12)))
+            }
+        }
+    }
+}

--- a/Logue/Views/CrossApp/CommandCenterChatView+Composer.swift
+++ b/Logue/Views/CrossApp/CommandCenterChatView+Composer.swift
@@ -51,6 +51,21 @@ extension CommandCenterChatView {
             .disabled(isGenerating)
             .help("Attach files")
 
+            // Web search for this turn
+            Button {
+                withAnimation(.easeOut(duration: 0.15)) { isWebSearchOnce.toggle() }
+            } label: {
+                Image(systemName: "globe")
+                    .font(.subheadline.weight(.medium))
+                    .foregroundStyle(
+                        isWebSearchOnce ? AppThemeConstants.brandPrimary : .white.opacity(0.4)
+                    )
+                    .frame(width: 28, height: 28)
+            }
+            .buttonStyle(.plain)
+            .disabled(isGenerating)
+            .help(isWebSearchOnce ? "Web search is on for this message" : "Search the web for this message")
+
             // Mic button
             Button {
                 voiceManager.toggle()
@@ -102,7 +117,7 @@ extension CommandCenterChatView {
         )
         .shadow(color: .black.opacity(0.35), radius: 30, y: 12)
         .overlay(alignment: .top) {
-            if !attachments.isEmpty {
+            if !attachments.isEmpty || isWebSearchOnce {
                 attachmentChips
                     .offset(y: -34)
             }
@@ -122,6 +137,15 @@ extension CommandCenterChatView {
     /// What is staged for the next send, with a way to take each one back off.
     private var attachmentChips: some View {
         HStack(spacing: 6) {
+            if isWebSearchOnce {
+                ModeChip(
+                    title: "Search",
+                    systemImage: "globe",
+                    tint: AppThemeConstants.brandPrimary
+                ) {
+                    isWebSearchOnce = false
+                }
+            }
             ForEach(attachments) { attachment in
                 HStack(spacing: 4) {
                     Image(systemName: "doc")

--- a/Logue/Views/CrossApp/CommandCenterChatView.swift
+++ b/Logue/Views/CrossApp/CommandCenterChatView.swift
@@ -38,6 +38,15 @@ struct CommandCenterChatView: View {
     /// Files staged for the next send. The island could not accept any until the intake was
     /// lifted out of the main window's input bar — see `AttachmentIntake`.
     @State var attachments: [TempAttachment] = []
+    // Extension-visible: +Composer
+    /// Web search for the next send.
+    ///
+    /// The same `UserDefaults` key the main window's chip binds, because the coordinator reads
+    /// it too — three readers of one value rather than a copy per surface. It follows that the
+    /// island must clear it after a send exactly as the main window does, or a search switched
+    /// on here silently arms the next send over there.
+    @AppStorage(AppConstants.UserDefaultsKeys.oneShotWebSearch)
+    var isWebSearchOnce: Bool = false
     // Extension-visible: +Bubbles
     @State var copiedMessageID: UUID?
     // Extension-visible: +Bubbles
@@ -288,8 +297,12 @@ struct CommandCenterChatView: View {
 
         let conversationID = ensureConversation()
         let staged = attachments
+        let searchThisTurn = isWebSearchOnce
         inputText = ""
         attachments = []
+        // Cleared per send, like the main window's chip. Left set, a search switched on here
+        // would arm the next send in the other window too.
+        isWebSearchOnce = false
 
         // Re-focus input after state update
         Task {
@@ -301,11 +314,21 @@ struct CommandCenterChatView: View {
         case .agentLoop, .deepResearch:
             // Deep Research is unreachable from here — no chip lights it — and if it ever
             // becomes reachable it belongs on the same coordinator, not a second pipeline.
-            coordinator.send(message: text, conversationID: conversationID, attachments: staged)
+            coordinator.send(
+                message: text,
+                conversationID: conversationID,
+                attachments: staged,
+                oneShotWebSearch: searchThisTurn
+            )
         case let .imagePlayground(concept):
             // ImagePlayground presents a sheet, which a floating pill cannot host. Answer it
             // as a normal turn rather than silently dropping the send.
-            coordinator.send(message: concept, conversationID: conversationID, attachments: staged)
+            coordinator.send(
+                message: concept,
+                conversationID: conversationID,
+                attachments: staged,
+                oneShotWebSearch: searchThisTurn
+            )
         }
     }
 

--- a/Logue/Views/CrossApp/CommandCenterChatView.swift
+++ b/Logue/Views/CrossApp/CommandCenterChatView.swift
@@ -32,7 +32,12 @@ struct CommandCenterChatView: View {
     @State private var conversationID: UUID?
     @State private var store = AgentConversationStore.shared
     @State private var coordinator = AgentCoordinator.shared
-    @State private var inputText: String = ""
+    // Extension-visible: +Composer
+    @State var inputText: String = ""
+    // Extension-visible: +Composer
+    /// Files staged for the next send. The island could not accept any until the intake was
+    /// lifted out of the main window's input bar — see `AttachmentIntake`.
+    @State var attachments: [TempAttachment] = []
     // Extension-visible: +Bubbles
     @State var copiedMessageID: UUID?
     // Extension-visible: +Bubbles
@@ -40,9 +45,11 @@ struct CommandCenterChatView: View {
     // Extension-visible: +Bubbles
     @State var speakingMessageID: UUID?
     @State private var synthesizer = AVSpeechSynthesizer()
-    @FocusState private var isInputFocused: Bool
+    // Extension-visible: +Composer
+    @FocusState var isInputFocused: Bool
 
-    private var voiceManager: VoicePushToTalkManager {
+    // Extension-visible: +Composer
+    var voiceManager: VoicePushToTalkManager {
         .shared
     }
 
@@ -76,8 +83,9 @@ struct CommandCenterChatView: View {
         }
     }
 
+    // Extension-visible: +Composer
     /// Whether the island's own thread is busy — never the main window's.
-    private var isGenerating: Bool {
+    var isGenerating: Bool {
         guard let conversationID else { return false }
         return coordinator.isProcessing(in: conversationID)
     }
@@ -254,94 +262,16 @@ struct CommandCenterChatView: View {
         )
     }
 
-    // MARK: - Prompt Pill
-
-    private var promptPill: some View {
-        HStack(alignment: .center, spacing: 12) {
-            // App logo
-            Image(nsImage: NSApp.applicationIconImage)
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .frame(width: 28, height: 28)
-                .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
-
-            // Input field
-            TextField("What can I help you with?", text: $inputText, axis: .vertical)
-                .font(.body)
-                .foregroundStyle(.white)
-                .textFieldStyle(.plain)
-                .focused($isInputFocused)
-                .lineLimit(1 ... 4)
-                .onKeyPress(.return, phases: .down) { _ in
-                    if NSEvent.modifierFlags.contains(.shift) {
-                        inputText += "\n"
-                        return .handled
-                    } else if canSend {
-                        sendMessage()
-                        return .handled
-                    }
-                    return .handled
-                }
-
-            // Mic button
-            Button {
-                voiceManager.toggle()
-            } label: {
-                Image(systemName: voiceManager.isRecording ? "mic.fill" : "mic")
-                    .font(.subheadline.weight(.medium))
-                    .foregroundStyle(voiceManager.isRecording ? AppThemeConstants.error : .white.opacity(0.4))
-                    .frame(width: 28, height: 28)
-            }
-            .buttonStyle(.plain)
-            .disabled(isGenerating)
-            .help(voiceManager.isRecording ? "Stop voice input" : "Voice input")
-
-            // Send / Stop
-            if isGenerating {
-                Button(action: stopStreaming) {
-                    Image(systemName: "stop.fill")
-                        .font(.subheadline.weight(.bold))
-                        .foregroundStyle(.white)
-                        .frame(width: 32, height: 32)
-                        .background(Circle().fill(AppThemeConstants.error))
-                }
-                .buttonStyle(.plain)
-            } else {
-                Button(action: sendMessage) {
-                    Image(systemName: "arrow.up")
-                        .font(.subheadline.weight(.bold))
-                        .foregroundStyle(canSend ? .white : .white.opacity(0.25))
-                        .frame(width: 32, height: 32)
-                        .background(
-                            Circle().fill(canSend ? AppThemeConstants.brandPrimary : Color.white.opacity(0.08))
-                        )
-                }
-                .buttonStyle(.plain)
-                .disabled(!canSend || LLMEngineStatus.shared.isBusy)
-                .keyboardShortcut(.return, modifiers: .command)
-            }
-        }
-        .padding(.leading, 14)
-        .padding(.trailing, 10)
-        .padding(.vertical, 10)
-        .background(
-            RoundedRectangle(cornerRadius: 22, style: .continuous)
-                .fill(Color(nsColor: NSColor(red: 0.11, green: 0.11, blue: 0.12, alpha: 0.92)))
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 22, style: .continuous)
-                .stroke(Color.white.opacity(0.07), lineWidth: 0.5)
-        )
-        .shadow(color: .black.opacity(0.35), radius: 30, y: 12)
-    }
-
     // MARK: - Logic
 
-    private var canSend: Bool {
-        !inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !isGenerating
+    // Extension-visible: +Composer
+    var canSend: Bool {
+        (!inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || !attachments.isEmpty)
+            && !isGenerating
     }
 
-    private func sendMessage() {
+    // Extension-visible: +Composer
+    func sendMessage() {
         let text = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
 
         // The same routing decision the main window makes. The island has no Deep Research
@@ -350,13 +280,16 @@ struct CommandCenterChatView: View {
         let route = AskRouter.route(
             for: AskRouter.Request(
                 text: text,
+                hasAttachments: !attachments.isEmpty,
                 imageIntentFires: PromptIntentClassifier.shared.shouldPresentImagePlayground(for: text)
             )
         )
         guard let route, !isGenerating else { return }
 
         let conversationID = ensureConversation()
+        let staged = attachments
         inputText = ""
+        attachments = []
 
         // Re-focus input after state update
         Task {
@@ -368,11 +301,11 @@ struct CommandCenterChatView: View {
         case .agentLoop, .deepResearch:
             // Deep Research is unreachable from here — no chip lights it — and if it ever
             // becomes reachable it belongs on the same coordinator, not a second pipeline.
-            coordinator.send(message: text, conversationID: conversationID)
+            coordinator.send(message: text, conversationID: conversationID, attachments: staged)
         case let .imagePlayground(concept):
             // ImagePlayground presents a sheet, which a floating pill cannot host. Answer it
             // as a normal turn rather than silently dropping the send.
-            coordinator.send(message: concept, conversationID: conversationID)
+            coordinator.send(message: concept, conversationID: conversationID, attachments: staged)
         }
     }
 
@@ -482,7 +415,8 @@ struct CommandCenterChatView: View {
         return conversation.id
     }
 
-    private func stopStreaming() {
+    // Extension-visible: +Composer
+    func stopStreaming() {
         coordinator.cancel()
         isInputFocused = true
     }

--- a/LogueTests/AttachmentIntakeTests.swift
+++ b/LogueTests/AttachmentIntakeTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Testing
+
+@testable import Logue
+
+/// The one piece of attachment intake that is pure, and the one worth pinning.
+///
+/// The picker and the drop unpacking touch `NSOpenPanel` and `NSItemProvider`, neither of
+/// which runs headlessly. The de-dupe rule does, and it is the part two surfaces could
+/// disagree about now that both call it — which is exactly why it stopped being `private`.
+@Suite("AttachmentIntake")
+@MainActor
+struct AttachmentIntakeTests {
+    private func attachment(_ name: String) -> TempAttachment {
+        TempAttachment(
+            kind: .plainText,
+            displayName: name,
+            extractedText: "contents of \(name)",
+            iconName: "doc"
+        )
+    }
+
+    @Test("The same file arriving twice is added once")
+    func duplicatesAreSkipped() {
+        // Dragging a file twice is a slip, not a request for two copies.
+        let existing = [attachment("notes.md")]
+        let merged = AttachmentIntake.merging([attachment("notes.md")], into: existing)
+        #expect(merged.count == 1)
+    }
+
+    @Test("Matching is by display name, not identity")
+    func matchesOnName() {
+        // The two drags carry different `TempAttachment` values — a fresh id each time, and
+        // in the real case possibly a different security-scoped URL for one file on disk.
+        // Comparing identity would let the same file in twice.
+        let first = attachment("report.pdf")
+        let second = attachment("report.pdf")
+        #expect(first.id != second.id)
+        #expect(AttachmentIntake.merging([second], into: [first]).count == 1)
+    }
+
+    @Test("Different files all arrive")
+    func distinctFilesAreKept() {
+        let merged = AttachmentIntake.merging(
+            [attachment("b.txt"), attachment("c.txt")],
+            into: [attachment("a.txt")]
+        )
+        #expect(merged.map(\.displayName) == ["a.txt", "b.txt", "c.txt"])
+    }
+
+    @Test("Order is preserved, with new files after the ones already staged")
+    func orderIsStable() {
+        // The chips read left to right in the order they were added; re-ordering on every
+        // drop would move a chip out from under the pointer about to close it.
+        let merged = AttachmentIntake.merging(
+            [attachment("z.txt"), attachment("a.txt")],
+            into: [attachment("m.txt")]
+        )
+        #expect(merged.map(\.displayName) == ["m.txt", "z.txt", "a.txt"])
+    }
+
+    @Test("A batch containing a duplicate keeps the rest")
+    func partialDuplicateKeepsTheRest() {
+        // Dropping a folder's worth of files where one is already staged should attach the
+        // others rather than being treated as a repeat of the whole batch.
+        let merged = AttachmentIntake.merging(
+            [attachment("a.txt"), attachment("new.txt")],
+            into: [attachment("a.txt")]
+        )
+        #expect(merged.map(\.displayName) == ["a.txt", "new.txt"])
+    }
+
+    @Test("Merging nothing changes nothing")
+    func emptyIncomingIsANoOp() {
+        let existing = [attachment("a.txt")]
+        #expect(AttachmentIntake.merging([], into: existing).map(\.displayName) == ["a.txt"])
+    }
+}


### PR DESCRIPTION
**Part of #61** — the attachment half of *"composer parts shared: attachment intake, `+` menu, mode chips, file chips"*. **Stacked on #71**; review that first.

## The gap

`AgentCoordinator.send` has taken attachments since the two surfaces were joined in #69. The island still could not send one — because the picker, the drop unpacking, the accepted types and the de-dupe rule were all `private` inside `InputBarView`, which is nested inside `AgentChatView`.

The capability existed. The way to put a file into it was locked inside a view the island does not use.

## What is here

**`AttachmentIntake`** — that logic with no view attached, called by both surfaces. Three rules were worth stating once, because a second copy would have got each subtly different:

- **Drops are not filtered against the accepted types.** A file manager hands over a URL with no type negotiation, and `TempAttachmentLoader` already refuses what it cannot read. Filtering in two places is how a file that loads fine starts being rejected on one surface and not the other.
- **De-dupe is by display name, not URL.** Dragging the same file twice is a slip rather than a request for two copies, and the two drags can carry different URLs for one file.
- **An unreadable file is dropped, not fatal.** Attaching four files and getting none because one was a broken alias is worse than attaching three.

**The island accepts files.** A paperclip, a drop onto the pill, a removable chip per staged file, and the files handed to `coordinator.send`. Both routes call the same intake, so a file arrives the same way whichever the user takes — and the same way it does in the main window.

Three details follow from attachments existing there at all:

- **`canSend` accepts an attachment with no text.** Dropping a file and pressing return is a real send; requiring a prompt would make the drop look ignored.
- **`hasAttachments` reaches `AskRouter`**, so the existing rule applies: someone who dropped a document and typed "draw me a diagram of this" gets the agent reading the file, not ImagePlayground inventing a picture.
- **Staged files are captured before the field is cleared**, so a send routed through ImagePlayground carries them rather than dropping them.

## Verification

**1526 tests in 130 suites** pass; SwiftFormat 0.62.1 and SwiftLint 0.65.0 clean at the versions CI pins.

`AttachmentIntakeTests` covers the de-dupe rule now that two surfaces depend on it, including the two a second implementation would have got wrong: a batch containing one already-staged file still attaches the rest, and matching is by display name rather than identity, since each drag mints a fresh `TempAttachment` for the same file on disk.

The picker and the drop unpacking are not covered — they touch `NSOpenPanel` and `NSItemProvider`, neither of which runs headlessly.

## What a reviewer should click

The main window is a **refactor of a working path**, so it is the regression risk:

1. Attach via `+`, drag a file in, drag the same file twice (a no-op), drag several at once.

The island is new, and needs Accessibility permission and a loaded model:

2. Drag a file onto the pill — a chip appears, and the × takes it off again.
3. Drop a file and press return with **no text** — it should send rather than look ignored.
4. Attach a document and ask "draw me a diagram of this" — the agent should read the file rather than opening ImagePlayground.

## Mode chips

`ModeChip` is lifted out of `InputBarView` too, so both surfaces show the same chip rather than each drawing one. The modes live in `UserDefaults` and are read by both surfaces **and** the coordinator, so a chip that looked different on one of them would be describing the same state in two voices.

The island gains a globe beside the paperclip, the chip when it is on, and `oneShotWebSearch:` on the send it had always been passing as `false`.

**The clearing is the part worth getting right.** `isWebSearchOnce` is one `UserDefaults` key, not a copy per surface — that is what keeps the coordinator in step — but it means a search switched on in the island and left set would silently arm the next send *in the main window*. It is captured for the turn and cleared immediately, exactly as the input bar does.

Worth clicking: turn search on in the island, send, confirm the chip clears — then check the main window's input bar is not still armed.

## Not here

**Deep Research**, deliberately. It runs through `DeepResearchCoordinator` and presents a progress view; a floating pill has nowhere to put that, and `AskRouter` already answers a lit Deep Research chip from the island as an ordinary turn rather than dropping the send. A chip the island could not honour would be worse than not offering one.

**The `+` menu as a menu.** The island surfaces the same two actions as buttons in the pill instead — there is no room for a popover over another app, and two controls do not need a menu to hold them.

