### PR TITLE
Land the #61 stack on main — #71 and #72 merged into branches that had already been consumed

### DIFF
--- a/Logue.xcodeproj/project.pbxproj
+++ b/Logue.xcodeproj/project.pbxproj
@@ -503,6 +503,7 @@
 		B7B53337BC65FF52350811CA /* SaveSummaryToDocumentSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64EBF5DF74CDD38CF0672831 /* SaveSummaryToDocumentSheet.swift */; };
 		B7D01F57BC78338825E2F9E1 /* WikiLinkCandidates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AAC8C464AD83B42DE49792C /* WikiLinkCandidates.swift */; };
 		B824D9860D0A36CC7346F386 /* MeetingMemoryIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3474D653C2A7624A299D8F8F /* MeetingMemoryIndex.swift */; };
+		B9F942962E4C4EBA6994CCF3 /* MessageActionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88A1A4DAACB05EBD1C285AF9 /* MessageActionsTests.swift */; };
 		BB1D1282E05AB0421F6D34DA /* RecordingSessionManager+DeviceLoss.swift in Sources */ = {isa = PBXBuildFile; fileRef = 675AEB89611D249202B95F30 /* RecordingSessionManager+DeviceLoss.swift */; };
 		BB6359369F688CF7176F9FD3 /* FolderSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = F62A7CA640C03A90AE0AEA26 /* FolderSnapshot.swift */; };
 		BC2C3ECF279AC5A50444CB47 /* SavedRecordingTrustTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30AC57F16E3BF3139F64CF79 /* SavedRecordingTrustTests.swift */; };
@@ -1081,6 +1082,7 @@
 		87A5F89112EFC50A714AFD79 /* SandboxContainerMigratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SandboxContainerMigratorTests.swift; sourceTree = "<group>"; };
 		88018F4CBB121A88EF363BBE /* MeetingListContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingListContentView.swift; sourceTree = "<group>"; };
 		8876D7837082707205CBFC6D /* LogueApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogueApp.swift; sourceTree = "<group>"; };
+		88A1A4DAACB05EBD1C285AF9 /* MessageActionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageActionsTests.swift; sourceTree = "<group>"; };
 		88C42C0A1E60F8FC22AC2EF3 /* BlockPasteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockPasteTests.swift; sourceTree = "<group>"; };
 		89916892E9BF400CDC89E1FF /* WebSearchTools.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSearchTools.swift; sourceTree = "<group>"; };
 		89D2D180775E0F9C8735345F /* ShortcutsSettingsTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutsSettingsTab.swift; sourceTree = "<group>"; };
@@ -1518,6 +1520,7 @@
 				98CF1BA4C3D6569694E01167 /* MarkdownImportTests.swift */,
 				E99E38903F074560903C7BAE /* MarkdownStorageMigratorTests.swift */,
 				640842B5780506F6C1A32F84 /* MarkdownStorageReenableTests.swift */,
+				88A1A4DAACB05EBD1C285AF9 /* MessageActionsTests.swift */,
 				46D5AD1551B13733D986BC37 /* NavigationHistoryTests.swift */,
 				D417341CA0E1725E2C8FB9BA /* NeighborhoodTests.swift */,
 				DA91866185B2C46BE60A76CB /* PreRollBufferTests.swift */,
@@ -2740,6 +2743,7 @@
 				E91DAB3A4652D6191D42770D /* MarkdownStorageMigratorTests.swift in Sources */,
 				88BAD2B1AEA0E379078BE2F6 /* MarkdownStorageReenableTests.swift in Sources */,
 				7685B4E18D7F1A25AE0F6738 /* MeetingLLMTests.swift in Sources */,
+				B9F942962E4C4EBA6994CCF3 /* MessageActionsTests.swift in Sources */,
 				A73935430EF00561EE6074E9 /* NavigationHistoryTests.swift in Sources */,
 				6D5F5E356DF157A16246B26C /* NeighborhoodTests.swift in Sources */,
 				35FC159E499EA14E07D6304B /* PreRollBufferTests.swift in Sources */,

--- a/Logue.xcodeproj/project.pbxproj
+++ b/Logue.xcodeproj/project.pbxproj
@@ -334,6 +334,7 @@
 		7328DEDD5667BF5F7A16A4C2 /* TranscriptionGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E668898070AF96B807C38D40 /* TranscriptionGate.swift */; };
 		734957AB953D227AAB99B235 /* MarkdownFolderScan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ECE5E10FE57E5C4B9E6658E /* MarkdownFolderScan.swift */; };
 		741C509F3A43CBF008D9C4BC /* ModelManager+Discovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9230215EEC7592F9378CA66C /* ModelManager+Discovery.swift */; };
+		74E1ECCB2472ED6957C5E552 /* CommandCenterChatView+Bubbles.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7847A3DB8F8CA72ECAE813F /* CommandCenterChatView+Bubbles.swift */; };
 		7574BF423E60FC56B9897A92 /* DeepResearchModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 293A43BD40C7FE1683585702 /* DeepResearchModels.swift */; };
 		7596EB185C35404F37571D7B /* TaskTextCommitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F736650FD9301A96321554D6 /* TaskTextCommitTests.swift */; };
 		75E00B6D645BDF14E88D8DDB /* DocumentSearchState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7D771D4ECF4472264165F1C /* DocumentSearchState.swift */; };
@@ -1353,6 +1354,7 @@
 		F6EA5546BBF8C4D1187CD26E /* LangGraph-Swift */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "LangGraph-Swift"; path = "Vendor/LangGraph-Swift"; sourceTree = SOURCE_ROOT; };
 		F736650FD9301A96321554D6 /* TaskTextCommitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskTextCommitTests.swift; sourceTree = "<group>"; };
 		F773F30D16F4FF92E56320E1 /* HomeContinueGridTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeContinueGridTests.swift; sourceTree = "<group>"; };
+		F7847A3DB8F8CA72ECAE813F /* CommandCenterChatView+Bubbles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CommandCenterChatView+Bubbles.swift"; sourceTree = "<group>"; };
 		F78B9E200B32B9974F32CF7D /* LLMResponseParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LLMResponseParser.swift; sourceTree = "<group>"; };
 		F7B886861180D41A132F1B6A /* AgentChatView+Input.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AgentChatView+Input.swift"; sourceTree = "<group>"; };
 		F7E1089CE3E964A5BC0545A8 /* whatsnew-wikilinks.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "whatsnew-wikilinks.png"; sourceTree = "<group>"; };
@@ -2280,6 +2282,7 @@
 			isa = PBXGroup;
 			children = (
 				19129D8F0F9161BC3E21AA0F /* CommandCenterChatView.swift */,
+				F7847A3DB8F8CA72ECAE813F /* CommandCenterChatView+Bubbles.swift */,
 				7ABC89CED798F0088E00B682 /* CommandCenterComposeView.swift */,
 				E7300054D056065027CC1FF3 /* CommandCenterNewMeetingView.swift */,
 				24578E3A172E90DC703D4C9D /* CommandCenterPIIView.swift */,
@@ -2870,6 +2873,7 @@
 				064963B61C0242F39204C049 /* CodeSyntaxHighlighter.swift in Sources */,
 				1CF5D6AE20C1BDE279762B9F /* ComingSoonPanelView.swift in Sources */,
 				4BD0DCD9E20A28C06D40AF62 /* CommandCenterChatRule.swift in Sources */,
+				74E1ECCB2472ED6957C5E552 /* CommandCenterChatView+Bubbles.swift in Sources */,
 				E5DF85C2C0803078D80C350C /* CommandCenterChatView.swift in Sources */,
 				5CBFF3B40F91960EC8178989 /* CommandCenterComposeView.swift in Sources */,
 				99FCB8FEB17A1DA884E6892C /* CommandCenterController.swift in Sources */,

--- a/Logue.xcodeproj/project.pbxproj
+++ b/Logue.xcodeproj/project.pbxproj
@@ -204,6 +204,7 @@
 		457B5F17B248B73950E85F0C /* CanvasSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31784F4F4DF98021B23FFFA9 /* CanvasSnapshot.swift */; };
 		45C718CBF00AF53ECFD9267D /* Neighborhood.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9017DE8546F2B3F48A6C3EB /* Neighborhood.swift */; };
 		4670A7C21D3D7C569ED2C057 /* VoiceInputIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D147FADD3CE97D983829125 /* VoiceInputIndicator.swift */; };
+		46C1636E40764DBB285B5C03 /* CommandCenterChatView+Composer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026499B13ACB9A5937CCC44A /* CommandCenterChatView+Composer.swift */; };
 		472EB0BDEFF4B649154E4D12 /* CharCounter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 141A999128E664D7D97120BB /* CharCounter.swift */; };
 		477DF8B7B1F59630238F15A1 /* FilterChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1422ADE4317F2B8650E23D7 /* FilterChip.swift */; };
 		47AF1C29A0DE6C0767146BA6 /* LLMClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA90D7698CBC2EB6CBF52AFB /* LLMClient.swift */; };
@@ -612,6 +613,7 @@
 		E4DE20313B09FFD5F231BFBB /* TranscriptionGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C7DA3D5F0B7598F71D9D15 /* TranscriptionGateTests.swift */; };
 		E536E26DFCF028B14B186996 /* SectionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1153D35EF20882A425B5D836 /* SectionHeader.swift */; };
 		E560D4C6313E3EBFDF0D32B3 /* BlockFrameStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3F2421D7F17F2EE5A04EF7F /* BlockFrameStoreTests.swift */; };
+		E5908FC6811FA07E101AB6F1 /* AttachmentIntakeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A8627FAD5FB6C9F54FE23A2 /* AttachmentIntakeTests.swift */; };
 		E5DF85C2C0803078D80C350C /* CommandCenterChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19129D8F0F9161BC3E21AA0F /* CommandCenterChatView.swift */; };
 		E607ACE5890354F65F74C864 /* LLMEngineStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3224E9FBD3E9D86A60DAA79C /* LLMEngineStatus.swift */; };
 		E63CD7720F92C807AEB1B7BE /* FactCheckCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B61F580088B1A2F4D33DE8 /* FactCheckCard.swift */; };
@@ -709,6 +711,7 @@
 		019756686F6D3BBAAE229D8F /* WikiLinkParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WikiLinkParserTests.swift; sourceTree = "<group>"; };
 		01DF49AA771F4050417643F2 /* DocumentType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentType.swift; sourceTree = "<group>"; };
 		0252C590E08043FE0A4200C7 /* MainWindowView+Navigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MainWindowView+Navigation.swift"; sourceTree = "<group>"; };
+		026499B13ACB9A5937CCC44A /* CommandCenterChatView+Composer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CommandCenterChatView+Composer.swift"; sourceTree = "<group>"; };
 		05509BDEDCFFC620AB9B8777 /* TranscriptTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptTimelineView.swift; sourceTree = "<group>"; };
 		058B2966E8BD330957460206 /* TranscriptTimelineView+Bookmarks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TranscriptTimelineView+Bookmarks.swift"; sourceTree = "<group>"; };
 		06255FC9EEF089BB08B5232B /* whatsnew-writing-editor.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "whatsnew-writing-editor.png"; sourceTree = "<group>"; };
@@ -1110,6 +1113,7 @@
 		98CF1BA4C3D6569694E01167 /* MarkdownImportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownImportTests.swift; sourceTree = "<group>"; };
 		998619AE2882C267AC86850D /* swift-markdown */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "swift-markdown"; path = "Vendor/swift-markdown"; sourceTree = SOURCE_ROOT; };
 		99E36F742DA233D8616E8CC1 /* CardSectionHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardSectionHeader.swift; sourceTree = "<group>"; };
+		9A8627FAD5FB6C9F54FE23A2 /* AttachmentIntakeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentIntakeTests.swift; sourceTree = "<group>"; };
 		9AAC8C464AD83B42DE49792C /* WikiLinkCandidates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WikiLinkCandidates.swift; sourceTree = "<group>"; };
 		9B611C161962C154FC8DA451 /* FolderIconPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderIconPicker.swift; sourceTree = "<group>"; };
 		9BFF6DFB33FFDD664F05A4E6 /* AccessibilityService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityService.swift; sourceTree = "<group>"; };
@@ -1448,6 +1452,7 @@
 				86029AD56EBB4317FFDFB4E4 /* AgentRunStateTests.swift */,
 				4F21C87791C6ECF443D14823 /* AppVersionTests.swift */,
 				0A4CB54883E92F9A6F98BE77 /* AskRouteTests.swift */,
+				9A8627FAD5FB6C9F54FE23A2 /* AttachmentIntakeTests.swift */,
 				2476E5FAF6705D05BF8C22F2 /* AudioFileChunkReaderTests.swift */,
 				5FBB6345B454F1E296E6DE8D /* AudioTimelineMixerTests.swift */,
 				505AF0501A911C8BE2CB13CC /* BatchTranscriptFilterTests.swift */,
