### PR TITLE
docs: add the Trendshift badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@
 </p>
 
 <p align="center">
+  <a href="https://trendshift.io/repositories/90137" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/90137/daily?language=Swift" alt="bitwize-ai/Logue | Trendshift" width="250" height="55"/></a>
+</p>
+
+<p align="center">
   <a aria-label="License: MIT" href="https://github.com/bitwize-ai/Logue/blob/main/LICENSE" target="_blank">
     <img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-4630EB.svg?style=flat-square&labelColor=000000" />
   </a>

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 
 <p align="center">
   <a href="https://trendshift.io/repositories/90137" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/90137/daily?language=Swift" alt="bitwize-ai/Logue | Trendshift" width="250" height="55"/></a>
+  <br/>
+  <sub>First reached July 28, 2026</sub>
 </p>
 
 <p align="center">


### PR DESCRIPTION
Logue reached **#8 Repository of the Day for Swift** on Trendshift (28 July 2026). This adds
the badge Trendshift publishes for it.

## Placement

Its own centred line **above** the existing shields row, not inside it. The Trendshift badge
is 250x55; the shields are flat-square and about 20px tall, so putting it in that run leaves
them floating against its middle.

## One thing worth knowing

The image is served **live** by Trendshift (`/daily?language=Swift`), not frozen at the day
it was achieved, so what it displays can change. I fetched it before committing to check what
it actually renders today:

- HTTP 200, `image/svg+xml`
- Text nodes: `TRENDSHIFT`, `· Swift`, `#8 Repository Of The Day`

So it matches the achievement right now. If the ranking moves, the README follows it. That
seemed preferable to hard-coding a static image, but say if you would rather pin it.

The `for Swift` qualifier is part of the badge itself, which matters: "#8 Repository of the
Day" without it reads as #8 overall.

Docs only, no code touched.