@@ -2286,6 +2291,7 @@
 			children = (
 				19129D8F0F9161BC3E21AA0F /* CommandCenterChatView.swift */,
 				F7847A3DB8F8CA72ECAE813F /* CommandCenterChatView+Bubbles.swift */,
+				026499B13ACB9A5937CCC44A /* CommandCenterChatView+Composer.swift */,
 				7ABC89CED798F0088E00B682 /* CommandCenterComposeView.swift */,
 				E7300054D056065027CC1FF3 /* CommandCenterNewMeetingView.swift */,
 				24578E3A172E90DC703D4C9D /* CommandCenterPIIView.swift */,
@@ -2655,6 +2661,7 @@
 				AAEF3C6465DC0A9EA911FE93 /* AgentRunStateTests.swift in Sources */,
 				B71E1192276BBC1904238D1A /* AppVersionTests.swift in Sources */,
 				85FB21E5E26B2D3D46093D47 /* AskRouteTests.swift in Sources */,
+				E5908FC6811FA07E101AB6F1 /* AttachmentIntakeTests.swift in Sources */,
 				08CC77D0F8EB0A6EAB31D544 /* AudioFileChunkReaderTests.swift in Sources */,
 				47F0712575338CEF0C0411F0 /* AudioTimelineMixerTests.swift in Sources */,
 				FE2FB582956D1251285E5C43 /* BatchTranscriptFilterTests.swift in Sources */,
@@ -2878,6 +2885,7 @@
 				1CF5D6AE20C1BDE279762B9F /* ComingSoonPanelView.swift in Sources */,
 				4BD0DCD9E20A28C06D40AF62 /* CommandCenterChatRule.swift in Sources */,
 				74E1ECCB2472ED6957C5E552 /* CommandCenterChatView+Bubbles.swift in Sources */,
+				46C1636E40764DBB285B5C03 /* CommandCenterChatView+Composer.swift in Sources */,
 				E5DF85C2C0803078D80C350C /* CommandCenterChatView.swift in Sources */,
 				5CBFF3B40F91960EC8178989 /* CommandCenterComposeView.swift in Sources */,
 				99FCB8FEB17A1DA884E6892C /* CommandCenterController.swift in Sources */,

--- a/Logue.xcodeproj/project.pbxproj
+++ b/Logue.xcodeproj/project.pbxproj
@@ -398,6 +398,7 @@
 		8D7D05B4E9AB2D3FC2B93F46 /* TaskDraftsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52599E057D11F1EEB4304B9 /* TaskDraftsTests.swift */; };
 		8DC751C30B843681CC342375 /* HomeAskPrompts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EE7A71E63405D18365880DF /* HomeAskPrompts.swift */; };
 		8E2A310067C068A86411694F /* WikiLinkCandidateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CF05733C63217FB320DD8E1 /* WikiLinkCandidateTests.swift */; };
+		8E93C898597CE89098CAA75E /* MessageActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55FA53C32F4D2968C07CEE5 /* MessageActions.swift */; };
 		8F052589F2A1FE3183EC5F56 /* TranscriptSentenceMerge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B96B5DBA01C6D2AC2AFD19 /* TranscriptSentenceMerge.swift */; };
 		900D62D26E62CC1BD86F6152 /* AudioTimelineMixer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CCEAA072E5CE2EDA0828E14 /* AudioTimelineMixer.swift */; };
 		90CE4DBE3D79C429616DB00A /* AgentConversation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 160A71994367176C72C11277 /* AgentConversation.swift */; };
@@ -1180,6 +1181,7 @@
 		B4D1E7321156F10B8D61510B /* SourcesPanelContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourcesPanelContent.swift; sourceTree = "<group>"; };
 		B52599E057D11F1EEB4304B9 /* TaskDraftsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskDraftsTests.swift; sourceTree = "<group>"; };
 		B54B9AE3D595F9F71042E772 /* RecordingCheckpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingCheckpoint.swift; sourceTree = "<group>"; };
+		B55FA53C32F4D2968C07CEE5 /* MessageActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageActions.swift; sourceTree = "<group>"; };
 		B57C9B916A88B9AC13B95DA7 /* MarkdownDocumentFileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownDocumentFileTests.swift; sourceTree = "<group>"; };
 		B57D98C9B0D1E6A69681C8C1 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		B612ADDBC4E7FB7917F6D72A /* SpaceFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceFile.swift; sourceTree = "<group>"; };
@@ -2162,6 +2164,7 @@
 				B1CF9F695CCB56896DC9A02C /* ApprovalGate.swift */,
 				86C6E3021828B2B8589C720A /* AskRoute.swift */,
 				4B2F874FCD0AF25F7B37D3FC /* MalformedToolCall.swift */,
+				B55FA53C32F4D2968C07CEE5 /* MessageActions.swift */,
 				6711FB8D13DD53809A655A14 /* WritingAgentGraph.swift */,
 				90E4CF4E9246459183E66FD7 /* WritingAgentState.swift */,
 			);
@@ -3068,6 +3071,7 @@
 				394298FD6FA5E69385C52C55 /* MemoryStore.swift in Sources */,
 				C70A9F7BBBA0C7D8B4E73ECA /* MenuBarCompanion.swift in Sources */,
 				AB209D330BE40FEB735204C7 /* MermaidRenderer.swift in Sources */,
+				8E93C898597CE89098CAA75E /* MessageActions.swift in Sources */,
 				077711B2656A23EF7E7727AF /* MicrophoneSpeechGate.swift in Sources */,
 				C5DD444112B8F0EBD6B1089D /* ModelAction.swift in Sources */,
 				E20DD767DAF8932B1D24E243 /* ModelChip.swift in Sources */,

--- a/Logue.xcodeproj/project.pbxproj
+++ b/Logue.xcodeproj/project.pbxproj
@@ -104,6 +104,7 @@
 		1BE965CE5953BCA256111BEA /* MeetingRowCompact.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72EE330160AA0276B2907F2A /* MeetingRowCompact.swift */; };
 		1C1775454781744474E68510 /* ToolApprovalButtons.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4DB5AD462B4A863201D5D61 /* ToolApprovalButtons.swift */; };
 		1C4A675BEB767A50A29D970F /* katex.min.css in Resources */ = {isa = PBXBuildFile; fileRef = E420BD97F84DEF6141ADEDA4 /* katex.min.css */; };
+		1C5F8AF69527526490E8CA54 /* AttachmentIntake.swift in Sources */ = {isa = PBXBuildFile; fileRef = 417436A70F2C0F1DDA347DC4 /* AttachmentIntake.swift */; };
 		1CCAD60D4518A9CCED75F860 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7449F6B54F0F197D704E4C59 /* AppDelegate.swift */; };
 		1CF5D6AE20C1BDE279762B9F /* ComingSoonPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4846B28779DCE95A2E8E9D23 /* ComingSoonPanelView.swift */; };
 		1CFA41464BB0BBD94D0F51D1 /* DurationFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D766396CB3F843CD222C7F46 /* DurationFormatter.swift */; };
@@ -873,6 +874,7 @@
 		3FF85EA0F9822CBD660E9AAB /* MarkdownStorageWarningSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownStorageWarningSheet.swift; sourceTree = "<group>"; };
 		40381D10206F56D057943756 /* SpaceContentPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceContentPane.swift; sourceTree = "<group>"; };
 		4066081DEC2821193FE7D882 /* WikiLinkURLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WikiLinkURLTests.swift; sourceTree = "<group>"; };
+		417436A70F2C0F1DDA347DC4 /* AttachmentIntake.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentIntake.swift; sourceTree = "<group>"; };
 		41C0416ED8CE675F6EF78FA0 /* TaskStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskStoreTests.swift; sourceTree = "<group>"; };
 		42BFEBF99163808EE4126279 /* HomeContextBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeContextBar.swift; sourceTree = "<group>"; };
 		42FA58E9E9D16008C0F7FF4E /* TaskTriage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskTriage.swift; sourceTree = "<group>"; };
@@ -2165,6 +2167,7 @@
 				62CA343B98C1F62D9F89B0B6 /* AgentRunState.swift */,
 				B1CF9F695CCB56896DC9A02C /* ApprovalGate.swift */,
 				86C6E3021828B2B8589C720A /* AskRoute.swift */,
+				417436A70F2C0F1DDA347DC4 /* AttachmentIntake.swift */,
 				4B2F874FCD0AF25F7B37D3FC /* MalformedToolCall.swift */,
 				B55FA53C32F4D2968C07CEE5 /* MessageActions.swift */,
 				6711FB8D13DD53809A655A14 /* WritingAgentGraph.swift */,
@@ -2819,6 +2822,7 @@
 				ED283783D6A185FB3914A331 /* ApprovalGate.swift in Sources */,
 				556246B3C2F8B616A0CDD27B /* AskRoute.swift in Sources */,
 				B62AF07AD0FDB3E3E4B31D77 /* AssistantActionRow.swift in Sources */,
+				1C5F8AF69527526490E8CA54 /* AttachmentIntake.swift in Sources */,
 				ECB8B236B80423C7D1A752FF /* AudioFileChunkReader.swift in Sources */,
 				DEDC62FB8C63F071222D9115 /* AudioLevelNormalizer.swift in Sources */,
 				86E9087748D55EBF2768316A /* AudioPlaybackService.swift in Sources */,

--- a/Logue.xcodeproj/project.pbxproj
+++ b/Logue.xcodeproj/project.pbxproj
@@ -466,6 +466,7 @@
 		A9B34E653A84128492DE6474 /* BlockRowView+Actions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FB93A6E198E565413AD03FC /* BlockRowView+Actions.swift */; };
 		A9C752BABC79AFFA2C4FD4F2 /* RecordingSpliceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94CFFCAEABE322C125D85AF3 /* RecordingSpliceTests.swift */; };
 		AA1456FCC75FBB7DFEFC1BE0 /* SpaceFileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 382510F54B865B60B16FDE73 /* SpaceFileTests.swift */; };
+		AAD4545E8533F6E509CC380C /* ModeChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD351EF77433FF052A024BAF /* ModeChip.swift */; };
 		AAEF3C6465DC0A9EA911FE93 /* AgentRunStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86029AD56EBB4317FFDFB4E4 /* AgentRunStateTests.swift */; };
 		AB209D330BE40FEB735204C7 /* MermaidRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCEE1CC67630CF84E03498D5 /* MermaidRenderer.swift */; };
 		AB5ECDB7A635C2DB974F908D /* SeedDataBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9478E4D1E64E36CDE232568E /* SeedDataBannerView.swift */; };
@@ -1379,6 +1380,7 @@
 		FBCD9FE533E01D4D082FF3EC /* WritingNSTextView+ListContinuation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WritingNSTextView+ListContinuation.swift"; sourceTree = "<group>"; };
 		FC17E4D853587B8D1F0BED80 /* DocumentIconPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentIconPicker.swift; sourceTree = "<group>"; };
 		FCEBD05BEF5831C92DDDE40E /* SuggestionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionParser.swift; sourceTree = "<group>"; };
+		FD351EF77433FF052A024BAF /* ModeChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModeChip.swift; sourceTree = "<group>"; };
 		FD9DB88569857E33E72CCFAE /* OverviewRecentActivityCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverviewRecentActivityCard.swift; sourceTree = "<group>"; };
 		FDFC48D1348543B9A74105F1 /* SpaceStore+MarkdownFolder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SpaceStore+MarkdownFolder.swift"; sourceTree = "<group>"; };
 		FE07F5F09706EA33B61BEF24 /* DocumentTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentTemplate.swift; sourceTree = "<group>"; };
@@ -2020,6 +2022,7 @@
 				C2A85CBFCD11CDF2FB693F73 /* InlineDiagramView.swift */,
 				8CCF492C5BB1691EC0946B25 /* InlineLaTeXView.swift */,
 				0AC3AC1CC9E373112B4CBCBC /* MemoryListView.swift */,
+				FD351EF77433FF052A024BAF /* ModeChip.swift */,
 				D1A491C56C1501F3D06F7734 /* PulsingDot.swift */,
 				2B203FDECC75AFF647507580 /* SourcesPanelView.swift */,
 				A4DB5AD462B4A863201D5D61 /* ToolApprovalButtons.swift */,
@@ -3089,6 +3092,7 @@
 				AB209D330BE40FEB735204C7 /* MermaidRenderer.swift in Sources */,
 				8E93C898597CE89098CAA75E /* MessageActions.swift in Sources */,
 				077711B2656A23EF7E7727AF /* MicrophoneSpeechGate.swift in Sources */,
+				AAD4545E8533F6E509CC380C /* ModeChip.swift in Sources */,
 				C5DD444112B8F0EBD6B1089D /* ModelAction.swift in Sources */,
 				E20DD767DAF8932B1D24E243 /* ModelChip.swift in Sources */,
 				E16818A635960352322D24E5 /* ModelConfiguration.swift in Sources */,

--- a/Logue/Agent/AttachmentIntake.swift
+++ b/Logue/Agent/AttachmentIntake.swift
@@ -1,0 +1,107 @@
+import AppKit
+import UniformTypeIdentifiers
+
+/// Getting files into a message, from wherever the message is being written.
+///
+/// Extracted from `InputBarView`, where it was `private` and therefore unreachable from the
+/// Command Center island — which is why the island has never accepted an attachment at all,
+/// despite `AgentCoordinator.send` taking them since the two surfaces were joined.
+///
+/// The rules here are the ones that were easy to get subtly different in a second copy:
+/// which types are offered, and what happens when the same file arrives twice.
+@MainActor
+enum AttachmentIntake {
+    /// What the picker offers, and by extension what a surface claims to accept.
+    ///
+    /// Drops are deliberately *not* filtered against this. A file manager hands over a URL
+    /// with no type negotiation, and `TempAttachmentLoader` already refuses what it cannot
+    /// read — filtering twice, in two places, is how a file that loads fine starts being
+    /// rejected on one surface and not the other.
+    static let acceptedTypes: [UTType] = [
+        .pdf, .plainText, .text, .image,
+        UTType("org.openxmlformats.spreadsheetml.sheet") ?? .data,
+        UTType("org.openxmlformats.wordprocessingml.document") ?? .data,
+        UTType("org.openxmlformats.presentationml.presentation") ?? .data,
+    ]
+
+    /// Adds `incoming` to `existing`, skipping anything already there.
+    ///
+    /// De-duped by display name rather than by URL: dragging the same file twice is a slip,
+    /// not a request for two copies, and the two drags can carry different URLs for one file
+    /// — a security-scoped copy the second time, for instance.
+    static func merging(
+        _ incoming: [TempAttachment],
+        into existing: [TempAttachment]
+    ) -> [TempAttachment] {
+        var result = existing
+        for attachment in incoming
+            where !result.contains(where: { $0.displayName == attachment.displayName })
+        {
+            result.append(attachment)
+        }
+        return result
+    }
+
+    /// Loads whatever of `urls` can be read. Unreadable files are dropped rather than
+    /// failing the batch: attaching four files and getting none because one was a broken
+    /// alias is worse than attaching three.
+    static func load(urls: [URL]) async -> [TempAttachment] {
+        var loaded: [TempAttachment] = []
+        for url in urls {
+            if let attachment = await TempAttachmentLoader.load(from: url) {
+                loaded.append(attachment)
+            }
+        }
+        return loaded
+    }
+
+    /// Presents the open panel and returns what the user picked, or nothing if they cancelled.
+    static func pickFiles() async -> [TempAttachment] {
+        let panel = NSOpenPanel()
+        panel.allowsMultipleSelection = true
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowedContentTypes = acceptedTypes
+        panel.prompt = "Attach"
+        panel.message = "Select files to attach to your message"
+
+        let urls: [URL] = await withCheckedContinuation { continuation in
+            panel.begin { response in
+                continuation.resume(returning: response == .OK ? panel.urls : [])
+            }
+        }
+        return await load(urls: urls)
+    }
+
+    /// Pulls file URLs out of a drop.
+    ///
+    /// `NSItemProvider` hands back either a `URL` or its `Data` representation depending on
+    /// where the drag came from, so both are unpacked. Anything else is not a file.
+    static func urls(from providers: [NSItemProvider]) async -> [URL] {
+        await withTaskGroup(of: URL?.self) { group in
+            for provider in providers {
+                group.addTask {
+                    await withCheckedContinuation { continuation in
+                        provider.loadItem(forTypeIdentifier: UTType.fileURL.identifier) { item, _ in
+                            switch item {
+                            case let url as URL:
+                                continuation.resume(returning: url)
+                            case let data as Data:
+                                continuation.resume(returning: URL(dataRepresentation: data, relativeTo: nil))
+                            default:
+                                continuation.resume(returning: nil)
+                            }
+                        }
+                    }
+                }
+            }
+            var found: [URL] = []
+            for await url in group {
+                if let url {
+                    found.append(url)
+                }
+            }
+            return found
+        }
+    }
+}

--- a/Logue/Agent/AttachmentIntake.swift
+++ b/Logue/Agent/AttachmentIntake.swift
@@ -42,9 +42,16 @@ enum AttachmentIntake {
         return result
     }
 
-    /// Loads whatever of `urls` can be read. Unreadable files are dropped rather than
-    /// failing the batch: attaching four files and getting none because one was a broken
-    /// alias is worse than attaching three.
+    /// Loads `urls` into attachments, in the order given.
+    ///
+    /// The `if let` is a contract rather than a filter: `TempAttachmentLoader.load` returns
+    /// an attachment for every URL today — an unreadable file becomes a chip carrying no
+    /// text rather than being dropped. This is written to tolerate a `nil` anyway, because
+    /// the alternative reading (fail the batch) is the wrong one: attaching four files and
+    /// getting none because one was a broken alias is worse than attaching three.
+    ///
+    /// `AttachmentIntakeTests` pins the ordering and the every-URL-yields-one contract, so
+    /// changing the loader to drop files is a decision that has to be made deliberately.
     static func load(urls: [URL]) async -> [TempAttachment] {
         var loaded: [TempAttachment] = []
         for url in urls {

--- a/Logue/Agent/MessageActions.swift
+++ b/Logue/Agent/MessageActions.swift
@@ -13,11 +13,17 @@ import UniformTypeIdentifiers
 /// one surface is added to both, by being mounted rather than redrawn.
 @MainActor
 enum MessageActions {
+    /// Puts `text` on the pasteboard.
+    ///
+    /// No toast. `.toastOverlay()` is mounted in exactly one place — the main window's chat
+    /// view — so a toast raised from the Command Center island either showed nothing or
+    /// painted its confirmation in the window *behind* the pill, describing something the
+    /// user did somewhere else. Each surface confirms in its own way instead: the main window
+    /// keeps its toast at the call site, the island ticks the row you pressed.
     static func copyToClipboard(_ text: String) {
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(text, forType: .string)
         HapticFeedback.copy()
-        ToastCenter.shared.show(UICopy.Toast.copied)
     }
 
     /// Writes the answer to a file the user picks.

--- a/Logue/Agent/MessageActions.swift
+++ b/Logue/Agent/MessageActions.swift
@@ -1,0 +1,59 @@
+import AppKit
+import UniformTypeIdentifiers
+
+/// What you can do with an assistant's answer, wherever it was asked from.
+///
+/// One definition because the two surfaces had drifted into offering different things: the
+/// main window could export a response as Markdown but not save it as a note, and the
+/// Command Center island could save a note but not export. Neither gap was a decision — each
+/// surface simply grew the action someone needed while they were looking at it.
+///
+/// Free of SwiftUI so both a view and a floating panel can call it, and so the behaviour is
+/// stated once rather than reimplemented per surface. `#61`'s ground rule: anything added to
+/// one surface is added to both, by being mounted rather than redrawn.
+@MainActor
+enum MessageActions {
+    static func copyToClipboard(_ text: String) {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(text, forType: .string)
+        HapticFeedback.copy()
+        ToastCenter.shared.show(UICopy.Toast.copied)
+    }
+
+    /// Writes the answer to a file the user picks.
+    ///
+    /// The panel is presented rather than a path invented: this is the user's filesystem, and
+    /// a silent write to Documents is how a feature becomes a thing people cannot find again.
+    static func exportMarkdown(_ text: String, suggestedName: String = "logue-response.md") {
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [UTType("net.daringfireball.markdown") ?? .plainText]
+        panel.nameFieldStringValue = suggestedName
+        panel.canCreateDirectories = true
+        panel.begin { response in
+            guard response == .OK, let url = panel.url else { return }
+            do {
+                try text.write(to: url, atomically: true, encoding: .utf8)
+            } catch {
+                // Surfaced rather than only logged: the user asked for a file and there is
+                // now no file, which is not something to discover later.
+                Task { @MainActor in
+                    ToastCenter.shared.show("Could not export: \(error.localizedDescription)")
+                }
+            }
+        }
+    }
+
+    /// Keeps the answer as a document in the library.
+    ///
+    /// Returns the new document's id so a caller can show its own confirmation against the
+    /// message it came from — the island marks the row it saved, which needs the pairing.
+    @discardableResult
+    static func saveAsNote(_ text: String, title: String = "Chat Note") -> UUID {
+        let document = DocumentStore.shared.createDocument(title: title)
+        var updated = document
+        updated.body = text
+        DocumentStore.shared.updateDocument(updated)
+        NSHapticFeedbackManager.defaultPerformer.perform(.alignment, performanceTime: .now)
+        return document.id
+    }
+}

--- a/Logue/App/AppDelegate.swift
+++ b/Logue/App/AppDelegate.swift
@@ -626,8 +626,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
     }
 
+    /// Brings the main window back, creating nothing but un-minimising and ordering front.
+    ///
+    /// Static and internal so the Command Center island can use it: "Open in Logue" has to
+    /// work with the window closed, and `NSApplication.activate` alone does not un-minimise
+    /// or order anything forward. Named apart from `showMainWindow()` because that one is
+    /// referenced by `#selector` and so cannot be overloaded.
     @objc
-    private func showMainWindow() {
+    static func bringMainWindowForward() {
+        (NSApp.delegate as? AppDelegate)?.showMainWindow()
+    }
+
+    @objc
+    func showMainWindow() {
         activateApp {
             if let window = NSApp.windows.first(where: { self.isMainAppWindow($0) }) {
                 if window.isMiniaturized {

--- a/Logue/CrossApp/CommandCenterChatRule.swift
+++ b/Logue/CrossApp/CommandCenterChatRule.swift
@@ -2,17 +2,30 @@ import Foundation
 
 /// What the chat island is currently holding.
 ///
-/// The two are kept apart because they earn different protection. Deliberately
-/// putting the island away — clicking off it, Esc, the close button, the shortcut
-/// — has always destroyed an unsent prompt, and a conversation is what a click
-/// off the island must not throw away. Switching apps is not a decision about the
-/// island at all, so that leaves either alone.
+/// The three are kept apart because they earn different protection. Deliberately
+/// putting the island away — Esc, the close button, the shortcut — has always
+/// destroyed an unsent prompt, and a conversation is what a click off the island
+/// must not throw away. Switching apps is not a decision about the island at all,
+/// so that leaves everything alone.
+///
+/// `hasAttachments` exists because staged files cost more to replace than typed
+/// text does. A dropped file is not recoverable by retyping it: the user found it
+/// in Finder, and after a dismissal they have to find it again. It was also the
+/// one kind of content the island could hold that nothing here knew about, which
+/// made an empty-looking island with a PDF staged on it disposable.
 struct CommandCenterChatContent: Equatable {
     var hasMessages: Bool
     var hasDraft: Bool
+    var hasAttachments: Bool
+
+    init(hasMessages: Bool, hasDraft: Bool, hasAttachments: Bool = false) {
+        self.hasMessages = hasMessages
+        self.hasDraft = hasDraft
+        self.hasAttachments = hasAttachments
+    }
 
     var isEmpty: Bool {
-        !hasMessages && !hasDraft
+        !hasMessages && !hasDraft && !hasAttachments
     }
 }
 

--- a/Logue/CrossApp/CommandCenterController.swift
+++ b/Logue/CrossApp/CommandCenterController.swift
@@ -117,9 +117,8 @@ class CommandCenterController: ObservableObject {
     private var currentMode: CommandCenterMode?
     private var escMonitor: Any?
     private var escLocalMonitor: Any?
-    private var clickMonitor: Any?
     private var clickLocalMonitor: Any?
-    private var chatContent = CommandCenterChatContent(hasMessages: false, hasDraft: false)
+    private var chatContent = CommandCenterChatContent(hasMessages: false, hasDraft: false, hasAttachments: false)
 
     /// The meeting ID of the active recording panel, used to restore the island.
     private(set) var activeRecordingMeetingID: UUID?
@@ -446,10 +445,15 @@ class CommandCenterController: ObservableObject {
                 return nil
             }
 
-            clickMonitor = NSEvent.addGlobalMonitorForEvents(matching: .leftMouseDown) { [weak self] event in
-                let screenPoint = Self.screenPoint(for: event)
-                Task { @MainActor in self?.dismissIfClickMissedPanel(screenPoint) }
-            }
+            // Deliberately no *global* mouse-down monitor. A mouse-down outside Logue is
+            // another application being clicked, which is `handleAppResignedActive`'s
+            // question, and it answers it with the real rule — an island holding something
+            // goes behind rather than being destroyed.
+            //
+            // Watching it here as well duplicated that decision with a cruder one, and broke
+            // dragging a file onto the island: the mouse-down that *starts* a drag in Finder
+            // is outside the pill, and the pill is still empty because the drop has not
+            // landed yet, so the island was torn down before the file arrived.
 
             clickLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseDown) { [weak self] event in
                 let screenPoint = Self.screenPoint(for: event)
@@ -466,10 +470,22 @@ class CommandCenterController: ObservableObject {
         return window.convertPoint(toScreen: event.locationInWindow)
     }
 
-    /// Puts an empty chat island away when a click lands anywhere but on it. An
-    /// island holding a conversation or an unsent prompt stays.
+    /// Puts a chat island away when a click inside Logue lands anywhere but on it.
+    ///
+    /// A conversation or a staged file keeps it. A *draft* deliberately does not —
+    /// with no messages there is no close button, so protecting the draft here would
+    /// leave an island with no visible way out. `CommandCenterChatRuleTests` states
+    /// that reasoning; the doc comment used to claim the opposite, and the code was
+    /// right.
+    ///
+    /// Attachments are the exception because they are not recoverable by retyping:
+    /// the user found that file in Finder once and would have to find it again.
     private func dismissIfClickMissedPanel(_ screenPoint: NSPoint) {
-        guard let panel, !chatContent.hasMessages, !panel.frame.contains(screenPoint) else { return }
+        guard let panel,
+              !chatContent.hasMessages,
+              !chatContent.hasAttachments,
+              !panel.frame.contains(screenPoint)
+        else { return }
         dismissPanel()
     }
 
@@ -482,9 +498,6 @@ class CommandCenterController: ObservableObject {
         }
         if let monitor = escLocalMonitor {
             NSEvent.removeMonitor(monitor); escLocalMonitor = nil
-        }
-        if let monitor = clickMonitor {
-            NSEvent.removeMonitor(monitor); clickMonitor = nil
         }
         if let monitor = clickLocalMonitor {
             NSEvent.removeMonitor(monitor); clickLocalMonitor = nil

--- a/Logue/UI/UICopy.swift
+++ b/Logue/UI/UICopy.swift
@@ -51,6 +51,8 @@ enum UICopy {
         static let researching = "Researching…"
         static let summarizing = "Summarizing…"
         static let executing = "Running tool…"
+        /// Shown when a send is refused because another conversation holds the engine.
+        static let busyElsewhere = "Logue is busy with another conversation"
 
         /// Pick a status string based on what the agent is currently doing.
         /// Falls back to "Thinking…" when no signal is available.

--- a/Logue/Views/Agent/AgentChatView+Input.swift
+++ b/Logue/Views/Agent/AgentChatView+Input.swift
@@ -58,9 +58,6 @@ extension AgentChatView {
             UTType("org.openxmlformats.wordprocessingml.document") ?? .data,
             UTType("org.openxmlformats.presentationml.presentation") ?? .data,
         ]
-        // File-picker allowlist. Same set, but the picker filters more strictly
-        // than the drop target.
-
         var body: some View {
             VStack(spacing: 0) {
                 if !attachments.isEmpty {

--- a/Logue/Views/Agent/AgentChatView+Input.swift
+++ b/Logue/Views/Agent/AgentChatView+Input.swift
@@ -58,14 +58,8 @@ extension AgentChatView {
             UTType("org.openxmlformats.wordprocessingml.document") ?? .data,
             UTType("org.openxmlformats.presentationml.presentation") ?? .data,
         ]
-        /// File-picker allowlist. Same set, but the picker filters more strictly
-        /// than the drop target.
-        static let acceptedPickerTypes: [UTType] = [
-            .pdf, .plainText, .text, .image,
-            UTType("org.openxmlformats.spreadsheetml.sheet") ?? .data,
-            UTType("org.openxmlformats.wordprocessingml.document") ?? .data,
-            UTType("org.openxmlformats.presentationml.presentation") ?? .data,
-        ]
+        // File-picker allowlist. Same set, but the picker filters more strictly
+        // than the drop target.
 
         var body: some View {
             VStack(spacing: 0) {
@@ -387,50 +381,19 @@ extension AgentChatView {
         /// same `TempAttachmentLoader` as drag-and-drop so the resulting chips and
         /// extracted text use one code path. De-duplicates by display name.
         private func openFilePicker() {
-            let panel = NSOpenPanel()
-            panel.allowsMultipleSelection = true
-            panel.canChooseFiles = true
-            panel.canChooseDirectories = false
-            panel.allowedContentTypes = Self.acceptedPickerTypes
-            panel.prompt = "Attach"
-            panel.message = "Select files to attach to your message"
-            panel.begin { response in
-                guard response == .OK else { return }
-                let urls = panel.urls
-                Task { @MainActor in
-                    for url in urls {
-                        guard let attachment = await TempAttachmentLoader.load(from: url) else { continue }
-                        if !attachments.contains(where: { $0.displayName == attachment.displayName }) {
-                            attachments.append(attachment)
-                        }
-                    }
-                }
+            Task { @MainActor in
+                let picked = await AttachmentIntake.pickFiles()
+                attachments = AttachmentIntake.merging(picked, into: attachments)
             }
         }
 
         // MARK: - Drop handling
 
         private func handleDrop(providers: [NSItemProvider]) {
-            for provider in providers {
-                provider.loadItem(forTypeIdentifier: UTType.fileURL.identifier) { item, _ in
-                    let url: URL? = switch item {
-                    case let dataURL as URL:
-                        dataURL
-                    case let data as Data:
-                        URL(dataRepresentation: data, relativeTo: nil)
-                    default:
-                        nil
-                    }
-                    guard let url else { return }
-                    Task { @MainActor in
-                        if let attachment = await TempAttachmentLoader.load(from: url) {
-                            // De-dupe by URL filename — dragging the same file twice is a no-op.
-                            if !attachments.contains(where: { $0.displayName == attachment.displayName }) {
-                                attachments.append(attachment)
-                            }
-                        }
-                    }
-                }
+            Task { @MainActor in
+                let urls = await AttachmentIntake.urls(from: providers)
+                let loaded = await AttachmentIntake.load(urls: urls)
+                attachments = AttachmentIntake.merging(loaded, into: attachments)
             }
         }
 

--- a/Logue/Views/Agent/AgentChatView+Input.swift
+++ b/Logue/Views/Agent/AgentChatView+Input.swift
@@ -160,7 +160,7 @@ extension AgentChatView {
         private var activeModeChips: some View {
             HStack(spacing: 6) {
                 if isWebSearchOnce {
-                    modeChip(
+                    ModeChip(
                         title: "Search",
                         systemImage: "globe",
                         tint: AppThemeConstants.brandPrimary
@@ -169,7 +169,7 @@ extension AgentChatView {
                     }
                 }
                 if isDeepResearch {
-                    modeChip(
+                    ModeChip(
                         title: "Deep research",
                         systemImage: "sparkle.magnifyingglass",
                         tint: AppThemeConstants.brandPrimary
@@ -179,38 +179,6 @@ extension AgentChatView {
                 }
                 Spacer(minLength: 0)
             }
-        }
-
-        private func modeChip(
-            title: String,
-            systemImage: String,
-            tint: Color,
-            onDismiss: @escaping () -> Void
-        ) -> some View {
-            HStack(spacing: 4) {
-                Image(systemName: systemImage)
-                    .font(.caption)
-                Text(title)
-                    .font(.caption.weight(.medium))
-                Button {
-                    onDismiss()
-                } label: {
-                    Image(systemName: "xmark")
-                        .font(.caption2)
-                }
-                .buttonStyle(.plain)
-                .help("Turn off \(title)")
-            }
-            .padding(.horizontal, 8)
-            .padding(.vertical, 3)
-            .foregroundStyle(tint)
-            .background(
-                Capsule().fill(tint.opacity(0.14))
-            )
-            .overlay(
-                Capsule().strokeBorder(tint.opacity(0.45), lineWidth: 0.5)
-            )
-            .transition(.scale.combined(with: .opacity))
         }
 
         // MARK: - Card Chrome

--- a/Logue/Views/Agent/AgentChatView+Messages.swift
+++ b/Logue/Views/Agent/AgentChatView+Messages.swift
@@ -1,6 +1,4 @@
-import AppKit
 import SwiftUI
-import UniformTypeIdentifiers
 
 // MARK: - Message List
 
@@ -142,6 +140,7 @@ extension AgentChatView {
                 HStack(spacing: 4) {
                     Button {
                         MessageActions.copyToClipboard(message.content)
+                        ToastCenter.shared.show(UICopy.Toast.copied)
                     } label: {
                         Image(systemName: "doc.on.doc")
                             .font(.system(size: 11))
@@ -356,7 +355,5 @@ extension AgentChatView {
             }
             return nil
         }
-
-        // MARK: - Clipboard / Export
     }
 }

--- a/Logue/Views/Agent/AgentChatView+Messages.swift
+++ b/Logue/Views/Agent/AgentChatView+Messages.swift
@@ -141,7 +141,7 @@ extension AgentChatView {
                 // Copy + Edit actions
                 HStack(spacing: 4) {
                     Button {
-                        copyToClipboard(message.content)
+                        MessageActions.copyToClipboard(message.content)
                     } label: {
                         Image(systemName: "doc.on.doc")
                             .font(.system(size: 11))
@@ -358,29 +358,5 @@ extension AgentChatView {
         }
 
         // MARK: - Clipboard / Export
-
-        private func copyToClipboard(_ text: String) {
-            NSPasteboard.general.clearContents()
-            NSPasteboard.general.setString(text, forType: .string)
-            HapticFeedback.copy()
-            Task { @MainActor in
-                ToastCenter.shared.show(UICopy.Toast.copied)
-            }
-        }
-
-        private func exportMarkdown(_ text: String) {
-            let panel = NSSavePanel()
-            panel.allowedContentTypes = [UTType("net.daringfireball.markdown") ?? .plainText]
-            panel.nameFieldStringValue = "logue-response.md"
-            panel.canCreateDirectories = true
-            panel.begin { response in
-                guard response == .OK, let url = panel.url else { return }
-                do {
-                    try text.write(to: url, atomically: true, encoding: .utf8)
-                } catch {
-                    NSLog("Failed to export markdown: \(error.localizedDescription)")
-                }
-            }
-        }
     }
 }

--- a/Logue/Views/Agent/AssistantActionRow.swift
+++ b/Logue/Views/Agent/AssistantActionRow.swift
@@ -8,6 +8,9 @@ import UniformTypeIdentifiers
 struct AssistantActionRow: View {
     let content: String
     @State private var chartTable: ChartTable?
+    /// Ticks the save button for a moment, so the action confirms itself where it happened
+    /// rather than only in a toast the user may be looking away from.
+    @State private var savedNote = false
 
     @State private var readAloud = AgentReadAloudService.shared
 
@@ -18,7 +21,7 @@ struct AssistantActionRow: View {
     var body: some View {
         HStack(spacing: 4) {
             Button {
-                copyToClipboard(content)
+                MessageActions.copyToClipboard(content)
             } label: {
                 Image(systemName: "doc.on.doc")
                     .font(.system(size: 11))
@@ -30,7 +33,24 @@ struct AssistantActionRow: View {
             .help("Copy response")
 
             Button {
-                exportMarkdown(content)
+                MessageActions.saveAsNote(content)
+                savedNote = true
+                Task {
+                    try? await Task.sleep(for: AppConstants.Delays.toastDismiss)
+                    savedNote = false
+                }
+            } label: {
+                Image(systemName: savedNote ? "checkmark" : "square.and.arrow.down")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                    .padding(5)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .help("Save response as a note")
+
+            Button {
+                MessageActions.exportMarkdown(content)
             } label: {
                 Image(systemName: "square.and.arrow.up")
                     .font(.system(size: 11))
@@ -82,30 +102,6 @@ struct AssistantActionRow: View {
     }
 
     // MARK: - Helpers
-
-    private func copyToClipboard(_ text: String) {
-        NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(text, forType: .string)
-        HapticFeedback.copy()
-        Task { @MainActor in
-            ToastCenter.shared.show(UICopy.Toast.copied)
-        }
-    }
-
-    private func exportMarkdown(_ text: String) {
-        let panel = NSSavePanel()
-        panel.allowedContentTypes = [UTType("net.daringfireball.markdown") ?? .plainText]
-        panel.nameFieldStringValue = "logue-response.md"
-        panel.canCreateDirectories = true
-        panel.begin { response in
-            guard response == .OK, let url = panel.url else { return }
-            do {
-                try text.write(to: url, atomically: true, encoding: .utf8)
-            } catch {
-                NSLog("Failed to export markdown: \(error.localizedDescription)")
-            }
-        }
-    }
 }
 
 // MARK: - ChartTable Identifiable

--- a/Logue/Views/Agent/AssistantActionRow.swift
+++ b/Logue/Views/Agent/AssistantActionRow.swift
@@ -1,15 +1,19 @@
-import AppKit
 import SwiftUI
-import UniformTypeIdentifiers
 
-/// Action row shown beneath each settled assistant message. Provides Copy,
-/// Export-as-Markdown, Read-Aloud (Phase 9), and Visualize-Table (Phase 8).
-/// Owns its own sheet state for the chart visualizer.
+/// Action row shown beneath each settled assistant message: Copy, Save as note,
+/// Export as Markdown, Read aloud, and Visualize table.
+///
+/// Owns its own sheet state for the chart visualizer. The actions themselves live in
+/// `MessageActions`, so the island offers the same set.
 struct AssistantActionRow: View {
     let content: String
     @State private var chartTable: ChartTable?
     /// Ticks the save button for a moment, so the action confirms itself where it happened
     /// rather than only in a toast the user may be looking away from.
+    /// Bumped on every save so a reset only clears the tick it was scheduled for. Without
+    /// it, saving twice in quick succession let the first timer clear the second save's
+    /// checkmark, which reads as the second save not having happened.
+    @State private var saveGeneration = 0
     @State private var savedNote = false
 
     @State private var readAloud = AgentReadAloudService.shared
@@ -22,6 +26,7 @@ struct AssistantActionRow: View {
         HStack(spacing: 4) {
             Button {
                 MessageActions.copyToClipboard(content)
+                ToastCenter.shared.show(UICopy.Toast.copied)
             } label: {
                 Image(systemName: "doc.on.doc")
                     .font(.system(size: 11))
@@ -34,10 +39,16 @@ struct AssistantActionRow: View {
 
             Button {
                 MessageActions.saveAsNote(content)
+                saveGeneration += 1
+                let generation = saveGeneration
                 savedNote = true
                 Task {
                     try? await Task.sleep(for: AppConstants.Delays.toastDismiss)
-                    savedNote = false
+                    // Only clear the tick this task lit. The island guards its equivalent the
+                    // same way; this copy was the one that lost the guard.
+                    if saveGeneration == generation {
+                        savedNote = false
+                    }
                 }
             } label: {
                 Image(systemName: savedNote ? "checkmark" : "square.and.arrow.down")

--- a/Logue/Views/Agent/ModeChip.swift
+++ b/Logue/Views/Agent/ModeChip.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+/// A mode that is on for the next send, with a way to turn it off.
+///
+/// Lifted out of `InputBarView` so the Command Center island shows the same chip rather than
+/// drawing its own. The modes are stored in `UserDefaults` and read by both surfaces *and* by
+/// the coordinator, so a chip that looked different on one of them would be describing the
+/// same state in two voices.
+struct ModeChip: View {
+    let title: String
+    let systemImage: String
+    let tint: Color
+    /// Turns the mode off. The `×` exists so a mode can be dropped without reopening the menu
+    /// that set it.
+    let onDismiss: () -> Void
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Image(systemName: systemImage)
+                .font(.caption)
+            Text(title)
+                .font(.caption.weight(.medium))
+            Button(action: onDismiss) {
+                Image(systemName: "xmark")
+                    .font(.caption2)
+            }
+            .buttonStyle(.plain)
+            .help("Turn off \(title)")
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 3)
+        .foregroundStyle(tint)
+        .background(Capsule().fill(tint.opacity(0.14)))
+        .overlay(Capsule().strokeBorder(tint.opacity(0.45), lineWidth: 0.5))
+        .transition(.scale.combined(with: .opacity))
+    }
+}

--- a/Logue/Views/CrossApp/CommandCenterChatView+Bubbles.swift
+++ b/Logue/Views/CrossApp/CommandCenterChatView+Bubbles.swift
@@ -1,0 +1,125 @@
+import SwiftUI
+import Textual
+
+/// How one turn is drawn in the island, and what you can do with it.
+///
+/// Split out because `CommandCenterChatView` went past the 450-line body cap once it grew an
+/// error banner. Rendering is the cohesive half: the view itself is now the panel, the prompt
+/// pill and the wiring to the coordinator, and this is what a message looks like.
+extension CommandCenterChatView {
+    /// The panel in `CommandCenterChatView` renders this, so it crosses the file boundary.
+    func messageBubble(_ message: EphemeralChatMessage) -> some View {
+        HStack(alignment: .top, spacing: 0) {
+            if message.isUser {
+                Spacer(minLength: 120)
+            }
+
+            VStack(alignment: message.isUser ? .trailing : .leading, spacing: 5) {
+                if message.isUser {
+                    Text(message.content)
+                        .font(AppThemeConstants.chatMessageFont)
+                        .foregroundStyle(.white)
+                        .textSelection(.enabled)
+                        .lineSpacing(3)
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 10)
+                        .background(
+                            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                                .fill(AppThemeConstants.brandPrimary)
+                        )
+                } else {
+                    markdownContent(message)
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 10)
+                        .background(
+                            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                                .fill(Color.primary.opacity(0.06))
+                        )
+                }
+
+                if !message.isUser, !message.isStreaming, !message.content.isEmpty {
+                    actionButtons(message)
+                }
+            }
+
+            if !message.isUser {
+                Spacer(minLength: 120)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func markdownContent(_ message: EphemeralChatMessage) -> some View {
+        let displayText = message.content.isEmpty && message.isStreaming ? "..." : message.content
+        StructuredText(markdown: displayText)
+            .font(AppThemeConstants.chatMessageFont)
+            .textual.structuredTextStyle(.gitHub)
+            .textual.inlineStyle(.gitHub)
+            .foregroundStyle(.primary)
+            .textSelection(.enabled)
+    }
+
+    private func actionButtons(_ message: EphemeralChatMessage) -> some View {
+        HStack(spacing: 4) {
+            Button { copyToClipboard(message) } label: {
+                HStack(spacing: 3) {
+                    Image(systemName: copiedMessageID == message.id ? "checkmark" : "doc.on.doc")
+                        .font(.caption2.weight(.medium))
+                    Text(copiedMessageID == message.id ? "Copied" : "Copy")
+                        .font(.caption2.weight(.medium))
+                }
+                .foregroundStyle(copiedMessageID == message.id ? AppThemeConstants.success : Color.secondary)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 3)
+                .background(Capsule().fill(Color.primary.opacity(0.04)))
+            }
+            .buttonStyle(.plain)
+
+            Button { saveMessageAsNote(message) } label: {
+                HStack(spacing: 3) {
+                    Image(systemName: savedMessageID == message.id ? "checkmark" : "square.and.arrow.down")
+                        .font(.caption2.weight(.medium))
+                    Text(savedMessageID == message.id ? "Saved" : "Save")
+                        .font(.caption2.weight(.medium))
+                }
+                .foregroundStyle(savedMessageID == message.id ? AppThemeConstants.success : Color.secondary)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 3)
+                .background(Capsule().fill(Color.primary.opacity(0.04)))
+            }
+            .buttonStyle(.plain)
+
+            Button {
+                MessageActions.exportMarkdown(message.content)
+            } label: {
+                HStack(spacing: 3) {
+                    Image(systemName: "square.and.arrow.up")
+                        .font(.caption2.weight(.medium))
+                    Text("Export")
+                        .font(.caption2.weight(.medium))
+                }
+                .foregroundStyle(Color.secondary)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 3)
+                .background(Capsule().fill(Color.primary.opacity(0.04)))
+            }
+            .buttonStyle(.plain)
+            .help("Export as Markdown")
+
+            Button { speakMessage(message) } label: {
+                HStack(spacing: 3) {
+                    Image(systemName: speakingMessageID == message.id ? "stop.fill" : "speaker.wave.2")
+                        .font(.caption2.weight(.medium))
+                    Text(speakingMessageID == message.id ? "Stop" : "Speak")
+                        .font(.caption2.weight(.medium))
+                }
+                .foregroundStyle(speakingMessageID == message.id ? AppThemeConstants.error : Color.secondary)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 3)
+                .background(Capsule().fill(Color.primary.opacity(0.04)))
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.leading, 2)
+    }
+}

--- a/Logue/Views/CrossApp/CommandCenterChatView+Composer.swift
+++ b/Logue/Views/CrossApp/CommandCenterChatView+Composer.swift
@@ -1,0 +1,148 @@
+import SwiftUI
+
+/// The island's composer: the prompt pill, what is staged for the next send, and the two ways
+/// a file gets in.
+///
+/// Split out for the same reason as `+Bubbles` — giving the island attachments took the view's
+/// body past the 450-line cap. The intake itself lives in `AttachmentIntake`, shared with the
+/// main window; this is only how the island presents it.
+extension CommandCenterChatView {
+    /// Rendered by the view itself, so it crosses the file boundary.
+    var promptPill: some View {
+        HStack(alignment: .center, spacing: 12) {
+            // App logo
+            Image(nsImage: NSApp.applicationIconImage)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 28, height: 28)
+                .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+
+            // Input field
+            TextField("What can I help you with?", text: $inputText, axis: .vertical)
+                .font(.body)
+                .foregroundStyle(.white)
+                .textFieldStyle(.plain)
+                .focused($isInputFocused)
+                .lineLimit(1 ... 4)
+                .onKeyPress(.return, phases: .down) { _ in
+                    if NSEvent.modifierFlags.contains(.shift) {
+                        inputText += "\n"
+                        return .handled
+                    } else if canSend {
+                        sendMessage()
+                        return .handled
+                    }
+                    return .handled
+                }
+
+            // Attach
+            Button {
+                Task { @MainActor in
+                    let picked = await AttachmentIntake.pickFiles()
+                    attachments = AttachmentIntake.merging(picked, into: attachments)
+                }
+            } label: {
+                Image(systemName: "paperclip")
+                    .font(.subheadline.weight(.medium))
+                    .foregroundStyle(.white.opacity(0.4))
+                    .frame(width: 28, height: 28)
+            }
+            .buttonStyle(.plain)
+            .disabled(isGenerating)
+            .help("Attach files")
+
+            // Mic button
+            Button {
+                voiceManager.toggle()
+            } label: {
+                Image(systemName: voiceManager.isRecording ? "mic.fill" : "mic")
+                    .font(.subheadline.weight(.medium))
+                    .foregroundStyle(voiceManager.isRecording ? AppThemeConstants.error : .white.opacity(0.4))
+                    .frame(width: 28, height: 28)
+            }
+            .buttonStyle(.plain)
+            .disabled(isGenerating)
+            .help(voiceManager.isRecording ? "Stop voice input" : "Voice input")
+
+            // Send / Stop
+            if isGenerating {
+                Button(action: stopStreaming) {
+                    Image(systemName: "stop.fill")
+                        .font(.subheadline.weight(.bold))
+                        .foregroundStyle(.white)
+                        .frame(width: 32, height: 32)
+                        .background(Circle().fill(AppThemeConstants.error))
+                }
+                .buttonStyle(.plain)
+            } else {
+                Button(action: sendMessage) {
+                    Image(systemName: "arrow.up")
+                        .font(.subheadline.weight(.bold))
+                        .foregroundStyle(canSend ? .white : .white.opacity(0.25))
+                        .frame(width: 32, height: 32)
+                        .background(
+                            Circle().fill(canSend ? AppThemeConstants.brandPrimary : Color.white.opacity(0.08))
+                        )
+                }
+                .buttonStyle(.plain)
+                .disabled(!canSend || LLMEngineStatus.shared.isBusy)
+                .keyboardShortcut(.return, modifiers: .command)
+            }
+        }
+        .padding(.leading, 14)
+        .padding(.trailing, 10)
+        .padding(.vertical, 10)
+        .background(
+            RoundedRectangle(cornerRadius: 22, style: .continuous)
+                .fill(Color(nsColor: NSColor(red: 0.11, green: 0.11, blue: 0.12, alpha: 0.92)))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 22, style: .continuous)
+                .stroke(Color.white.opacity(0.07), lineWidth: 0.5)
+        )
+        .shadow(color: .black.opacity(0.35), radius: 30, y: 12)
+        .overlay(alignment: .top) {
+            if !attachments.isEmpty {
+                attachmentChips
+                    .offset(y: -34)
+            }
+        }
+        // Dropping onto the pill is the same intake as the picker, so a file arrives the
+        // same way whichever route the user takes.
+        .onDrop(of: [.fileURL], isTargeted: nil) { providers in
+            Task { @MainActor in
+                let urls = await AttachmentIntake.urls(from: providers)
+                let loaded = await AttachmentIntake.load(urls: urls)
+                attachments = AttachmentIntake.merging(loaded, into: attachments)
+            }
+            return true
+        }
+    }
+
+    /// What is staged for the next send, with a way to take each one back off.
+    private var attachmentChips: some View {
+        HStack(spacing: 6) {
+            ForEach(attachments) { attachment in
+                HStack(spacing: 4) {
+                    Image(systemName: "doc")
+                        .font(.caption2)
+                    Text(attachment.displayName)
+                        .font(.caption2)
+                        .lineLimit(1)
+                    Button {
+                        attachments.removeAll { $0.id == attachment.id }
+                    } label: {
+                        Image(systemName: "xmark")
+                            .font(.system(size: 8, weight: .bold))
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Remove \(attachment.displayName)")
+                }
+                .foregroundStyle(.white.opacity(0.8))
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(Capsule().fill(Color.white.opacity(0.12)))
+            }
+        }
+    }
+}

--- a/Logue/Views/CrossApp/CommandCenterChatView+Composer.swift
+++ b/Logue/Views/CrossApp/CommandCenterChatView+Composer.swift
@@ -148,11 +148,16 @@ extension CommandCenterChatView {
             }
             ForEach(attachments) { attachment in
                 HStack(spacing: 4) {
-                    Image(systemName: "doc")
+                    // The attachment's own icon, as the main window shows it. Hardcoding
+                    // "doc" here made a PDF and a spreadsheet look identical on the island
+                    // and different in the main window — per-surface drift in a chip that
+                    // was copied rather than shared.
+                    Image(systemName: attachment.iconName)
                         .font(.caption2)
                     Text(attachment.displayName)
                         .font(.caption2)
                         .lineLimit(1)
+                        .truncationMode(.middle)
                     Button {
                         attachments.removeAll { $0.id == attachment.id }
                     } label: {

--- a/Logue/Views/CrossApp/CommandCenterChatView+Composer.swift
+++ b/Logue/Views/CrossApp/CommandCenterChatView+Composer.swift
@@ -51,6 +51,21 @@ extension CommandCenterChatView {
             .disabled(isGenerating)
             .help("Attach files")
 
+            // Web search for this turn
+            Button {
+                withAnimation(.easeOut(duration: 0.15)) { isWebSearchOnce.toggle() }
+            } label: {
+                Image(systemName: "globe")
+                    .font(.subheadline.weight(.medium))
+                    .foregroundStyle(
+                        isWebSearchOnce ? AppThemeConstants.brandPrimary : .white.opacity(0.4)
+                    )
+                    .frame(width: 28, height: 28)
+            }
+            .buttonStyle(.plain)
+            .disabled(isGenerating)
+            .help(isWebSearchOnce ? "Web search is on for this message" : "Search the web for this message")
+
             // Mic button
             Button {
                 voiceManager.toggle()
@@ -102,7 +117,7 @@ extension CommandCenterChatView {
         )
         .shadow(color: .black.opacity(0.35), radius: 30, y: 12)
         .overlay(alignment: .top) {
-            if !attachments.isEmpty {
+            if !attachments.isEmpty || isWebSearchOnce {
                 attachmentChips
                     .offset(y: -34)
             }
@@ -122,6 +137,15 @@ extension CommandCenterChatView {
     /// What is staged for the next send, with a way to take each one back off.
     private var attachmentChips: some View {
         HStack(spacing: 6) {
+            if isWebSearchOnce {
+                ModeChip(
+                    title: "Search",
+                    systemImage: "globe",
+                    tint: AppThemeConstants.brandPrimary
+                ) {
+                    isWebSearchOnce = false
+                }
+            }
             ForEach(attachments) { attachment in
                 HStack(spacing: 4) {
                     Image(systemName: "doc")

--- a/Logue/Views/CrossApp/CommandCenterChatView.swift
+++ b/Logue/Views/CrossApp/CommandCenterChatView.swift
@@ -38,6 +38,15 @@ struct CommandCenterChatView: View {
     /// Files staged for the next send. The island could not accept any until the intake was
     /// lifted out of the main window's input bar — see `AttachmentIntake`.
     @State var attachments: [TempAttachment] = []
+    // Extension-visible: +Composer
+    /// Web search for the next send.
+    ///
+    /// The same `UserDefaults` key the main window's chip binds, because the coordinator reads
+    /// it too — three readers of one value rather than a copy per surface. It follows that the
+    /// island must clear it after a send exactly as the main window does, or a search switched
+    /// on here silently arms the next send over there.
+    @AppStorage(AppConstants.UserDefaultsKeys.oneShotWebSearch)
+    var isWebSearchOnce: Bool = false
     // Extension-visible: +Bubbles
     @State var copiedMessageID: UUID?
     // Extension-visible: +Bubbles
@@ -288,8 +297,12 @@ struct CommandCenterChatView: View {
 
         let conversationID = ensureConversation()
         let staged = attachments
+        let searchThisTurn = isWebSearchOnce
         inputText = ""
         attachments = []
+        // Cleared per send, like the main window's chip. Left set, a search switched on here
+        // would arm the next send in the other window too.
+        isWebSearchOnce = false
 
         // Re-focus input after state update
         Task {
@@ -301,11 +314,21 @@ struct CommandCenterChatView: View {
         case .agentLoop, .deepResearch:
             // Deep Research is unreachable from here — no chip lights it — and if it ever
             // becomes reachable it belongs on the same coordinator, not a second pipeline.
-            coordinator.send(message: text, conversationID: conversationID, attachments: staged)
+            coordinator.send(
+                message: text,
+                conversationID: conversationID,
+                attachments: staged,
+                oneShotWebSearch: searchThisTurn
+            )
         case let .imagePlayground(concept):
             // ImagePlayground presents a sheet, which a floating pill cannot host. Answer it
             // as a normal turn rather than silently dropping the send.
-            coordinator.send(message: concept, conversationID: conversationID, attachments: staged)
+            coordinator.send(
+                message: concept,
+                conversationID: conversationID,
+                attachments: staged,
+                oneShotWebSearch: searchThisTurn
+            )
         }
     }
 

--- a/Logue/Views/CrossApp/CommandCenterChatView.swift
+++ b/Logue/Views/CrossApp/CommandCenterChatView.swift
@@ -39,14 +39,18 @@ struct CommandCenterChatView: View {
     /// lifted out of the main window's input bar — see `AttachmentIntake`.
     @State var attachments: [TempAttachment] = []
     // Extension-visible: +Composer
-    /// Web search for the next send.
+    /// Web search for the next send, belonging to this island alone.
     ///
-    /// The same `UserDefaults` key the main window's chip binds, because the coordinator reads
-    /// it too — three readers of one value rather than a copy per surface. It follows that the
-    /// island must clear it after a send exactly as the main window does, or a search switched
-    /// on here silently arms the next send over there.
-    @AppStorage(AppConstants.UserDefaultsKeys.oneShotWebSearch)
-    var isWebSearchOnce: Bool = false
+    /// It used to bind the same `UserDefaults` key as the main window's chip, on the reasoning
+    /// that one value with several readers beats a copy per surface. That was wrong in the
+    /// direction nobody checked: the island clears the flag after every send, so asking a
+    /// quick question here silently disarmed a Search chip the user had turned on in the main
+    /// window and left armed on an unsent prompt. They would never be told — the prompt just
+    /// runs without web tools.
+    ///
+    /// The coordinator takes the value as a parameter, so nothing needs the shared read. A
+    /// per-send mode is per surface, and this is `@State` accordingly.
+    @State var isWebSearchOnce: Bool = false
     // Extension-visible: +Bubbles
     @State var copiedMessageID: UUID?
     // Extension-visible: +Bubbles
@@ -302,6 +306,16 @@ struct CommandCenterChatView: View {
         )
         guard let route, !isGenerating else { return }
 
+        // `isGenerating` is scoped to this conversation, which is right for the spinner and
+        // wrong for this: `AgentCoordinator.send` refuses on a *global* busy check. Without
+        // this guard a send made while the main window was mid-run cleared the field, the
+        // staged files and the mode flags, then hit that refusal and did nothing — no bubble,
+        // no error, and an empty conversation left behind by `ensureConversation`.
+        guard !coordinator.isProcessingAnyConversation else {
+            ToastCenter.shared.show(UICopy.Status.busyElsewhere, kind: .warning)
+            return
+        }
+
         let conversationID = ensureConversation()
         let staged = attachments
         let searchThisTurn = isWebSearchOnce
@@ -426,7 +440,11 @@ struct CommandCenterChatView: View {
         // Selecting before activating, so the window is already showing the right thread when
         // it comes forward rather than visibly switching to it afterwards.
         store.selectedConversationID = conversationID
-        NSApplication.shared.activate(ignoringOtherApps: true)
+        // Activating is not enough. With the main window closed or minimised there is no
+        // window to come forward and no `MainWindowView` to observe `.chatFocusInput`, so the
+        // button dismissed the island, made Logue frontmost, and showed nothing — leaving the
+        // thread it promised to carry over unreachable until the user opened a window by hand.
+        AppDelegate.bringMainWindowForward()
         NotificationCenter.default.post(name: .chatFocusInput, object: nil)
         onDismiss()
     }

--- a/Logue/Views/CrossApp/CommandCenterChatView.swift
+++ b/Logue/Views/CrossApp/CommandCenterChatView.swift
@@ -33,9 +33,12 @@ struct CommandCenterChatView: View {
     @State private var store = AgentConversationStore.shared
     @State private var coordinator = AgentCoordinator.shared
     @State private var inputText: String = ""
-    @State private var copiedMessageID: UUID?
-    @State private var savedMessageID: UUID?
-    @State private var speakingMessageID: UUID?
+    // Extension-visible: +Bubbles
+    @State var copiedMessageID: UUID?
+    // Extension-visible: +Bubbles
+    @State var savedMessageID: UUID?
+    // Extension-visible: +Bubbles
+    @State var speakingMessageID: UUID?
     @State private var synthesizer = AVSpeechSynthesizer()
     @FocusState private var isInputFocused: Bool
 
@@ -234,123 +237,6 @@ struct CommandCenterChatView: View {
             RoundedRectangle(cornerRadius: 18, style: .continuous)
                 .stroke(Color.white.opacity(0.08), lineWidth: 0.5)
         )
-    }
-
-    // MARK: - Message Bubbles
-
-    private func messageBubble(_ message: EphemeralChatMessage) -> some View {
-        HStack(alignment: .top, spacing: 0) {
-            if message.isUser {
-                Spacer(minLength: 120)
-            }
-
-            VStack(alignment: message.isUser ? .trailing : .leading, spacing: 5) {
-                if message.isUser {
-                    Text(message.content)
-                        .font(AppThemeConstants.chatMessageFont)
-                        .foregroundStyle(.white)
-                        .textSelection(.enabled)
-                        .lineSpacing(3)
-                        .padding(.horizontal, 14)
-                        .padding(.vertical, 10)
-                        .background(
-                            RoundedRectangle(cornerRadius: 14, style: .continuous)
-                                .fill(AppThemeConstants.brandPrimary)
-                        )
-                } else {
-                    markdownContent(message)
-                        .padding(.horizontal, 14)
-                        .padding(.vertical, 10)
-                        .background(
-                            RoundedRectangle(cornerRadius: 14, style: .continuous)
-                                .fill(Color.primary.opacity(0.06))
-                        )
-                }
-
-                if !message.isUser, !message.isStreaming, !message.content.isEmpty {
-                    actionButtons(message)
-                }
-            }
-
-            if !message.isUser {
-                Spacer(minLength: 120)
-            }
-        }
-    }
-
-    @ViewBuilder
-    private func markdownContent(_ message: EphemeralChatMessage) -> some View {
-        let displayText = message.content.isEmpty && message.isStreaming ? "..." : message.content
-        StructuredText(markdown: displayText)
-            .font(AppThemeConstants.chatMessageFont)
-            .textual.structuredTextStyle(.gitHub)
-            .textual.inlineStyle(.gitHub)
-            .foregroundStyle(.primary)
-            .textSelection(.enabled)
-    }
-
-    private func actionButtons(_ message: EphemeralChatMessage) -> some View {
-        HStack(spacing: 4) {
-            Button { copyToClipboard(message) } label: {
-                HStack(spacing: 3) {
-                    Image(systemName: copiedMessageID == message.id ? "checkmark" : "doc.on.doc")
-                        .font(.caption2.weight(.medium))
-                    Text(copiedMessageID == message.id ? "Copied" : "Copy")
-                        .font(.caption2.weight(.medium))
-                }
-                .foregroundStyle(copiedMessageID == message.id ? AppThemeConstants.success : Color.secondary)
-                .padding(.horizontal, 6)
-                .padding(.vertical, 3)
-                .background(Capsule().fill(Color.primary.opacity(0.04)))
-            }
-            .buttonStyle(.plain)
-
-            Button { saveMessageAsNote(message) } label: {
-                HStack(spacing: 3) {
-                    Image(systemName: savedMessageID == message.id ? "checkmark" : "square.and.arrow.down")
-                        .font(.caption2.weight(.medium))
-                    Text(savedMessageID == message.id ? "Saved" : "Save")
-                        .font(.caption2.weight(.medium))
-                }
-                .foregroundStyle(savedMessageID == message.id ? AppThemeConstants.success : Color.secondary)
-                .padding(.horizontal, 6)
-                .padding(.vertical, 3)
-                .background(Capsule().fill(Color.primary.opacity(0.04)))
-            }
-            .buttonStyle(.plain)
-
-            Button {
-                MessageActions.exportMarkdown(message.content)
-            } label: {
-                HStack(spacing: 3) {
-                    Image(systemName: "square.and.arrow.up")
-                        .font(.caption2.weight(.medium))
-                    Text("Export")
-                        .font(.caption2.weight(.medium))
-                }
-                .foregroundStyle(Color.secondary)
-                .padding(.horizontal, 6)
-                .padding(.vertical, 3)
-                .background(Capsule().fill(Color.primary.opacity(0.04)))
-            }
-            .buttonStyle(.plain)
-            .help("Export as Markdown")
-
-            Button { speakMessage(message) } label: {
-                HStack(spacing: 3) {
-                    Image(systemName: speakingMessageID == message.id ? "stop.fill" : "speaker.wave.2")
-                        .font(.caption2.weight(.medium))
-                    Text(speakingMessageID == message.id ? "Stop" : "Speak")
-                        .font(.caption2.weight(.medium))
-                }
-                .foregroundStyle(speakingMessageID == message.id ? AppThemeConstants.error : Color.secondary)
-                .padding(.horizontal, 6)
-                .padding(.vertical, 3)
-                .background(Capsule().fill(Color.primary.opacity(0.04)))
-            }
-            .buttonStyle(.plain)
-        }
-        .padding(.leading, 2)
     }
 
     // MARK: - Prompt Pill
@@ -579,7 +465,8 @@ struct CommandCenterChatView: View {
         isInputFocused = true
     }
 
-    private func speakMessage(_ message: EphemeralChatMessage) {
+    // Extension-visible: +Bubbles
+    func speakMessage(_ message: EphemeralChatMessage) {
         if speakingMessageID == message.id {
             synthesizer.stopSpeaking(at: .immediate)
             speakingMessageID = nil
@@ -598,7 +485,8 @@ struct CommandCenterChatView: View {
         synthesizer.speak(utterance)
     }
 
-    private func saveMessageAsNote(_ message: EphemeralChatMessage) {
+    // Extension-visible: +Bubbles
+    func saveMessageAsNote(_ message: EphemeralChatMessage) {
         MessageActions.saveAsNote(message.content)
         savedMessageID = message.id
         Task {
@@ -609,7 +497,8 @@ struct CommandCenterChatView: View {
         }
     }
 
-    private func copyToClipboard(_ message: EphemeralChatMessage) {
+    // Extension-visible: +Bubbles
+    func copyToClipboard(_ message: EphemeralChatMessage) {
         MessageActions.copyToClipboard(message.content)
         copiedMessageID = message.id
         Task {

--- a/Logue/Views/CrossApp/CommandCenterChatView.swift
+++ b/Logue/Views/CrossApp/CommandCenterChatView.swift
@@ -218,6 +218,11 @@ struct CommandCenterChatView: View {
                     }
                 }
             }
+
+            if let error = currentError {
+                errorBanner(error)
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+            }
         }
         .frame(width: pillWidth)
         .frame(maxHeight: 420)
@@ -468,6 +473,57 @@ struct CommandCenterChatView: View {
             // as a normal turn rather than silently dropping the send.
             coordinator.send(message: concept, conversationID: conversationID)
         }
+    }
+
+    /// The error for this thread, if the last run left one.
+    ///
+    /// Scoped like every other read: an error from a run the main window started is that
+    /// window's to report, and showing it here would blame the island for something it did
+    /// not do.
+    private var currentError: String? {
+        guard let conversationID else { return nil }
+        return coordinator.lastError(in: conversationID)
+    }
+
+    /// Says when a send failed.
+    ///
+    /// The island had this and lost it when it moved onto the coordinator: the old bare
+    /// completion caught its own error and wrote "No AI model loaded" into the bubble, and
+    /// that path went away with the `chatStream` call. Without this the most likely failure
+    /// a first-time user hits — no model set up yet — makes the send appear to vanish.
+    ///
+    /// Narrower than the main window's banner because the pill is narrow: the same
+    /// dismissable shape, without the second line of detail there is no room for.
+    private func errorBanner(_ message: String) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.caption)
+                .foregroundStyle(AppThemeConstants.error)
+
+            Text(message)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(3)
+                .fixedSize(horizontal: false, vertical: true)
+                .textSelection(.enabled)
+
+            Spacer(minLength: 0)
+
+            Button {
+                withAnimation { coordinator.dismissError() }
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                    .padding(3)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Dismiss error")
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
+        .background(AppThemeConstants.error.opacity(AppThemeConstants.hoverOpacity))
     }
 
     /// Hands the island's thread to the main window and steps out of the way.

--- a/Logue/Views/CrossApp/CommandCenterChatView.swift
+++ b/Logue/Views/CrossApp/CommandCenterChatView.swift
@@ -32,7 +32,12 @@ struct CommandCenterChatView: View {
     @State private var conversationID: UUID?
     @State private var store = AgentConversationStore.shared
     @State private var coordinator = AgentCoordinator.shared
-    @State private var inputText: String = ""
+    // Extension-visible: +Composer
+    @State var inputText: String = ""
+    // Extension-visible: +Composer
+    /// Files staged for the next send. The island could not accept any until the intake was
+    /// lifted out of the main window's input bar — see `AttachmentIntake`.
+    @State var attachments: [TempAttachment] = []
     // Extension-visible: +Bubbles
     @State var copiedMessageID: UUID?
     // Extension-visible: +Bubbles
@@ -40,9 +45,11 @@ struct CommandCenterChatView: View {
     // Extension-visible: +Bubbles
     @State var speakingMessageID: UUID?
     @State private var synthesizer = AVSpeechSynthesizer()
-    @FocusState private var isInputFocused: Bool
+    // Extension-visible: +Composer
+    @FocusState var isInputFocused: Bool
 
-    private var voiceManager: VoicePushToTalkManager {
+    // Extension-visible: +Composer
+    var voiceManager: VoicePushToTalkManager {
         .shared
     }
 
@@ -76,8 +83,9 @@ struct CommandCenterChatView: View {
         }
     }
 
+    // Extension-visible: +Composer
     /// Whether the island's own thread is busy — never the main window's.
-    private var isGenerating: Bool {
+    var isGenerating: Bool {
         guard let conversationID else { return false }
         return coordinator.isProcessing(in: conversationID)
     }
@@ -254,94 +262,16 @@ struct CommandCenterChatView: View {
         )
     }
 
-    // MARK: - Prompt Pill
-
-    private var promptPill: some View {
-        HStack(alignment: .center, spacing: 12) {
-            // App logo
-            Image(nsImage: NSApp.applicationIconImage)
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .frame(width: 28, height: 28)
-                .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
-
-            // Input field
-            TextField("What can I help you with?", text: $inputText, axis: .vertical)
-                .font(.body)
-                .foregroundStyle(.white)
-                .textFieldStyle(.plain)
-                .focused($isInputFocused)
-                .lineLimit(1 ... 4)
-                .onKeyPress(.return, phases: .down) { _ in
-                    if NSEvent.modifierFlags.contains(.shift) {
-                        inputText += "\n"
-                        return .handled
-                    } else if canSend {
-                        sendMessage()
-                        return .handled
-                    }
-                    return .handled
-                }
-
-            // Mic button
-            Button {
-                voiceManager.toggle()
-            } label: {
-                Image(systemName: voiceManager.isRecording ? "mic.fill" : "mic")
-                    .font(.subheadline.weight(.medium))
-                    .foregroundStyle(voiceManager.isRecording ? AppThemeConstants.error : .white.opacity(0.4))
-                    .frame(width: 28, height: 28)
-            }
-            .buttonStyle(.plain)
-            .disabled(isGenerating)
-            .help(voiceManager.isRecording ? "Stop voice input" : "Voice input")
-
-            // Send / Stop
-            if isGenerating {
-                Button(action: stopStreaming) {
-                    Image(systemName: "stop.fill")
-                        .font(.subheadline.weight(.bold))
-                        .foregroundStyle(.white)
-                        .frame(width: 32, height: 32)
-                        .background(Circle().fill(AppThemeConstants.error))
-                }
-                .buttonStyle(.plain)
-            } else {
-                Button(action: sendMessage) {
-                    Image(systemName: "arrow.up")
-                        .font(.subheadline.weight(.bold))
-                        .foregroundStyle(canSend ? .white : .white.opacity(0.25))
-                        .frame(width: 32, height: 32)
-                        .background(
-                            Circle().fill(canSend ? AppThemeConstants.brandPrimary : Color.white.opacity(0.08))
-                        )
-                }
-                .buttonStyle(.plain)
-                .disabled(!canSend || LLMEngineStatus.shared.isBusy)
-                .keyboardShortcut(.return, modifiers: .command)
-            }
-        }
-        .padding(.leading, 14)
-        .padding(.trailing, 10)
-        .padding(.vertical, 10)
-        .background(
-            RoundedRectangle(cornerRadius: 22, style: .continuous)
-                .fill(Color(nsColor: NSColor(red: 0.11, green: 0.11, blue: 0.12, alpha: 0.92)))
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 22, style: .continuous)
-                .stroke(Color.white.opacity(0.07), lineWidth: 0.5)
-        )
-        .shadow(color: .black.opacity(0.35), radius: 30, y: 12)
-    }
-
     // MARK: - Logic
 
-    private var canSend: Bool {
-        !inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !isGenerating
+    // Extension-visible: +Composer
+    var canSend: Bool {
+        (!inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || !attachments.isEmpty)
+            && !isGenerating
     }
 
-    private func sendMessage() {
+    // Extension-visible: +Composer
+    func sendMessage() {
         let text = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
 
         // The same routing decision the main window makes. The island has no Deep Research
@@ -350,13 +280,16 @@ struct CommandCenterChatView: View {
         let route = AskRouter.route(
             for: AskRouter.Request(
                 text: text,
+                hasAttachments: !attachments.isEmpty,
                 imageIntentFires: PromptIntentClassifier.shared.shouldPresentImagePlayground(for: text)
             )
         )
         guard let route, !isGenerating else { return }
 
         let conversationID = ensureConversation()
+        let staged = attachments
         inputText = ""
+        attachments = []
 
         // Re-focus input after state update
         Task {
@@ -368,11 +301,11 @@ struct CommandCenterChatView: View {
         case .agentLoop, .deepResearch:
             // Deep Research is unreachable from here — no chip lights it — and if it ever
             // becomes reachable it belongs on the same coordinator, not a second pipeline.
-            coordinator.send(message: text, conversationID: conversationID)
+            coordinator.send(message: text, conversationID: conversationID, attachments: staged)
         case let .imagePlayground(concept):
             // ImagePlayground presents a sheet, which a floating pill cannot host. Answer it
             // as a normal turn rather than silently dropping the send.
-            coordinator.send(message: concept, conversationID: conversationID)
+            coordinator.send(message: concept, conversationID: conversationID, attachments: staged)
         }
     }
 
@@ -482,7 +415,8 @@ struct CommandCenterChatView: View {
         return conversation.id
     }
 
-    private func stopStreaming() {
+    // Extension-visible: +Composer
+    func stopStreaming() {
         coordinator.cancel()
         isInputFocused = true
     }

--- a/Logue/Views/CrossApp/CommandCenterChatView.swift
+++ b/Logue/Views/CrossApp/CommandCenterChatView.swift
@@ -104,7 +104,8 @@ struct CommandCenterChatView: View {
     private var content: CommandCenterChatContent {
         CommandCenterChatContent(
             hasMessages: !messages.isEmpty,
-            hasDraft: !inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            hasDraft: !inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+            hasAttachments: !attachments.isEmpty
         )
     }
 
@@ -139,6 +140,12 @@ struct CommandCenterChatView: View {
             synthesizer.stopSpeaking(at: .immediate)
         }
         .onChange(of: messages.count) { _, _ in
+            onContentChanged(content)
+        }
+        // Staged files count as content, so the controller has to be told about them —
+        // without this the island reports itself empty while holding a PDF, and the next
+        // click anywhere off the pill throws it away.
+        .onChange(of: attachments.count) { _, _ in
             onContentChanged(content)
         }
         .onChange(of: inputText) { _, _ in

--- a/Logue/Views/CrossApp/CommandCenterChatView.swift
+++ b/Logue/Views/CrossApp/CommandCenterChatView.swift
@@ -167,6 +167,25 @@ struct CommandCenterChatView: View {
 
                 Spacer()
 
+                if conversationID != nil {
+                    Button {
+                        openInLogue()
+                    } label: {
+                        HStack(spacing: 4) {
+                            Image(systemName: "arrow.up.forward")
+                                .font(.caption2.weight(.semibold))
+                            Text("Open in Logue")
+                                .font(.caption.weight(.semibold))
+                        }
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(Capsule().fill(Color.primary.opacity(0.06)))
+                    }
+                    .buttonStyle(.plain)
+                    .help("Continue this conversation in the main window")
+                }
+
                 Button(action: onDismiss) {
                     Image(systemName: "xmark")
                         .font(.caption2.weight(.bold))
@@ -432,6 +451,26 @@ struct CommandCenterChatView: View {
             // as a normal turn rather than silently dropping the send.
             coordinator.send(message: concept, conversationID: conversationID)
         }
+    }
+
+    /// Hands the island's thread to the main window and steps out of the way.
+    ///
+    /// Only reachable once a thread exists — before the first send there is nothing to carry,
+    /// and selecting a conversation that does not exist would leave the main window on an
+    /// empty landing state that looks like the send was lost.
+    ///
+    /// `chatFocusInput` rather than `chatNewConversation`: the latter *creates* a
+    /// conversation, which is the opposite of what this does. This one surfaces Home and
+    /// focuses the input, leaving the selected thread alone — which is what "continue this
+    /// conversation over there" means.
+    private func openInLogue() {
+        guard let conversationID else { return }
+        // Selecting before activating, so the window is already showing the right thread when
+        // it comes forward rather than visibly switching to it afterwards.
+        store.selectedConversationID = conversationID
+        NSApplication.shared.activate(ignoringOtherApps: true)
+        NotificationCenter.default.post(name: .chatFocusInput, object: nil)
+        onDismiss()
     }
 
     /// The island's thread, made on first use.

--- a/Logue/Views/CrossApp/CommandCenterChatView.swift
+++ b/Logue/Views/CrossApp/CommandCenterChatView.swift
@@ -314,6 +314,23 @@ struct CommandCenterChatView: View {
             }
             .buttonStyle(.plain)
 
+            Button {
+                MessageActions.exportMarkdown(message.content)
+            } label: {
+                HStack(spacing: 3) {
+                    Image(systemName: "square.and.arrow.up")
+                        .font(.caption2.weight(.medium))
+                    Text("Export")
+                        .font(.caption2.weight(.medium))
+                }
+                .foregroundStyle(Color.secondary)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 3)
+                .background(Capsule().fill(Color.primary.opacity(0.04)))
+            }
+            .buttonStyle(.plain)
+            .help("Export as Markdown")
+
             Button { speakMessage(message) } label: {
                 HStack(spacing: 3) {
                     Image(systemName: speakingMessageID == message.id ? "stop.fill" : "speaker.wave.2")
@@ -526,11 +543,7 @@ struct CommandCenterChatView: View {
     }
 
     private func saveMessageAsNote(_ message: EphemeralChatMessage) {
-        let doc = DocumentStore.shared.createDocument(title: "Chat Note")
-        var updated = doc
-        updated.body = message.content
-        DocumentStore.shared.updateDocument(updated)
-        NSHapticFeedbackManager.defaultPerformer.perform(.alignment, performanceTime: .now)
+        MessageActions.saveAsNote(message.content)
         savedMessageID = message.id
         Task {
             try? await Task.sleep(for: AppConstants.Delays.toastDismiss)
@@ -541,9 +554,7 @@ struct CommandCenterChatView: View {
     }
 
     private func copyToClipboard(_ message: EphemeralChatMessage) {
-        NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(message.content, forType: .string)
-        NSHapticFeedbackManager.defaultPerformer.perform(.alignment, performanceTime: .now)
+        MessageActions.copyToClipboard(message.content)
         copiedMessageID = message.id
         Task {
             try? await Task.sleep(for: AppConstants.Delays.toastDismiss)

--- a/Logue/Views/CrossApp/CommandCenterChatView.swift
+++ b/Logue/Views/CrossApp/CommandCenterChatView.swift
@@ -222,6 +222,21 @@ struct CommandCenterChatView: View {
                 }
             }
 
+            if !pendingApprovals.isEmpty, let conversationID {
+                VStack(spacing: 8) {
+                    ForEach(pendingApprovals) { call in
+                        ToolExecutionCard(
+                            toolCall: call,
+                            result: nil,
+                            conversationID: conversationID
+                        )
+                    }
+                }
+                .padding(.horizontal, 16)
+                .padding(.bottom, 10)
+                .transition(.move(edge: .bottom).combined(with: .opacity))
+            }
+
             if let error = currentError {
                 errorBanner(error)
                     .transition(.move(edge: .bottom).combined(with: .opacity))
@@ -359,6 +374,27 @@ struct CommandCenterChatView: View {
             // as a normal turn rather than silently dropping the send.
             coordinator.send(message: concept, conversationID: conversationID)
         }
+    }
+
+    /// Tool calls from this thread that are waiting on the user.
+    ///
+    /// The island runs the full agent loop as of #61, which means it runs the approval gate
+    /// too — and the gate blocks the run until someone answers. With no prompt here, a
+    /// destructive tool asked for from the island showed nothing, sat for
+    /// `approvalTimeoutSeconds` (five minutes), and then failed. The run looked frozen and
+    /// there was no way to say yes.
+    ///
+    /// Only calls that need an answer are rendered. Completed tool calls stay filtered out of
+    /// the island — the main window shows those as history, and a pill floating over another
+    /// app has no room for a transcript of everything the agent did. What it must show is
+    /// what it is blocking on.
+    private var pendingApprovals: [AgentToolCall] {
+        guard let conversationID,
+              let conversation = store.conversations.first(where: { $0.id == conversationID })
+        else { return [] }
+        return conversation.messages
+            .flatMap(\.toolCalls)
+            .filter { $0.status == .needsConfirmation }
     }
 
     /// The error for this thread, if the last run left one.

--- a/LogueTests/AttachmentIntakeTests.swift
+++ b/LogueTests/AttachmentIntakeTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Testing
+
+@testable import Logue
+
+/// The one piece of attachment intake that is pure, and the one worth pinning.
+///
+/// The picker and the drop unpacking touch `NSOpenPanel` and `NSItemProvider`, neither of
+/// which runs headlessly. The de-dupe rule does, and it is the part two surfaces could
+/// disagree about now that both call it — which is exactly why it stopped being `private`.
+@Suite("AttachmentIntake")
+@MainActor
+struct AttachmentIntakeTests {
+    private func attachment(_ name: String) -> TempAttachment {
+        TempAttachment(
+            kind: .plainText,
+            displayName: name,
+            extractedText: "contents of \(name)",
+            iconName: "doc"
+        )
+    }
+
+    @Test("The same file arriving twice is added once")
+    func duplicatesAreSkipped() {
+        // Dragging a file twice is a slip, not a request for two copies.
+        let existing = [attachment("notes.md")]
+        let merged = AttachmentIntake.merging([attachment("notes.md")], into: existing)
+        #expect(merged.count == 1)
+    }
+
+    @Test("Matching is by display name, not identity")
+    func matchesOnName() {
+        // The two drags carry different `TempAttachment` values — a fresh id each time, and
+        // in the real case possibly a different security-scoped URL for one file on disk.
+        // Comparing identity would let the same file in twice.
+        let first = attachment("report.pdf")
+        let second = attachment("report.pdf")
+        #expect(first.id != second.id)
+        #expect(AttachmentIntake.merging([second], into: [first]).count == 1)
+    }
+
+    @Test("Different files all arrive")
+    func distinctFilesAreKept() {
+        let merged = AttachmentIntake.merging(
+            [attachment("b.txt"), attachment("c.txt")],
+            into: [attachment("a.txt")]
+        )
+        #expect(merged.map(\.displayName) == ["a.txt", "b.txt", "c.txt"])
+    }
+
+    @Test("Order is preserved, with new files after the ones already staged")
+    func orderIsStable() {
+        // The chips read left to right in the order they were added; re-ordering on every
+        // drop would move a chip out from under the pointer about to close it.
+        let merged = AttachmentIntake.merging(
+            [attachment("z.txt"), attachment("a.txt")],
+            into: [attachment("m.txt")]
+        )
+        #expect(merged.map(\.displayName) == ["m.txt", "z.txt", "a.txt"])
+    }
+
+    @Test("A batch containing a duplicate keeps the rest")
+    func partialDuplicateKeepsTheRest() {
+        // Dropping a folder's worth of files where one is already staged should attach the
+        // others rather than being treated as a repeat of the whole batch.
+        let merged = AttachmentIntake.merging(
+            [attachment("a.txt"), attachment("new.txt")],
+            into: [attachment("a.txt")]
+        )
+        #expect(merged.map(\.displayName) == ["a.txt", "new.txt"])
+    }
+
+    @Test("Merging nothing changes nothing")
+    func emptyIncomingIsANoOp() {
+        let existing = [attachment("a.txt")]
+        #expect(AttachmentIntake.merging([], into: existing).map(\.displayName) == ["a.txt"])
+    }
+}

--- a/LogueTests/AttachmentIntakeTests.swift
+++ b/LogueTests/AttachmentIntakeTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+import UniformTypeIdentifiers
 
 @testable import Logue
 
@@ -74,5 +75,73 @@ struct AttachmentIntakeTests {
     func emptyIncomingIsANoOp() {
         let existing = [attachment("a.txt")]
         #expect(AttachmentIntake.merging([], into: existing).map(\.displayName) == ["a.txt"])
+    }
+
+    // MARK: - Loading
+
+    /// A scratch directory with real files in it, torn down afterwards.
+    private func withScratchFiles(
+        _ names: [String],
+        _ body: (URL, [URL]) async throws -> Void
+    ) async throws {
+        let root = URL.temporaryDirectory
+            .appendingPathComponent("logue-intake-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let urls = try names.map { name -> URL in
+            let url = root.appendingPathComponent(name)
+            try "contents of \(name)".write(to: url, atomically: true, encoding: .utf8)
+            return url
+        }
+        try await body(root, urls)
+    }
+
+    @Test("Files load in the order they were given")
+    func loadPreservesOrder() async throws {
+        // The chips read left to right in drop order, so a loader that raced would move a
+        // chip out from under the pointer about to close it.
+        try await withScratchFiles(["a.txt", "b.txt", "c.txt"]) { _, urls in
+            let loaded = await AttachmentIntake.load(urls: urls)
+            #expect(loaded.map(\.displayName) == ["a.txt", "b.txt", "c.txt"])
+        }
+    }
+
+    @Test("One unreadable file does not cost the whole batch")
+    func oneBadFileKeepsTheRest() async throws {
+        // Attaching four files and getting none because one was a broken alias is worse than
+        // attaching three. Note what this pins: every URL yields an attachment today, so the
+        // missing file arrives as a chip carrying no text rather than being dropped. Either
+        // behaviour satisfies "the rest survive"; silently losing the good files does not.
+        try await withScratchFiles(["good1.txt", "good2.txt"]) { root, urls in
+            let missing = root.appendingPathComponent("gone.txt")
+            let loaded = await AttachmentIntake.load(urls: [urls[0], missing, urls[1]])
+            let names = loaded.map(\.displayName)
+            #expect(names.contains("good1.txt"))
+            #expect(names.contains("good2.txt"))
+        }
+    }
+
+    @Test("Nothing in, nothing out")
+    func loadingNoURLsIsEmpty() async {
+        #expect(await AttachmentIntake.load(urls: []).isEmpty)
+    }
+
+    // MARK: - The picker allowlist
+
+    @Test("Every Office type resolves, so the allowlist never silently widens")
+    func officeTypesResolve() {
+        // Each is written `UTType("org.openxmlformats…") ?? .data`. If an identifier is wrong
+        // — or an OS release stops vending it — the fallback does not fail closed, it widens
+        // the picker to *every* file type. The user then picks a .zip, the loader stages a
+        // chip carrying nothing, and the file appears to have been ignored with no error.
+        for identifier in [
+            "org.openxmlformats.spreadsheetml.sheet",
+            "org.openxmlformats.wordprocessingml.document",
+            "org.openxmlformats.presentationml.presentation",
+        ] {
+            #expect(UTType(identifier) != nil, "no UTType for \(identifier)")
+        }
+        #expect(AttachmentIntake.acceptedTypes.contains(.data) == false, "the allowlist degraded to .data")
     }
 }

--- a/LogueTests/CommandCenterChatRuleTests.swift
+++ b/LogueTests/CommandCenterChatRuleTests.swift
@@ -99,12 +99,37 @@ struct CommandCenterChatRuleTests {
 
     // MARK: - What the island is holding
 
-    @Test("An island is empty only with neither a conversation nor a draft")
-    func contentIsEmptyOnlyWhenBothAreAbsent() {
+    @Test("An island is empty only with no conversation, no draft and nothing staged")
+    func contentIsEmptyOnlyWhenAllAreAbsent() {
         #expect(CommandCenterChatContent(hasMessages: false, hasDraft: false).isEmpty)
         #expect(!CommandCenterChatContent(hasMessages: true, hasDraft: false).isEmpty)
         #expect(!CommandCenterChatContent(hasMessages: false, hasDraft: true).isEmpty)
         #expect(!CommandCenterChatContent(hasMessages: true, hasDraft: true).isEmpty)
+    }
+
+    @Test("A staged file makes an island non-empty")
+    func stagedFilesCount() {
+        // Attachments were the one kind of content the island could hold that nothing here
+        // knew about, so an island holding a PDF and nothing else reported itself disposable
+        // and was torn down by the next click or app switch.
+        let staged = CommandCenterChatContent(hasMessages: false, hasDraft: false, hasAttachments: true)
+        #expect(!staged.isEmpty)
+    }
+
+    @Test("A staged file survives an app switch")
+    func stagedFilesSurviveFocusLoss() {
+        // The rule reads `isEmpty`, so this follows from the case above — which is the point:
+        // teaching the struct about attachments is what fixes every reader at once.
+        let staged = CommandCenterChatContent(hasMessages: false, hasDraft: false, hasAttachments: true)
+        #expect(CommandCenterChatRule.focusLoss(mode: .chat, chatHasContent: !staged.isEmpty)
+            == .sendBehindOtherApps)
+    }
+
+    @Test("An island with nothing staged is still disposable on an app switch")
+    func emptyIslandStillGoesAway() {
+        // The other direction, so the fix above cannot turn into "the island never closes".
+        let empty = CommandCenterChatContent(hasMessages: false, hasDraft: false)
+        #expect(CommandCenterChatRule.focusLoss(mode: .chat, chatHasContent: !empty.isEmpty) == .dismiss)
     }
 
     @Test("A draft survives an app switch but not a deliberate dismissal")
@@ -118,6 +143,11 @@ struct CommandCenterChatRuleTests {
         // Clicking off it is such a decision, and has always discarded an unsent
         // prompt. Protecting the draft here would leave an island with no visible
         // way out — the close button only exists once there are messages.
+        //
+        // Staged files are the deliberate exception: a dropped file cannot be recovered
+        // by retyping it, so `dismissIfClickMissedPanel` checks `hasAttachments` while
+        // still ignoring `hasDraft`. Esc remains the way out in both cases.
         #expect(!draftOnly.hasMessages)
+        #expect(!draftOnly.hasAttachments)
     }
 }

--- a/LogueTests/MessageActionsTests.swift
+++ b/LogueTests/MessageActionsTests.swift
@@ -1,0 +1,52 @@
+import Foundation
+import Testing
+
+@testable import Logue
+
+/// What you can do with an assistant's answer.
+///
+/// `copyToClipboard` and `exportMarkdown` are `NSPasteboard`/`NSSavePanel` and are not
+/// reachable headlessly. `saveAsNote` is, and it is the one carrying a contract the commit
+/// that introduced it relies on: it returns the new document's id so a caller can tick the
+/// row it came from. Nothing pinned that.
+@Suite("MessageActions")
+@MainActor
+struct MessageActionsTests {
+    @Test("Saving a note writes the text and returns that document's id")
+    func saveAsNoteReturnsTheDocumentItWrote() {
+        // The island marks the message it saved by pairing this id against the row. If
+        // `createDocument` and `updateDocument` ever disagreed about identity, the wrong row
+        // would tick — or none would — and nothing would fail.
+        let body = "The answer was 41, plus one."
+        let id = MessageActions.saveAsNote(body, title: "Saved answer")
+
+        let saved = DocumentStore.shared.documents.first { $0.id == id }
+        #expect(saved != nil, "the returned id must name a document that exists")
+        #expect(saved?.body == body, "the update has to have been applied before the id is handed back")
+        #expect(saved?.title == "Saved answer")
+
+        DocumentStore.shared.deleteDocument(id: id)
+    }
+
+    @Test("Two saves make two documents")
+    func eachSaveIsItsOwnDocument() {
+        // Saving the same answer twice is a slip the app should not silently collapse — the
+        // user asked for two notes and would go looking for the second one.
+        let first = MessageActions.saveAsNote("same text", title: "A")
+        let second = MessageActions.saveAsNote("same text", title: "A")
+        #expect(first != second)
+
+        DocumentStore.shared.deleteDocument(id: first)
+        DocumentStore.shared.deleteDocument(id: second)
+    }
+
+    @Test("An empty answer still produces a document rather than nothing")
+    func emptyBodyStillSaves() {
+        // The button is only offered on a settled, non-empty message, so this is defensive —
+        // but returning an id for a document that was never created would be the worst
+        // possible failure, since the caller ticks a row on the strength of it.
+        let id = MessageActions.saveAsNote("", title: "Empty")
+        #expect(DocumentStore.shared.documents.contains { $0.id == id })
+        DocumentStore.shared.deleteDocument(id: id)
+    }
+}


### PR DESCRIPTION
Part of #56. Closes #61 — it is the last of that item's eight boxes.

## What happened

**#71 and #72 say Merged on GitHub, and their code is not on `main`.** (#69's is —
it travelled up with #66. An earlier version of this paragraph named #69 too, which a
reviewer correctly called out.) The stack was merged top-down instead of bottom-up:

| Time | PR | Merged into |
| ---- | -- | ----------- |
| 03:03 | #69 | `shan/issue-61-shared-session` |
| 03:04 | #71 | `shan/issue-61-run-scoping` |
| 03:04 | #72 | `shan/issue-61-open-in-logue` |
| 03:05 | #66 | `main` |

`#69` took `run-scoping`'s tip into `shared-session` a minute *before* `#71` updated
`run-scoping`, so #71's commits — and #72's on top of them — landed on branches that had
already been consumed. `#66` then merged `shared-session` into `main` carrying only what it
held at 03:03. Nothing was lost; eight commits simply never travelled upwards.

This PR merges the tip of the stack, `shan/issue-61-shared-composer`, into `main`.

## What it brings

Nothing new — this is the already-reviewed content of #71 and #72:

- `Open in Logue` carries the island's conversation into the main window (`6e795a5`)
- One set of message actions mounted on both surfaces (`c768ed2`) — `MessageActions`
- The island says when a send failed (`def64c7`), and the bubbles split out under the
  `type_body_length` cap the banner pushed it over (`ad0a2a6`)
- The island can answer an approval prompt (`1c77d80`) rather than stalling for the
  five-minute timeout with nothing on screen
- Attachment intake lifted out of the input bar (`0fa9c5f`) and the island accepting
  files (`37524ba`)
- Web search for a single turn, with the main window's chip (`70aedd7`)

Merged with no conflicts. `xcodegen generate` leaves `project.pbxproj` byte-identical, so
the auto-merged file is correct.

## Verification

- `xcodebuild build` — succeeds
- `./scripts/test-no-llm.sh` — **1541 tests in 132 suites** pass
- SwiftFormat 0.62.1 `--lint` — 0/529 files require formatting
- SwiftLint 0.65.0 `--strict` — 0 violations in 660 files

## Why this could happen again

Merging a stack top-down is silent: every PR reports success, CI is green on each, and the
loss only shows up when someone opens `main` and finds a file missing. The order has to be
tip-first — merge the PR furthest from `main` before the one below it — or each merge
freezes its base at a tip that is about to move.

---

## Reviewed, and what the review changed

Three independent agents reviewed this at `1f8ad5e` — correctness/compatibility, craft,
and tests/claims — and I verified every finding against the files before acting on it.
Findings I could not personally walk were dropped rather than reported.

**The central claim was independently confirmed.** #71's and #72's merge commits are
provably not ancestors of `origin/main`; all five files are still missing; and the
recovery is complete — the 11 paths here exactly match `main...shared-composer`. The
auto-merged `project.pbxproj` audits correct in both directions: every new file present,
no stale entries, no file on disk missing from the project.

### Blocking — fixed

**A staged file was not content, so the island threw it away.**
`CommandCenterChatContent` knew about messages and drafts but not attachments, and
nothing fed attachments into it. An island holding a PDF and nothing else reported
itself empty, and both readers of that struct treated it as disposable — a click that
missed the pill tore it down, and so did switching apps. The file is not recoverable by
retyping: the user found it in Finder once and would have to find it again.

**Worse: dragging a file onto the island could not work at all.** The global
left-mouse-down monitor fired on the mouse-down *in Finder that starts the drag* — outside
the pill, and the pill still empty because the drop had not landed — so the island was
torn down before the file arrived. That monitor is removed rather than patched: a
mouse-down outside Logue is another app being clicked, which `handleAppResignedActive`
already answers with the real rule. The local monitor stays.

Drafts deliberately stay unprotected from a click-off — with no messages there is no
close button, and `CommandCenterChatRuleTests` already stated that reasoning. The code
was right and the doc comment claimed the opposite; the comment was the wrong one.

### Major — fixed

- **A send while the main window was running was silently eaten.** `isGenerating` is
  scoped to the island's conversation; `AgentCoordinator.send` refuses on a *global* busy
  check. The island cleared the field, the staged files and the mode flags, called send,
  hit the refusal, and did nothing — no bubble, no error, and an empty thread left behind.
- **The island was clearing the main window's armed Search chip.** Both bound the same
  `UserDefaults` key, and the island clears it after every send. Asking a quick question
  here disarmed a chip turned on over there and left on an unsent prompt, which then ran
  without web tools and never said so. The island now owns its own per-send flag.
- **Open in Logue did nothing with the window closed or minimised.** It activated the app
  and posted `.chatFocusInput`, which only `MainWindowView` observes — and that does not
  exist when the window is closed.
- **Copy from the island toasted into the wrong window.** `.toastOverlay()` is mounted in
  exactly one place; the shared helper no longer assumes a surface only one of its callers
  has.
- **The island's attachment chip had already drifted** from the main window's — hardcoded
  `"doc"` instead of the attachment's icon, no middle truncation.

### Minor — fixed

`AssistantActionRow`'s save tick reset unconditionally, so a second save had its
checkmark cleared by the first save's timer. Three dead imports, an empty MARK, an orphan
comment for a moved property, and a doc comment that had stopped enumerating what the row
does.

### Tests added

Review found three behaviours these commit messages elevate to rules, all headlessly
testable and none tested. Writing them exposed a fourth thing: `load`'s comment claimed
unreadable files are dropped, but `TempAttachmentLoader.load` returns an attachment on
every path including its `catch`, so the `if let` never fails. The comment now says what
actually happens.

Mutation-checked: removing the body-update from `saveAsNote` turns its case red.

**1551 tests in 133 suites**, SwiftFormat 0.62.1 and SwiftLint 0.65.0 `--strict` clean.

### Still owed

Click-through. The dismissal rules, the drag-to-attach path and Open-in-Logue with a
closed window are all behaviour static review cannot confirm — and two of the fixes above
change dismissal behaviour, so they are exactly what a tester should hit first:

1. Open the island over another app, drop a file on it, click elsewhere — the island and
   the file survive; Esc still closes it.
2. Drag a file from Finder onto an empty island — it attaches. This could not work before.
3. Start a long run in the main window, then send from the island — you are told it is
   busy, and your text and files are still there.
4. Arm Search in the main window, send from the island, go back — the chip is still armed.
5. Close the main window entirely, then Open in Logue from the island — the window comes
   back with the thread selected.
